### PR TITLE
Use protobuf-lite

### DIFF
--- a/floj-core/pom.xml
+++ b/floj-core/pom.xml
@@ -76,7 +76,7 @@
                                         </path>
                                         <pathconvert pathsep=" " property="proto.files" refid="proto.path"/>
                                         <exec executable="protoc" failonerror="true">
-                                            <arg value="--java_out=${project.basedir}/src/main/java"/>
+                                            <arg value="--javalite_out=${project.basedir}/src/main/java"/>
                                             <arg value="-I${project.basedir}/src"/>
                                             <arg line="${proto.files}"/>
                                         </exec>
@@ -188,7 +188,7 @@
                                         <urn>com.fasterxml.jackson.core:jackson-databind:2.5.2:jar:null:test:2b4dd13fbe6f8c6b146d4c3b7fd70862f136802d</urn>
                                         <urn>com.google.code.findbugs:jsr305:2.0.1:jar:null:compile:516c03b21d50a644d538de0f0369c620989cd8f0</urn>
                                         <urn>com.google.guava:guava:18.0:jar:null:compile:cce0823396aa693798f8882e64213b1772032b09</urn>
-                                        <urn>com.google.protobuf:protobuf-java:2.6.1:jar:null:compile:d9521f2aecb909835746b7a5facf612af5e890e8</urn>
+                                        <urn>com.google.protobuf:protobuf-lite:3.0.1:jar:null:compile:59b5b9c6e1a3054696d23492f888c1f8b583f5fc</urn>
                                         <urn>com.h2database:h2:1.3.167:jar:null:compile:d3867d586f087e53eb12fc65e5693d8ee9a5da17</urn>
                                         <urn>com.lambdaworks:scrypt:1.4.0:jar:null:compile:906506b74f30c8c20bccd9ed4a11112d8941fe87</urn>
                                         <urn>com.madgag.spongycastle:core:1.51.0.0:jar:null:compile:0f642963312ea0e615ad65f28adc5a5b3a2a0862</urn>
@@ -382,8 +382,8 @@
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>2.6.1</version>
+            <artifactId>protobuf-lite</artifactId>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/floj-core/src/main/java/org/flo/crawler/PeerSeedProtos.java
+++ b/floj-core/src/main/java/org/flo/crawler/PeerSeedProtos.java
@@ -6,11 +6,11 @@ package org.flo.crawler;
 public final class PeerSeedProtos {
   private PeerSeedProtos() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
   }
   public interface PeerSeedDataOrBuilder extends
       // @@protoc_insertion_point(interface_extends:org.flo.crawler.PeerSeedData)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required string ip_address = 1;</code>
@@ -47,113 +47,17 @@ public final class PeerSeedProtos {
   /**
    * Protobuf type {@code org.flo.crawler.PeerSeedData}
    */
-  public static final class PeerSeedData extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class PeerSeedData extends
+      com.google.protobuf.GeneratedMessageLite<
+          PeerSeedData, PeerSeedData.Builder> implements
       // @@protoc_insertion_point(message_implements:org.flo.crawler.PeerSeedData)
       PeerSeedDataOrBuilder {
-    // Use PeerSeedData.newBuilder() to construct.
-    private PeerSeedData(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private PeerSeedData() {
+      ipAddress_ = "";
     }
-    private PeerSeedData(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final PeerSeedData defaultInstance;
-    public static PeerSeedData getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public PeerSeedData getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PeerSeedData(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              ipAddress_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              port_ = input.readUInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              services_ = input.readUInt32();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeedData_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeedData_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.crawler.PeerSeedProtos.PeerSeedData.class, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<PeerSeedData> PARSER =
-        new com.google.protobuf.AbstractParser<PeerSeedData>() {
-      public PeerSeedData parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PeerSeedData(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<PeerSeedData> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int IP_ADDRESS_FIELD_NUMBER = 1;
-    private java.lang.Object ipAddress_;
+    private java.lang.String ipAddress_;
     /**
      * <code>required string ip_address = 1;</code>
      */
@@ -164,34 +68,43 @@ public final class PeerSeedProtos {
      * <code>required string ip_address = 1;</code>
      */
     public java.lang.String getIpAddress() {
-      java.lang.Object ref = ipAddress_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          ipAddress_ = s;
-        }
-        return s;
-      }
+      return ipAddress_;
     }
     /**
      * <code>required string ip_address = 1;</code>
      */
     public com.google.protobuf.ByteString
         getIpAddressBytes() {
-      java.lang.Object ref = ipAddress_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        ipAddress_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(ipAddress_);
+    }
+    /**
+     * <code>required string ip_address = 1;</code>
+     */
+    private void setIpAddress(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      ipAddress_ = value;
+    }
+    /**
+     * <code>required string ip_address = 1;</code>
+     */
+    private void clearIpAddress() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      ipAddress_ = getDefaultInstance().getIpAddress();
+    }
+    /**
+     * <code>required string ip_address = 1;</code>
+     */
+    private void setIpAddressBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      ipAddress_ = value.toStringUtf8();
     }
 
     public static final int PORT_FIELD_NUMBER = 2;
@@ -208,6 +121,20 @@ public final class PeerSeedProtos {
     public int getPort() {
       return port_;
     }
+    /**
+     * <code>required uint32 port = 2;</code>
+     */
+    private void setPort(int value) {
+      bitField0_ |= 0x00000002;
+      port_ = value;
+    }
+    /**
+     * <code>required uint32 port = 2;</code>
+     */
+    private void clearPort() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      port_ = 0;
+    }
 
     public static final int SERVICES_FIELD_NUMBER = 3;
     private int services_;
@@ -223,39 +150,25 @@ public final class PeerSeedProtos {
     public int getServices() {
       return services_;
     }
-
-    private void initFields() {
-      ipAddress_ = "";
-      port_ = 0;
-      services_ = 0;
+    /**
+     * <code>required uint32 services = 3;</code>
+     */
+    private void setServices(int value) {
+      bitField0_ |= 0x00000004;
+      services_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasIpAddress()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasPort()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasServices()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>required uint32 services = 3;</code>
+     */
+    private void clearServices() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      services_ = 0;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getIpAddressBytes());
+        output.writeString(1, getIpAddress());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeUInt32(2, port_);
@@ -263,10 +176,9 @@ public final class PeerSeedProtos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeUInt32(3, services_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -274,7 +186,7 @@ public final class PeerSeedProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getIpAddressBytes());
+          .computeStringSize(1, getIpAddress());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -284,295 +196,127 @@ public final class PeerSeedProtos {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(3, services_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeedData parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.crawler.PeerSeedProtos.PeerSeedData prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code org.flo.crawler.PeerSeedData}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.crawler.PeerSeedProtos.PeerSeedData, Builder> implements
         // @@protoc_insertion_point(builder_implements:org.flo.crawler.PeerSeedData)
         org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeedData_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeedData_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.crawler.PeerSeedProtos.PeerSeedData.class, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder.class);
-      }
-
       // Construct using org.flo.crawler.PeerSeedProtos.PeerSeedData.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        ipAddress_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
-        port_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        services_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeedData_descriptor;
-      }
-
-      public org.flo.crawler.PeerSeedProtos.PeerSeedData getDefaultInstanceForType() {
-        return org.flo.crawler.PeerSeedProtos.PeerSeedData.getDefaultInstance();
-      }
-
-      public org.flo.crawler.PeerSeedProtos.PeerSeedData build() {
-        org.flo.crawler.PeerSeedProtos.PeerSeedData result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.crawler.PeerSeedProtos.PeerSeedData buildPartial() {
-        org.flo.crawler.PeerSeedProtos.PeerSeedData result = new org.flo.crawler.PeerSeedProtos.PeerSeedData(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.ipAddress_ = ipAddress_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.port_ = port_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.services_ = services_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.crawler.PeerSeedProtos.PeerSeedData) {
-          return mergeFrom((org.flo.crawler.PeerSeedProtos.PeerSeedData)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.crawler.PeerSeedProtos.PeerSeedData other) {
-        if (other == org.flo.crawler.PeerSeedProtos.PeerSeedData.getDefaultInstance()) return this;
-        if (other.hasIpAddress()) {
-          bitField0_ |= 0x00000001;
-          ipAddress_ = other.ipAddress_;
-          onChanged();
-        }
-        if (other.hasPort()) {
-          setPort(other.getPort());
-        }
-        if (other.hasServices()) {
-          setServices(other.getServices());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasIpAddress()) {
-          
-          return false;
-        }
-        if (!hasPort()) {
-          
-          return false;
-        }
-        if (!hasServices()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.crawler.PeerSeedProtos.PeerSeedData parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.crawler.PeerSeedProtos.PeerSeedData) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.lang.Object ipAddress_ = "";
       /**
        * <code>required string ip_address = 1;</code>
        */
       public boolean hasIpAddress() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasIpAddress();
       }
       /**
        * <code>required string ip_address = 1;</code>
        */
       public java.lang.String getIpAddress() {
-        java.lang.Object ref = ipAddress_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            ipAddress_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getIpAddress();
       }
       /**
        * <code>required string ip_address = 1;</code>
        */
       public com.google.protobuf.ByteString
           getIpAddressBytes() {
-        java.lang.Object ref = ipAddress_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          ipAddress_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getIpAddressBytes();
       }
       /**
        * <code>required string ip_address = 1;</code>
        */
       public Builder setIpAddress(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        ipAddress_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setIpAddress(value);
         return this;
       }
       /**
        * <code>required string ip_address = 1;</code>
        */
       public Builder clearIpAddress() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        ipAddress_ = getDefaultInstance().getIpAddress();
-        onChanged();
+        copyOnWrite();
+        instance.clearIpAddress();
         return this;
       }
       /**
@@ -580,93 +324,215 @@ public final class PeerSeedProtos {
        */
       public Builder setIpAddressBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        ipAddress_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setIpAddressBytes(value);
         return this;
       }
 
-      private int port_ ;
       /**
        * <code>required uint32 port = 2;</code>
        */
       public boolean hasPort() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasPort();
       }
       /**
        * <code>required uint32 port = 2;</code>
        */
       public int getPort() {
-        return port_;
+        return instance.getPort();
       }
       /**
        * <code>required uint32 port = 2;</code>
        */
       public Builder setPort(int value) {
-        bitField0_ |= 0x00000002;
-        port_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPort(value);
         return this;
       }
       /**
        * <code>required uint32 port = 2;</code>
        */
       public Builder clearPort() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        port_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearPort();
         return this;
       }
 
-      private int services_ ;
       /**
        * <code>required uint32 services = 3;</code>
        */
       public boolean hasServices() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasServices();
       }
       /**
        * <code>required uint32 services = 3;</code>
        */
       public int getServices() {
-        return services_;
+        return instance.getServices();
       }
       /**
        * <code>required uint32 services = 3;</code>
        */
       public Builder setServices(int value) {
-        bitField0_ |= 0x00000004;
-        services_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setServices(value);
         return this;
       }
       /**
        * <code>required uint32 services = 3;</code>
        */
       public Builder clearServices() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        services_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearServices();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:org.flo.crawler.PeerSeedData)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.crawler.PeerSeedProtos.PeerSeedData();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new PeerSeedData(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasIpAddress()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasPort()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasServices()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.crawler.PeerSeedProtos.PeerSeedData other = (org.flo.crawler.PeerSeedProtos.PeerSeedData) arg1;
+          ipAddress_ = visitor.visitString(
+              hasIpAddress(), ipAddress_,
+              other.hasIpAddress(), other.ipAddress_);
+          port_ = visitor.visitInt(
+              hasPort(), port_,
+              other.hasPort(), other.port_);
+          services_ = visitor.visitInt(
+              hasServices(), services_,
+              other.hasServices(), other.services_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000001;
+                  ipAddress_ = s;
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  port_ = input.readUInt32();
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000004;
+                  services_ = input.readUInt32();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.crawler.PeerSeedProtos.PeerSeedData.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:org.flo.crawler.PeerSeedData)
+    private static final org.flo.crawler.PeerSeedProtos.PeerSeedData DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new PeerSeedData();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.crawler.PeerSeedProtos.PeerSeedData getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<PeerSeedData> PARSER;
+
+    public static com.google.protobuf.Parser<PeerSeedData> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface PeerSeedsOrBuilder extends
       // @@protoc_insertion_point(interface_extends:org.flo.crawler.PeerSeeds)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
@@ -681,31 +547,21 @@ public final class PeerSeedProtos {
      * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
      */
     int getSeedCount();
-    /**
-     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-     */
-    java.util.List<? extends org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder> 
-        getSeedOrBuilderList();
-    /**
-     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-     */
-    org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder getSeedOrBuilder(
-        int index);
 
     /**
-     * <code>required uint64 timestamp = 2;</code>
-     *
      * <pre>
      * seconds since UNIX epoch
      * </pre>
+     *
+     * <code>required uint64 timestamp = 2;</code>
      */
     boolean hasTimestamp();
     /**
-     * <code>required uint64 timestamp = 2;</code>
-     *
      * <pre>
      * seconds since UNIX epoch
      * </pre>
+     *
+     * <code>required uint64 timestamp = 2;</code>
      */
     long getTimestamp();
 
@@ -726,119 +582,18 @@ public final class PeerSeedProtos {
   /**
    * Protobuf type {@code org.flo.crawler.PeerSeeds}
    */
-  public static final class PeerSeeds extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class PeerSeeds extends
+      com.google.protobuf.GeneratedMessageLite<
+          PeerSeeds, PeerSeeds.Builder> implements
       // @@protoc_insertion_point(message_implements:org.flo.crawler.PeerSeeds)
       PeerSeedsOrBuilder {
-    // Use PeerSeeds.newBuilder() to construct.
-    private PeerSeeds(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private PeerSeeds() {
+      seed_ = emptyProtobufList();
+      net_ = "";
     }
-    private PeerSeeds(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final PeerSeeds defaultInstance;
-    public static PeerSeeds getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public PeerSeeds getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PeerSeeds(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                seed_ = new java.util.ArrayList<org.flo.crawler.PeerSeedProtos.PeerSeedData>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              seed_.add(input.readMessage(org.flo.crawler.PeerSeedProtos.PeerSeedData.PARSER, extensionRegistry));
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000001;
-              timestamp_ = input.readUInt64();
-              break;
-            }
-            case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              net_ = bs;
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          seed_ = java.util.Collections.unmodifiableList(seed_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeeds_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeeds_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.crawler.PeerSeedProtos.PeerSeeds.class, org.flo.crawler.PeerSeedProtos.PeerSeeds.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<PeerSeeds> PARSER =
-        new com.google.protobuf.AbstractParser<PeerSeeds>() {
-      public PeerSeeds parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PeerSeeds(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<PeerSeeds> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int SEED_FIELD_NUMBER = 1;
-    private java.util.List<org.flo.crawler.PeerSeedProtos.PeerSeedData> seed_;
+    private com.google.protobuf.Internal.ProtobufList<org.flo.crawler.PeerSeedProtos.PeerSeedData> seed_;
     /**
      * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
      */
@@ -871,32 +626,139 @@ public final class PeerSeedProtos {
         int index) {
       return seed_.get(index);
     }
+    private void ensureSeedIsMutable() {
+      if (!seed_.isModifiable()) {
+        seed_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(seed_);
+       }
+    }
+
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void setSeed(
+        int index, org.flo.crawler.PeerSeedProtos.PeerSeedData value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureSeedIsMutable();
+      seed_.set(index, value);
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void setSeed(
+        int index, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder builderForValue) {
+      ensureSeedIsMutable();
+      seed_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void addSeed(org.flo.crawler.PeerSeedProtos.PeerSeedData value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureSeedIsMutable();
+      seed_.add(value);
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void addSeed(
+        int index, org.flo.crawler.PeerSeedProtos.PeerSeedData value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureSeedIsMutable();
+      seed_.add(index, value);
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void addSeed(
+        org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder builderForValue) {
+      ensureSeedIsMutable();
+      seed_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void addSeed(
+        int index, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder builderForValue) {
+      ensureSeedIsMutable();
+      seed_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void addAllSeed(
+        java.lang.Iterable<? extends org.flo.crawler.PeerSeedProtos.PeerSeedData> values) {
+      ensureSeedIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, seed_);
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void clearSeed() {
+      seed_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
+     */
+    private void removeSeed(int index) {
+      ensureSeedIsMutable();
+      seed_.remove(index);
+    }
 
     public static final int TIMESTAMP_FIELD_NUMBER = 2;
     private long timestamp_;
     /**
-     * <code>required uint64 timestamp = 2;</code>
-     *
      * <pre>
      * seconds since UNIX epoch
      * </pre>
+     *
+     * <code>required uint64 timestamp = 2;</code>
      */
     public boolean hasTimestamp() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required uint64 timestamp = 2;</code>
-     *
      * <pre>
      * seconds since UNIX epoch
      * </pre>
+     *
+     * <code>required uint64 timestamp = 2;</code>
      */
     public long getTimestamp() {
       return timestamp_;
     }
+    /**
+     * <pre>
+     * seconds since UNIX epoch
+     * </pre>
+     *
+     * <code>required uint64 timestamp = 2;</code>
+     */
+    private void setTimestamp(long value) {
+      bitField0_ |= 0x00000001;
+      timestamp_ = value;
+    }
+    /**
+     * <pre>
+     * seconds since UNIX epoch
+     * </pre>
+     *
+     * <code>required uint64 timestamp = 2;</code>
+     */
+    private void clearTimestamp() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      timestamp_ = 0L;
+    }
 
     public static final int NET_FIELD_NUMBER = 3;
-    private java.lang.Object net_;
+    private java.lang.String net_;
     /**
      * <code>required string net = 3;</code>
      */
@@ -907,68 +769,47 @@ public final class PeerSeedProtos {
      * <code>required string net = 3;</code>
      */
     public java.lang.String getNet() {
-      java.lang.Object ref = net_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          net_ = s;
-        }
-        return s;
-      }
+      return net_;
     }
     /**
      * <code>required string net = 3;</code>
      */
     public com.google.protobuf.ByteString
         getNetBytes() {
-      java.lang.Object ref = net_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        net_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(net_);
     }
-
-    private void initFields() {
-      seed_ = java.util.Collections.emptyList();
-      timestamp_ = 0L;
-      net_ = "";
+    /**
+     * <code>required string net = 3;</code>
+     */
+    private void setNet(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      net_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasTimestamp()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasNet()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      for (int i = 0; i < getSeedCount(); i++) {
-        if (!getSeed(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>required string net = 3;</code>
+     */
+    private void clearNet() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      net_ = getDefaultInstance().getNet();
+    }
+    /**
+     * <code>required string net = 3;</code>
+     */
+    private void setNetBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      net_ = value.toStringUtf8();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       for (int i = 0; i < seed_.size(); i++) {
         output.writeMessage(1, seed_.get(i));
       }
@@ -976,12 +817,11 @@ public final class PeerSeedProtos {
         output.writeUInt64(2, timestamp_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(3, getNetBytes());
+        output.writeString(3, getNet());
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -997,329 +837,120 @@ public final class PeerSeedProtos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(3, getNetBytes());
+          .computeStringSize(3, getNet());
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.PeerSeeds parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.crawler.PeerSeedProtos.PeerSeeds prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code org.flo.crawler.PeerSeeds}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.crawler.PeerSeedProtos.PeerSeeds, Builder> implements
         // @@protoc_insertion_point(builder_implements:org.flo.crawler.PeerSeeds)
         org.flo.crawler.PeerSeedProtos.PeerSeedsOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeeds_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeeds_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.crawler.PeerSeedProtos.PeerSeeds.class, org.flo.crawler.PeerSeedProtos.PeerSeeds.Builder.class);
-      }
-
       // Construct using org.flo.crawler.PeerSeedProtos.PeerSeeds.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getSeedFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-
-      public Builder clear() {
-        super.clear();
-        if (seedBuilder_ == null) {
-          seed_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          seedBuilder_.clear();
-        }
-        timestamp_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        net_ = "";
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_PeerSeeds_descriptor;
-      }
-
-      public org.flo.crawler.PeerSeedProtos.PeerSeeds getDefaultInstanceForType() {
-        return org.flo.crawler.PeerSeedProtos.PeerSeeds.getDefaultInstance();
-      }
-
-      public org.flo.crawler.PeerSeedProtos.PeerSeeds build() {
-        org.flo.crawler.PeerSeedProtos.PeerSeeds result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.crawler.PeerSeedProtos.PeerSeeds buildPartial() {
-        org.flo.crawler.PeerSeedProtos.PeerSeeds result = new org.flo.crawler.PeerSeedProtos.PeerSeeds(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (seedBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            seed_ = java.util.Collections.unmodifiableList(seed_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.seed_ = seed_;
-        } else {
-          result.seed_ = seedBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.timestamp_ = timestamp_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.net_ = net_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.crawler.PeerSeedProtos.PeerSeeds) {
-          return mergeFrom((org.flo.crawler.PeerSeedProtos.PeerSeeds)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.crawler.PeerSeedProtos.PeerSeeds other) {
-        if (other == org.flo.crawler.PeerSeedProtos.PeerSeeds.getDefaultInstance()) return this;
-        if (seedBuilder_ == null) {
-          if (!other.seed_.isEmpty()) {
-            if (seed_.isEmpty()) {
-              seed_ = other.seed_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureSeedIsMutable();
-              seed_.addAll(other.seed_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.seed_.isEmpty()) {
-            if (seedBuilder_.isEmpty()) {
-              seedBuilder_.dispose();
-              seedBuilder_ = null;
-              seed_ = other.seed_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-              seedBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getSeedFieldBuilder() : null;
-            } else {
-              seedBuilder_.addAllMessages(other.seed_);
-            }
-          }
-        }
-        if (other.hasTimestamp()) {
-          setTimestamp(other.getTimestamp());
-        }
-        if (other.hasNet()) {
-          bitField0_ |= 0x00000004;
-          net_ = other.net_;
-          onChanged();
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasTimestamp()) {
-          
-          return false;
-        }
-        if (!hasNet()) {
-          
-          return false;
-        }
-        for (int i = 0; i < getSeedCount(); i++) {
-          if (!getSeed(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.crawler.PeerSeedProtos.PeerSeeds parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.crawler.PeerSeedProtos.PeerSeeds) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.util.List<org.flo.crawler.PeerSeedProtos.PeerSeedData> seed_ =
-        java.util.Collections.emptyList();
-      private void ensureSeedIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          seed_ = new java.util.ArrayList<org.flo.crawler.PeerSeedProtos.PeerSeedData>(seed_);
-          bitField0_ |= 0x00000001;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.flo.crawler.PeerSeedProtos.PeerSeedData, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder, org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder> seedBuilder_;
 
       /**
        * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
        */
       public java.util.List<org.flo.crawler.PeerSeedProtos.PeerSeedData> getSeedList() {
-        if (seedBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(seed_);
-        } else {
-          return seedBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getSeedList());
       }
       /**
        * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
        */
       public int getSeedCount() {
-        if (seedBuilder_ == null) {
-          return seed_.size();
-        } else {
-          return seedBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getSeedCount();
+      }/**
        * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
        */
       public org.flo.crawler.PeerSeedProtos.PeerSeedData getSeed(int index) {
-        if (seedBuilder_ == null) {
-          return seed_.get(index);
-        } else {
-          return seedBuilder_.getMessage(index);
-        }
+        return instance.getSeed(index);
       }
       /**
        * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
        */
       public Builder setSeed(
           int index, org.flo.crawler.PeerSeedProtos.PeerSeedData value) {
-        if (seedBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureSeedIsMutable();
-          seed_.set(index, value);
-          onChanged();
-        } else {
-          seedBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setSeed(index, value);
         return this;
       }
       /**
@@ -1327,29 +958,16 @@ public final class PeerSeedProtos {
        */
       public Builder setSeed(
           int index, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder builderForValue) {
-        if (seedBuilder_ == null) {
-          ensureSeedIsMutable();
-          seed_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          seedBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setSeed(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
        */
       public Builder addSeed(org.flo.crawler.PeerSeedProtos.PeerSeedData value) {
-        if (seedBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureSeedIsMutable();
-          seed_.add(value);
-          onChanged();
-        } else {
-          seedBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addSeed(value);
         return this;
       }
       /**
@@ -1357,16 +975,8 @@ public final class PeerSeedProtos {
        */
       public Builder addSeed(
           int index, org.flo.crawler.PeerSeedProtos.PeerSeedData value) {
-        if (seedBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureSeedIsMutable();
-          seed_.add(index, value);
-          onChanged();
-        } else {
-          seedBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addSeed(index, value);
         return this;
       }
       /**
@@ -1374,13 +984,8 @@ public final class PeerSeedProtos {
        */
       public Builder addSeed(
           org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder builderForValue) {
-        if (seedBuilder_ == null) {
-          ensureSeedIsMutable();
-          seed_.add(builderForValue.build());
-          onChanged();
-        } else {
-          seedBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addSeed(builderForValue);
         return this;
       }
       /**
@@ -1388,13 +993,8 @@ public final class PeerSeedProtos {
        */
       public Builder addSeed(
           int index, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder builderForValue) {
-        if (seedBuilder_ == null) {
-          ensureSeedIsMutable();
-          seed_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          seedBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addSeed(index, builderForValue);
         return this;
       }
       /**
@@ -1402,215 +1002,106 @@ public final class PeerSeedProtos {
        */
       public Builder addAllSeed(
           java.lang.Iterable<? extends org.flo.crawler.PeerSeedProtos.PeerSeedData> values) {
-        if (seedBuilder_ == null) {
-          ensureSeedIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, seed_);
-          onChanged();
-        } else {
-          seedBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllSeed(values);
         return this;
       }
       /**
        * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
        */
       public Builder clearSeed() {
-        if (seedBuilder_ == null) {
-          seed_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          seedBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearSeed();
         return this;
       }
       /**
        * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
        */
       public Builder removeSeed(int index) {
-        if (seedBuilder_ == null) {
-          ensureSeedIsMutable();
-          seed_.remove(index);
-          onChanged();
-        } else {
-          seedBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeSeed(index);
         return this;
       }
-      /**
-       * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-       */
-      public org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder getSeedBuilder(
-          int index) {
-        return getSeedFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-       */
-      public org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder getSeedOrBuilder(
-          int index) {
-        if (seedBuilder_ == null) {
-          return seed_.get(index);  } else {
-          return seedBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-       */
-      public java.util.List<? extends org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder> 
-           getSeedOrBuilderList() {
-        if (seedBuilder_ != null) {
-          return seedBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(seed_);
-        }
-      }
-      /**
-       * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-       */
-      public org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder addSeedBuilder() {
-        return getSeedFieldBuilder().addBuilder(
-            org.flo.crawler.PeerSeedProtos.PeerSeedData.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-       */
-      public org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder addSeedBuilder(
-          int index) {
-        return getSeedFieldBuilder().addBuilder(
-            index, org.flo.crawler.PeerSeedProtos.PeerSeedData.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .org.flo.crawler.PeerSeedData seed = 1;</code>
-       */
-      public java.util.List<org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder> 
-           getSeedBuilderList() {
-        return getSeedFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.flo.crawler.PeerSeedProtos.PeerSeedData, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder, org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder> 
-          getSeedFieldBuilder() {
-        if (seedBuilder_ == null) {
-          seedBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.flo.crawler.PeerSeedProtos.PeerSeedData, org.flo.crawler.PeerSeedProtos.PeerSeedData.Builder, org.flo.crawler.PeerSeedProtos.PeerSeedDataOrBuilder>(
-                  seed_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
-                  getParentForChildren(),
-                  isClean());
-          seed_ = null;
-        }
-        return seedBuilder_;
-      }
 
-      private long timestamp_ ;
       /**
-       * <code>required uint64 timestamp = 2;</code>
-       *
        * <pre>
        * seconds since UNIX epoch
        * </pre>
+       *
+       * <code>required uint64 timestamp = 2;</code>
        */
       public boolean hasTimestamp() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasTimestamp();
       }
       /**
-       * <code>required uint64 timestamp = 2;</code>
-       *
        * <pre>
        * seconds since UNIX epoch
        * </pre>
+       *
+       * <code>required uint64 timestamp = 2;</code>
        */
       public long getTimestamp() {
-        return timestamp_;
+        return instance.getTimestamp();
       }
       /**
-       * <code>required uint64 timestamp = 2;</code>
-       *
        * <pre>
        * seconds since UNIX epoch
        * </pre>
+       *
+       * <code>required uint64 timestamp = 2;</code>
        */
       public Builder setTimestamp(long value) {
-        bitField0_ |= 0x00000002;
-        timestamp_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTimestamp(value);
         return this;
       }
       /**
-       * <code>required uint64 timestamp = 2;</code>
-       *
        * <pre>
        * seconds since UNIX epoch
        * </pre>
+       *
+       * <code>required uint64 timestamp = 2;</code>
        */
       public Builder clearTimestamp() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        timestamp_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearTimestamp();
         return this;
       }
 
-      private java.lang.Object net_ = "";
       /**
        * <code>required string net = 3;</code>
        */
       public boolean hasNet() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasNet();
       }
       /**
        * <code>required string net = 3;</code>
        */
       public java.lang.String getNet() {
-        java.lang.Object ref = net_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            net_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getNet();
       }
       /**
        * <code>required string net = 3;</code>
        */
       public com.google.protobuf.ByteString
           getNetBytes() {
-        java.lang.Object ref = net_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          net_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getNetBytes();
       }
       /**
        * <code>required string net = 3;</code>
        */
       public Builder setNet(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        net_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setNet(value);
         return this;
       }
       /**
        * <code>required string net = 3;</code>
        */
       public Builder clearNet() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        net_ = getDefaultInstance().getNet();
-        onChanged();
+        copyOnWrite();
+        instance.clearNet();
         return this;
       }
       /**
@@ -1618,29 +1109,162 @@ public final class PeerSeedProtos {
        */
       public Builder setNetBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        net_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setNetBytes(value);
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:org.flo.crawler.PeerSeeds)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.crawler.PeerSeedProtos.PeerSeeds();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new PeerSeeds(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasTimestamp()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasNet()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          for (int i = 0; i < getSeedCount(); i++) {
+            if (!getSeed(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          seed_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.crawler.PeerSeedProtos.PeerSeeds other = (org.flo.crawler.PeerSeedProtos.PeerSeeds) arg1;
+          seed_= visitor.visitList(seed_, other.seed_);
+          timestamp_ = visitor.visitLong(
+              hasTimestamp(), timestamp_,
+              other.hasTimestamp(), other.timestamp_);
+          net_ = visitor.visitString(
+              hasNet(), net_,
+              other.hasNet(), other.net_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  if (!seed_.isModifiable()) {
+                    seed_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(seed_);
+                  }
+                  seed_.add(
+                      input.readMessage(org.flo.crawler.PeerSeedProtos.PeerSeedData.parser(), extensionRegistry));
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000001;
+                  timestamp_ = input.readUInt64();
+                  break;
+                }
+                case 26: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000002;
+                  net_ = s;
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.crawler.PeerSeedProtos.PeerSeeds.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:org.flo.crawler.PeerSeeds)
+    private static final org.flo.crawler.PeerSeedProtos.PeerSeeds DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new PeerSeeds();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.crawler.PeerSeedProtos.PeerSeeds getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<PeerSeeds> PARSER;
+
+    public static com.google.protobuf.Parser<PeerSeeds> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface SignedPeerSeedsOrBuilder extends
       // @@protoc_insertion_point(interface_extends:org.flo.crawler.SignedPeerSeeds)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required bytes peer_seeds = 1;</code>
@@ -1672,109 +1296,16 @@ public final class PeerSeedProtos {
   /**
    * Protobuf type {@code org.flo.crawler.SignedPeerSeeds}
    */
-  public static final class SignedPeerSeeds extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class SignedPeerSeeds extends
+      com.google.protobuf.GeneratedMessageLite<
+          SignedPeerSeeds, SignedPeerSeeds.Builder> implements
       // @@protoc_insertion_point(message_implements:org.flo.crawler.SignedPeerSeeds)
       SignedPeerSeedsOrBuilder {
-    // Use SignedPeerSeeds.newBuilder() to construct.
-    private SignedPeerSeeds(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private SignedPeerSeeds() {
+      peerSeeds_ = com.google.protobuf.ByteString.EMPTY;
+      signature_ = com.google.protobuf.ByteString.EMPTY;
+      pubkey_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private SignedPeerSeeds(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final SignedPeerSeeds defaultInstance;
-    public static SignedPeerSeeds getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public SignedPeerSeeds getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private SignedPeerSeeds(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              peerSeeds_ = input.readBytes();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              signature_ = input.readBytes();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              pubkey_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_SignedPeerSeeds_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_SignedPeerSeeds_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.class, org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<SignedPeerSeeds> PARSER =
-        new com.google.protobuf.AbstractParser<SignedPeerSeeds>() {
-      public SignedPeerSeeds parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SignedPeerSeeds(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<SignedPeerSeeds> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int PEER_SEEDS_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString peerSeeds_;
@@ -1789,6 +1320,23 @@ public final class PeerSeedProtos {
      */
     public com.google.protobuf.ByteString getPeerSeeds() {
       return peerSeeds_;
+    }
+    /**
+     * <code>required bytes peer_seeds = 1;</code>
+     */
+    private void setPeerSeeds(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      peerSeeds_ = value;
+    }
+    /**
+     * <code>required bytes peer_seeds = 1;</code>
+     */
+    private void clearPeerSeeds() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      peerSeeds_ = getDefaultInstance().getPeerSeeds();
     }
 
     public static final int SIGNATURE_FIELD_NUMBER = 2;
@@ -1805,6 +1353,23 @@ public final class PeerSeedProtos {
     public com.google.protobuf.ByteString getSignature() {
       return signature_;
     }
+    /**
+     * <code>required bytes signature = 2;</code>
+     */
+    private void setSignature(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      signature_ = value;
+    }
+    /**
+     * <code>required bytes signature = 2;</code>
+     */
+    private void clearSignature() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      signature_ = getDefaultInstance().getSignature();
+    }
 
     public static final int PUBKEY_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString pubkey_;
@@ -1820,37 +1385,26 @@ public final class PeerSeedProtos {
     public com.google.protobuf.ByteString getPubkey() {
       return pubkey_;
     }
-
-    private void initFields() {
-      peerSeeds_ = com.google.protobuf.ByteString.EMPTY;
-      signature_ = com.google.protobuf.ByteString.EMPTY;
-      pubkey_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <code>required bytes pubkey = 3;</code>
+     */
+    private void setPubkey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      pubkey_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasPeerSeeds()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasSignature()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasPubkey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>required bytes pubkey = 3;</code>
+     */
+    private void clearPubkey() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      pubkey_ = getDefaultInstance().getPubkey();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, peerSeeds_);
       }
@@ -1860,10 +1414,9 @@ public final class PeerSeedProtos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBytes(3, pubkey_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -1881,412 +1434,324 @@ public final class PeerSeedProtos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, pubkey_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.crawler.PeerSeedProtos.SignedPeerSeeds prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code org.flo.crawler.SignedPeerSeeds}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.crawler.PeerSeedProtos.SignedPeerSeeds, Builder> implements
         // @@protoc_insertion_point(builder_implements:org.flo.crawler.SignedPeerSeeds)
         org.flo.crawler.PeerSeedProtos.SignedPeerSeedsOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_SignedPeerSeeds_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_SignedPeerSeeds_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.class, org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.Builder.class);
-      }
-
       // Construct using org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        peerSeeds_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        signature_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        pubkey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.crawler.PeerSeedProtos.internal_static_org_flo_crawler_SignedPeerSeeds_descriptor;
-      }
-
-      public org.flo.crawler.PeerSeedProtos.SignedPeerSeeds getDefaultInstanceForType() {
-        return org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.getDefaultInstance();
-      }
-
-      public org.flo.crawler.PeerSeedProtos.SignedPeerSeeds build() {
-        org.flo.crawler.PeerSeedProtos.SignedPeerSeeds result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.crawler.PeerSeedProtos.SignedPeerSeeds buildPartial() {
-        org.flo.crawler.PeerSeedProtos.SignedPeerSeeds result = new org.flo.crawler.PeerSeedProtos.SignedPeerSeeds(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.peerSeeds_ = peerSeeds_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.signature_ = signature_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.pubkey_ = pubkey_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.crawler.PeerSeedProtos.SignedPeerSeeds) {
-          return mergeFrom((org.flo.crawler.PeerSeedProtos.SignedPeerSeeds)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.crawler.PeerSeedProtos.SignedPeerSeeds other) {
-        if (other == org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.getDefaultInstance()) return this;
-        if (other.hasPeerSeeds()) {
-          setPeerSeeds(other.getPeerSeeds());
-        }
-        if (other.hasSignature()) {
-          setSignature(other.getSignature());
-        }
-        if (other.hasPubkey()) {
-          setPubkey(other.getPubkey());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasPeerSeeds()) {
-          
-          return false;
-        }
-        if (!hasSignature()) {
-          
-          return false;
-        }
-        if (!hasPubkey()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.crawler.PeerSeedProtos.SignedPeerSeeds parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.crawler.PeerSeedProtos.SignedPeerSeeds) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString peerSeeds_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes peer_seeds = 1;</code>
        */
       public boolean hasPeerSeeds() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasPeerSeeds();
       }
       /**
        * <code>required bytes peer_seeds = 1;</code>
        */
       public com.google.protobuf.ByteString getPeerSeeds() {
-        return peerSeeds_;
+        return instance.getPeerSeeds();
       }
       /**
        * <code>required bytes peer_seeds = 1;</code>
        */
       public Builder setPeerSeeds(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        peerSeeds_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPeerSeeds(value);
         return this;
       }
       /**
        * <code>required bytes peer_seeds = 1;</code>
        */
       public Builder clearPeerSeeds() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        peerSeeds_ = getDefaultInstance().getPeerSeeds();
-        onChanged();
+        copyOnWrite();
+        instance.clearPeerSeeds();
         return this;
       }
 
-      private com.google.protobuf.ByteString signature_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes signature = 2;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasSignature();
       }
       /**
        * <code>required bytes signature = 2;</code>
        */
       public com.google.protobuf.ByteString getSignature() {
-        return signature_;
+        return instance.getSignature();
       }
       /**
        * <code>required bytes signature = 2;</code>
        */
       public Builder setSignature(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        signature_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSignature(value);
         return this;
       }
       /**
        * <code>required bytes signature = 2;</code>
        */
       public Builder clearSignature() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        signature_ = getDefaultInstance().getSignature();
-        onChanged();
+        copyOnWrite();
+        instance.clearSignature();
         return this;
       }
 
-      private com.google.protobuf.ByteString pubkey_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes pubkey = 3;</code>
        */
       public boolean hasPubkey() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasPubkey();
       }
       /**
        * <code>required bytes pubkey = 3;</code>
        */
       public com.google.protobuf.ByteString getPubkey() {
-        return pubkey_;
+        return instance.getPubkey();
       }
       /**
        * <code>required bytes pubkey = 3;</code>
        */
       public Builder setPubkey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        pubkey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPubkey(value);
         return this;
       }
       /**
        * <code>required bytes pubkey = 3;</code>
        */
       public Builder clearPubkey() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        pubkey_ = getDefaultInstance().getPubkey();
-        onChanged();
+        copyOnWrite();
+        instance.clearPubkey();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:org.flo.crawler.SignedPeerSeeds)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.crawler.PeerSeedProtos.SignedPeerSeeds();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new SignedPeerSeeds(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:org.flo.crawler.SignedPeerSeeds)
-  }
-
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_org_flo_crawler_PeerSeedData_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_org_flo_crawler_PeerSeedData_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_org_flo_crawler_PeerSeeds_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_org_flo_crawler_PeerSeeds_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_org_flo_crawler_SignedPeerSeeds_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_org_flo_crawler_SignedPeerSeeds_fieldAccessorTable;
-
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
-    return descriptor;
-  }
-  private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
-  static {
-    java.lang.String[] descriptorData = {
-      "\n\017peerseeds.proto\022\017org.flo.crawler\"B\n\014Pe" +
-      "erSeedData\022\022\n\nip_address\030\001 \002(\t\022\014\n\004port\030\002" +
-      " \002(\r\022\020\n\010services\030\003 \002(\r\"X\n\tPeerSeeds\022+\n\004s" +
-      "eed\030\001 \003(\0132\035.org.flo.crawler.PeerSeedData" +
-      "\022\021\n\ttimestamp\030\002 \002(\004\022\013\n\003net\030\003 \002(\t\"H\n\017Sign" +
-      "edPeerSeeds\022\022\n\npeer_seeds\030\001 \002(\014\022\021\n\tsigna" +
-      "ture\030\002 \002(\014\022\016\n\006pubkey\030\003 \002(\014B!\n\017org.flo.cr" +
-      "awlerB\016PeerSeedProtos"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasPeerSeeds()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
             return null;
           }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-    internal_static_org_flo_crawler_PeerSeedData_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_org_flo_crawler_PeerSeedData_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_org_flo_crawler_PeerSeedData_descriptor,
-        new java.lang.String[] { "IpAddress", "Port", "Services", });
-    internal_static_org_flo_crawler_PeerSeeds_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_org_flo_crawler_PeerSeeds_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_org_flo_crawler_PeerSeeds_descriptor,
-        new java.lang.String[] { "Seed", "Timestamp", "Net", });
-    internal_static_org_flo_crawler_SignedPeerSeeds_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_org_flo_crawler_SignedPeerSeeds_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_org_flo_crawler_SignedPeerSeeds_descriptor,
-        new java.lang.String[] { "PeerSeeds", "Signature", "Pubkey", });
+          if (!hasSignature()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasPubkey()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.crawler.PeerSeedProtos.SignedPeerSeeds other = (org.flo.crawler.PeerSeedProtos.SignedPeerSeeds) arg1;
+          peerSeeds_ = visitor.visitByteString(
+              hasPeerSeeds(), peerSeeds_,
+              other.hasPeerSeeds(), other.peerSeeds_);
+          signature_ = visitor.visitByteString(
+              hasSignature(), signature_,
+              other.hasSignature(), other.signature_);
+          pubkey_ = visitor.visitByteString(
+              hasPubkey(), pubkey_,
+              other.hasPubkey(), other.pubkey_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  peerSeeds_ = input.readBytes();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  signature_ = input.readBytes();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  pubkey_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.crawler.PeerSeedProtos.SignedPeerSeeds.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
+    }
+
+
+    // @@protoc_insertion_point(class_scope:org.flo.crawler.SignedPeerSeeds)
+    private static final org.flo.crawler.PeerSeedProtos.SignedPeerSeeds DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new SignedPeerSeeds();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.crawler.PeerSeedProtos.SignedPeerSeeds getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<SignedPeerSeeds> PARSER;
+
+    public static com.google.protobuf.Parser<SignedPeerSeeds> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
+  }
+
+
+  static {
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/floj-core/src/main/java/org/flo/paymentchannel/Protos.java
+++ b/floj-core/src/main/java/org/flo/paymentchannel/Protos.java
@@ -6,57 +6,49 @@ package org.flo.paymentchannel;
 public final class Protos {
   private Protos() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
   }
   public interface TwoWayChannelMessageOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.TwoWayChannelMessage)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-     *
      * <pre>
      * This is required so if a new message type is added in future, old software aborts trying
      * to read the message as early as possible. If the message doesn't parse, the socket should
      * be closed.
      * </pre>
+     *
+     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
      */
     boolean hasType();
     /**
-     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-     *
      * <pre>
      * This is required so if a new message type is added in future, old software aborts trying
      * to read the message as early as possible. If the message doesn't parse, the socket should
      * be closed.
      * </pre>
+     *
+     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
      */
     org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType getType();
 
     /**
-     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-     *
      * <pre>
      * Now one optional field for each message. Only the field specified by type should be read.
      * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
      */
     boolean hasClientVersion();
     /**
-     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-     *
      * <pre>
      * Now one optional field for each message. Only the field specified by type should be read.
      * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
      */
     org.flo.paymentchannel.Protos.ClientVersion getClientVersion();
-    /**
-     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-     *
-     * <pre>
-     * Now one optional field for each message. Only the field specified by type should be read.
-     * </pre>
-     */
-    org.flo.paymentchannel.Protos.ClientVersionOrBuilder getClientVersionOrBuilder();
 
     /**
      * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
@@ -66,10 +58,6 @@ public final class Protos {
      * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
      */
     org.flo.paymentchannel.Protos.ServerVersion getServerVersion();
-    /**
-     * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
-     */
-    org.flo.paymentchannel.Protos.ServerVersionOrBuilder getServerVersionOrBuilder();
 
     /**
      * <code>optional .paymentchannels.Initiate initiate = 4;</code>
@@ -79,10 +67,6 @@ public final class Protos {
      * <code>optional .paymentchannels.Initiate initiate = 4;</code>
      */
     org.flo.paymentchannel.Protos.Initiate getInitiate();
-    /**
-     * <code>optional .paymentchannels.Initiate initiate = 4;</code>
-     */
-    org.flo.paymentchannel.Protos.InitiateOrBuilder getInitiateOrBuilder();
 
     /**
      * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
@@ -92,10 +76,6 @@ public final class Protos {
      * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
      */
     org.flo.paymentchannel.Protos.ProvideRefund getProvideRefund();
-    /**
-     * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
-     */
-    org.flo.paymentchannel.Protos.ProvideRefundOrBuilder getProvideRefundOrBuilder();
 
     /**
      * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
@@ -105,10 +85,6 @@ public final class Protos {
      * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
      */
     org.flo.paymentchannel.Protos.ReturnRefund getReturnRefund();
-    /**
-     * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
-     */
-    org.flo.paymentchannel.Protos.ReturnRefundOrBuilder getReturnRefundOrBuilder();
 
     /**
      * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
@@ -118,10 +94,6 @@ public final class Protos {
      * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
      */
     org.flo.paymentchannel.Protos.ProvideContract getProvideContract();
-    /**
-     * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
-     */
-    org.flo.paymentchannel.Protos.ProvideContractOrBuilder getProvideContractOrBuilder();
 
     /**
      * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
@@ -131,10 +103,6 @@ public final class Protos {
      * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
      */
     org.flo.paymentchannel.Protos.UpdatePayment getUpdatePayment();
-    /**
-     * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
-     */
-    org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder getUpdatePaymentOrBuilder();
 
     /**
      * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
@@ -144,10 +112,6 @@ public final class Protos {
      * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
      */
     org.flo.paymentchannel.Protos.PaymentAck getPaymentAck();
-    /**
-     * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
-     */
-    org.flo.paymentchannel.Protos.PaymentAckOrBuilder getPaymentAckOrBuilder();
 
     /**
      * <code>optional .paymentchannels.Settlement settlement = 9;</code>
@@ -157,10 +121,6 @@ public final class Protos {
      * <code>optional .paymentchannels.Settlement settlement = 9;</code>
      */
     org.flo.paymentchannel.Protos.Settlement getSettlement();
-    /**
-     * <code>optional .paymentchannels.Settlement settlement = 9;</code>
-     */
-    org.flo.paymentchannel.Protos.SettlementOrBuilder getSettlementOrBuilder();
 
     /**
      * <code>optional .paymentchannels.Error error = 10;</code>
@@ -170,281 +130,54 @@ public final class Protos {
      * <code>optional .paymentchannels.Error error = 10;</code>
      */
     org.flo.paymentchannel.Protos.Error getError();
-    /**
-     * <code>optional .paymentchannels.Error error = 10;</code>
-     */
-    org.flo.paymentchannel.Protos.ErrorOrBuilder getErrorOrBuilder();
   }
   /**
-   * Protobuf type {@code paymentchannels.TwoWayChannelMessage}
-   *
    * <pre>
    * This message is designed to be either sent raw over the network (e.g. length prefixed) or embedded inside another
    * protocol that is being extended to support micropayments. In this file "primary" typically can be read as "client"
    * and "secondary" as "server".
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.TwoWayChannelMessage}
    */
-  public static final class TwoWayChannelMessage extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class TwoWayChannelMessage extends
+      com.google.protobuf.GeneratedMessageLite<
+          TwoWayChannelMessage, TwoWayChannelMessage.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.TwoWayChannelMessage)
       TwoWayChannelMessageOrBuilder {
-    // Use TwoWayChannelMessage.newBuilder() to construct.
-    private TwoWayChannelMessage(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private TwoWayChannelMessage() {
+      type_ = 1;
     }
-    private TwoWayChannelMessage(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final TwoWayChannelMessage defaultInstance;
-    public static TwoWayChannelMessage getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public TwoWayChannelMessage getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private TwoWayChannelMessage(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              int rawValue = input.readEnum();
-              org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType value = org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(1, rawValue);
-              } else {
-                bitField0_ |= 0x00000001;
-                type_ = value;
-              }
-              break;
-            }
-            case 18: {
-              org.flo.paymentchannel.Protos.ClientVersion.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                subBuilder = clientVersion_.toBuilder();
-              }
-              clientVersion_ = input.readMessage(org.flo.paymentchannel.Protos.ClientVersion.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(clientVersion_);
-                clientVersion_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000002;
-              break;
-            }
-            case 26: {
-              org.flo.paymentchannel.Protos.ServerVersion.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                subBuilder = serverVersion_.toBuilder();
-              }
-              serverVersion_ = input.readMessage(org.flo.paymentchannel.Protos.ServerVersion.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(serverVersion_);
-                serverVersion_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000004;
-              break;
-            }
-            case 34: {
-              org.flo.paymentchannel.Protos.Initiate.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                subBuilder = initiate_.toBuilder();
-              }
-              initiate_ = input.readMessage(org.flo.paymentchannel.Protos.Initiate.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(initiate_);
-                initiate_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000008;
-              break;
-            }
-            case 42: {
-              org.flo.paymentchannel.Protos.ProvideRefund.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                subBuilder = provideRefund_.toBuilder();
-              }
-              provideRefund_ = input.readMessage(org.flo.paymentchannel.Protos.ProvideRefund.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(provideRefund_);
-                provideRefund_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000010;
-              break;
-            }
-            case 50: {
-              org.flo.paymentchannel.Protos.ReturnRefund.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                subBuilder = returnRefund_.toBuilder();
-              }
-              returnRefund_ = input.readMessage(org.flo.paymentchannel.Protos.ReturnRefund.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(returnRefund_);
-                returnRefund_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000020;
-              break;
-            }
-            case 58: {
-              org.flo.paymentchannel.Protos.ProvideContract.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000040) == 0x00000040)) {
-                subBuilder = provideContract_.toBuilder();
-              }
-              provideContract_ = input.readMessage(org.flo.paymentchannel.Protos.ProvideContract.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(provideContract_);
-                provideContract_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000040;
-              break;
-            }
-            case 66: {
-              org.flo.paymentchannel.Protos.UpdatePayment.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                subBuilder = updatePayment_.toBuilder();
-              }
-              updatePayment_ = input.readMessage(org.flo.paymentchannel.Protos.UpdatePayment.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(updatePayment_);
-                updatePayment_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000080;
-              break;
-            }
-            case 74: {
-              org.flo.paymentchannel.Protos.Settlement.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000200) == 0x00000200)) {
-                subBuilder = settlement_.toBuilder();
-              }
-              settlement_ = input.readMessage(org.flo.paymentchannel.Protos.Settlement.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(settlement_);
-                settlement_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000200;
-              break;
-            }
-            case 82: {
-              org.flo.paymentchannel.Protos.Error.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000400) == 0x00000400)) {
-                subBuilder = error_.toBuilder();
-              }
-              error_ = input.readMessage(org.flo.paymentchannel.Protos.Error.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(error_);
-                error_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000400;
-              break;
-            }
-            case 90: {
-              org.flo.paymentchannel.Protos.PaymentAck.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000100) == 0x00000100)) {
-                subBuilder = paymentAck_.toBuilder();
-              }
-              paymentAck_ = input.readMessage(org.flo.paymentchannel.Protos.PaymentAck.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(paymentAck_);
-                paymentAck_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000100;
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_TwoWayChannelMessage_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_TwoWayChannelMessage_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.TwoWayChannelMessage.class, org.flo.paymentchannel.Protos.TwoWayChannelMessage.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<TwoWayChannelMessage> PARSER =
-        new com.google.protobuf.AbstractParser<TwoWayChannelMessage>() {
-      public TwoWayChannelMessage parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TwoWayChannelMessage(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<TwoWayChannelMessage> getParserForType() {
-      return PARSER;
-    }
-
     /**
      * Protobuf enum {@code paymentchannels.TwoWayChannelMessage.MessageType}
      */
     public enum MessageType
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
        * <code>CLIENT_VERSION = 1;</code>
        */
-      CLIENT_VERSION(0, 1),
+      CLIENT_VERSION(1),
       /**
        * <code>SERVER_VERSION = 2;</code>
        */
-      SERVER_VERSION(1, 2),
+      SERVER_VERSION(2),
       /**
        * <code>INITIATE = 3;</code>
        */
-      INITIATE(2, 3),
+      INITIATE(3),
       /**
        * <code>PROVIDE_REFUND = 4;</code>
        */
-      PROVIDE_REFUND(3, 4),
+      PROVIDE_REFUND(4),
       /**
        * <code>RETURN_REFUND = 5;</code>
        */
-      RETURN_REFUND(4, 5),
+      RETURN_REFUND(5),
       /**
        * <code>PROVIDE_CONTRACT = 6;</code>
        */
-      PROVIDE_CONTRACT(5, 6),
+      PROVIDE_CONTRACT(6),
       /**
-       * <code>CHANNEL_OPEN = 7;</code>
-       *
        * <pre>
        * Note that there are no optional fields set for CHANNEL_OPEN, it is sent from the
        * secondary to the primary to indicate that the provided contract was received,
@@ -454,23 +187,23 @@ public final class Protos {
        * reopen the channel by setting the contract transaction hash in its CLIENT_VERSION
        * message.
        * </pre>
+       *
+       * <code>CHANNEL_OPEN = 7;</code>
        */
-      CHANNEL_OPEN(6, 7),
+      CHANNEL_OPEN(7),
       /**
        * <code>UPDATE_PAYMENT = 8;</code>
        */
-      UPDATE_PAYMENT(7, 8),
+      UPDATE_PAYMENT(8),
       /**
-       * <code>PAYMENT_ACK = 11;</code>
-       *
        * <pre>
        * Sent by the server to the client after an UPDATE_PAYMENT message is successfully processed.
        * </pre>
-       */
-      PAYMENT_ACK(8, 11),
-      /**
-       * <code>CLOSE = 9;</code>
        *
+       * <code>PAYMENT_ACK = 11;</code>
+       */
+      PAYMENT_ACK(11),
+      /**
        * <pre>
        * Either side can send this message. If the client sends it to the server, then the server
        * takes the most recent signature it received in an UPDATE_PAYMENT and uses it to create a
@@ -483,19 +216,21 @@ public final class Protos {
        * case this is just an equivalent to a TCP FIN packet. An explicit end-of-protocol markers can be
        * useful when this protocol is embedded inside another.
        * </pre>
-       */
-      CLOSE(9, 9),
-      /**
-       * <code>ERROR = 10;</code>
        *
+       * <code>CLOSE = 9;</code>
+       */
+      CLOSE(9),
+      /**
        * <pre>
        * Used to indicate an error condition.
        * Both parties should make an effort to send either an ERROR or a CLOSE immediately
        * before closing the socket (unless they just received an ERROR or a CLOSE). This is important
        * because the protocol may not run over TCP.
        * </pre>
+       *
+       * <code>ERROR = 10;</code>
        */
-      ERROR(10, 10),
+      ERROR(10),
       ;
 
       /**
@@ -523,8 +258,6 @@ public final class Protos {
        */
       public static final int PROVIDE_CONTRACT_VALUE = 6;
       /**
-       * <code>CHANNEL_OPEN = 7;</code>
-       *
        * <pre>
        * Note that there are no optional fields set for CHANNEL_OPEN, it is sent from the
        * secondary to the primary to indicate that the provided contract was received,
@@ -534,6 +267,8 @@ public final class Protos {
        * reopen the channel by setting the contract transaction hash in its CLIENT_VERSION
        * message.
        * </pre>
+       *
+       * <code>CHANNEL_OPEN = 7;</code>
        */
       public static final int CHANNEL_OPEN_VALUE = 7;
       /**
@@ -541,16 +276,14 @@ public final class Protos {
        */
       public static final int UPDATE_PAYMENT_VALUE = 8;
       /**
-       * <code>PAYMENT_ACK = 11;</code>
-       *
        * <pre>
        * Sent by the server to the client after an UPDATE_PAYMENT message is successfully processed.
        * </pre>
+       *
+       * <code>PAYMENT_ACK = 11;</code>
        */
       public static final int PAYMENT_ACK_VALUE = 11;
       /**
-       * <code>CLOSE = 9;</code>
-       *
        * <pre>
        * Either side can send this message. If the client sends it to the server, then the server
        * takes the most recent signature it received in an UPDATE_PAYMENT and uses it to create a
@@ -563,24 +296,36 @@ public final class Protos {
        * case this is just an equivalent to a TCP FIN packet. An explicit end-of-protocol markers can be
        * useful when this protocol is embedded inside another.
        * </pre>
+       *
+       * <code>CLOSE = 9;</code>
        */
       public static final int CLOSE_VALUE = 9;
       /**
-       * <code>ERROR = 10;</code>
-       *
        * <pre>
        * Used to indicate an error condition.
        * Both parties should make an effort to send either an ERROR or a CLOSE immediately
        * before closing the socket (unless they just received an ERROR or a CLOSE). This is important
        * because the protocol may not run over TCP.
        * </pre>
+       *
+       * <code>ERROR = 10;</code>
        */
       public static final int ERROR_VALUE = 10;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static MessageType valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static MessageType forNumber(int value) {
         switch (value) {
           case 1: return CLIENT_VERSION;
           case 2: return SERVER_VERSION;
@@ -601,43 +346,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<MessageType>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          MessageType> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<MessageType>() {
               public MessageType findValueByNumber(int number) {
-                return MessageType.valueOf(number);
+                return MessageType.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.TwoWayChannelMessage.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final MessageType[] VALUES = values();
-
-      public static MessageType valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private MessageType(int index, int value) {
-        this.index = index;
+      private MessageType(int value) {
         this.value = value;
       }
 
@@ -646,63 +365,136 @@ public final class Protos {
 
     private int bitField0_;
     public static final int TYPE_FIELD_NUMBER = 1;
-    private org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType type_;
+    private int type_;
     /**
-     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-     *
      * <pre>
      * This is required so if a new message type is added in future, old software aborts trying
      * to read the message as early as possible. If the message doesn't parse, the socket should
      * be closed.
      * </pre>
+     *
+     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
      */
     public boolean hasType() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-     *
      * <pre>
      * This is required so if a new message type is added in future, old software aborts trying
      * to read the message as early as possible. If the message doesn't parse, the socket should
      * be closed.
      * </pre>
+     *
+     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
      */
     public org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType getType() {
-      return type_;
+      org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType result = org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.forNumber(type_);
+      return result == null ? org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.CLIENT_VERSION : result;
+    }
+    /**
+     * <pre>
+     * This is required so if a new message type is added in future, old software aborts trying
+     * to read the message as early as possible. If the message doesn't parse, the socket should
+     * be closed.
+     * </pre>
+     *
+     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
+     */
+    private void setType(org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      bitField0_ |= 0x00000001;
+      type_ = value.getNumber();
+    }
+    /**
+     * <pre>
+     * This is required so if a new message type is added in future, old software aborts trying
+     * to read the message as early as possible. If the message doesn't parse, the socket should
+     * be closed.
+     * </pre>
+     *
+     * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
+     */
+    private void clearType() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      type_ = 1;
     }
 
     public static final int CLIENT_VERSION_FIELD_NUMBER = 2;
     private org.flo.paymentchannel.Protos.ClientVersion clientVersion_;
     /**
-     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-     *
      * <pre>
      * Now one optional field for each message. Only the field specified by type should be read.
      * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
      */
     public boolean hasClientVersion() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-     *
      * <pre>
      * Now one optional field for each message. Only the field specified by type should be read.
      * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
      */
     public org.flo.paymentchannel.Protos.ClientVersion getClientVersion() {
-      return clientVersion_;
+      return clientVersion_ == null ? org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance() : clientVersion_;
     }
     /**
-     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-     *
      * <pre>
      * Now one optional field for each message. Only the field specified by type should be read.
      * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
      */
-    public org.flo.paymentchannel.Protos.ClientVersionOrBuilder getClientVersionOrBuilder() {
-      return clientVersion_;
+    private void setClientVersion(org.flo.paymentchannel.Protos.ClientVersion value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      clientVersion_ = value;
+      bitField0_ |= 0x00000002;
+      }
+    /**
+     * <pre>
+     * Now one optional field for each message. Only the field specified by type should be read.
+     * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
+     */
+    private void setClientVersion(
+        org.flo.paymentchannel.Protos.ClientVersion.Builder builderForValue) {
+      clientVersion_ = builderForValue.build();
+      bitField0_ |= 0x00000002;
+    }
+    /**
+     * <pre>
+     * Now one optional field for each message. Only the field specified by type should be read.
+     * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
+     */
+    private void mergeClientVersion(org.flo.paymentchannel.Protos.ClientVersion value) {
+      if (clientVersion_ != null &&
+          clientVersion_ != org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance()) {
+        clientVersion_ =
+          org.flo.paymentchannel.Protos.ClientVersion.newBuilder(clientVersion_).mergeFrom(value).buildPartial();
+      } else {
+        clientVersion_ = value;
+      }
+      bitField0_ |= 0x00000002;
+    }
+    /**
+     * <pre>
+     * Now one optional field for each message. Only the field specified by type should be read.
+     * </pre>
+     *
+     * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
+     */
+    private void clearClientVersion() {  clientVersion_ = null;
+      bitField0_ = (bitField0_ & ~0x00000002);
     }
 
     public static final int SERVER_VERSION_FIELD_NUMBER = 3;
@@ -717,13 +509,44 @@ public final class Protos {
      * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
      */
     public org.flo.paymentchannel.Protos.ServerVersion getServerVersion() {
-      return serverVersion_;
+      return serverVersion_ == null ? org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance() : serverVersion_;
     }
     /**
      * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
      */
-    public org.flo.paymentchannel.Protos.ServerVersionOrBuilder getServerVersionOrBuilder() {
-      return serverVersion_;
+    private void setServerVersion(org.flo.paymentchannel.Protos.ServerVersion value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      serverVersion_ = value;
+      bitField0_ |= 0x00000004;
+      }
+    /**
+     * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
+     */
+    private void setServerVersion(
+        org.flo.paymentchannel.Protos.ServerVersion.Builder builderForValue) {
+      serverVersion_ = builderForValue.build();
+      bitField0_ |= 0x00000004;
+    }
+    /**
+     * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
+     */
+    private void mergeServerVersion(org.flo.paymentchannel.Protos.ServerVersion value) {
+      if (serverVersion_ != null &&
+          serverVersion_ != org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance()) {
+        serverVersion_ =
+          org.flo.paymentchannel.Protos.ServerVersion.newBuilder(serverVersion_).mergeFrom(value).buildPartial();
+      } else {
+        serverVersion_ = value;
+      }
+      bitField0_ |= 0x00000004;
+    }
+    /**
+     * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
+     */
+    private void clearServerVersion() {  serverVersion_ = null;
+      bitField0_ = (bitField0_ & ~0x00000004);
     }
 
     public static final int INITIATE_FIELD_NUMBER = 4;
@@ -738,13 +561,44 @@ public final class Protos {
      * <code>optional .paymentchannels.Initiate initiate = 4;</code>
      */
     public org.flo.paymentchannel.Protos.Initiate getInitiate() {
-      return initiate_;
+      return initiate_ == null ? org.flo.paymentchannel.Protos.Initiate.getDefaultInstance() : initiate_;
     }
     /**
      * <code>optional .paymentchannels.Initiate initiate = 4;</code>
      */
-    public org.flo.paymentchannel.Protos.InitiateOrBuilder getInitiateOrBuilder() {
-      return initiate_;
+    private void setInitiate(org.flo.paymentchannel.Protos.Initiate value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      initiate_ = value;
+      bitField0_ |= 0x00000008;
+      }
+    /**
+     * <code>optional .paymentchannels.Initiate initiate = 4;</code>
+     */
+    private void setInitiate(
+        org.flo.paymentchannel.Protos.Initiate.Builder builderForValue) {
+      initiate_ = builderForValue.build();
+      bitField0_ |= 0x00000008;
+    }
+    /**
+     * <code>optional .paymentchannels.Initiate initiate = 4;</code>
+     */
+    private void mergeInitiate(org.flo.paymentchannel.Protos.Initiate value) {
+      if (initiate_ != null &&
+          initiate_ != org.flo.paymentchannel.Protos.Initiate.getDefaultInstance()) {
+        initiate_ =
+          org.flo.paymentchannel.Protos.Initiate.newBuilder(initiate_).mergeFrom(value).buildPartial();
+      } else {
+        initiate_ = value;
+      }
+      bitField0_ |= 0x00000008;
+    }
+    /**
+     * <code>optional .paymentchannels.Initiate initiate = 4;</code>
+     */
+    private void clearInitiate() {  initiate_ = null;
+      bitField0_ = (bitField0_ & ~0x00000008);
     }
 
     public static final int PROVIDE_REFUND_FIELD_NUMBER = 5;
@@ -759,13 +613,44 @@ public final class Protos {
      * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
      */
     public org.flo.paymentchannel.Protos.ProvideRefund getProvideRefund() {
-      return provideRefund_;
+      return provideRefund_ == null ? org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance() : provideRefund_;
     }
     /**
      * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
      */
-    public org.flo.paymentchannel.Protos.ProvideRefundOrBuilder getProvideRefundOrBuilder() {
-      return provideRefund_;
+    private void setProvideRefund(org.flo.paymentchannel.Protos.ProvideRefund value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      provideRefund_ = value;
+      bitField0_ |= 0x00000010;
+      }
+    /**
+     * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
+     */
+    private void setProvideRefund(
+        org.flo.paymentchannel.Protos.ProvideRefund.Builder builderForValue) {
+      provideRefund_ = builderForValue.build();
+      bitField0_ |= 0x00000010;
+    }
+    /**
+     * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
+     */
+    private void mergeProvideRefund(org.flo.paymentchannel.Protos.ProvideRefund value) {
+      if (provideRefund_ != null &&
+          provideRefund_ != org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance()) {
+        provideRefund_ =
+          org.flo.paymentchannel.Protos.ProvideRefund.newBuilder(provideRefund_).mergeFrom(value).buildPartial();
+      } else {
+        provideRefund_ = value;
+      }
+      bitField0_ |= 0x00000010;
+    }
+    /**
+     * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
+     */
+    private void clearProvideRefund() {  provideRefund_ = null;
+      bitField0_ = (bitField0_ & ~0x00000010);
     }
 
     public static final int RETURN_REFUND_FIELD_NUMBER = 6;
@@ -780,13 +665,44 @@ public final class Protos {
      * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
      */
     public org.flo.paymentchannel.Protos.ReturnRefund getReturnRefund() {
-      return returnRefund_;
+      return returnRefund_ == null ? org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance() : returnRefund_;
     }
     /**
      * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
      */
-    public org.flo.paymentchannel.Protos.ReturnRefundOrBuilder getReturnRefundOrBuilder() {
-      return returnRefund_;
+    private void setReturnRefund(org.flo.paymentchannel.Protos.ReturnRefund value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      returnRefund_ = value;
+      bitField0_ |= 0x00000020;
+      }
+    /**
+     * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
+     */
+    private void setReturnRefund(
+        org.flo.paymentchannel.Protos.ReturnRefund.Builder builderForValue) {
+      returnRefund_ = builderForValue.build();
+      bitField0_ |= 0x00000020;
+    }
+    /**
+     * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
+     */
+    private void mergeReturnRefund(org.flo.paymentchannel.Protos.ReturnRefund value) {
+      if (returnRefund_ != null &&
+          returnRefund_ != org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance()) {
+        returnRefund_ =
+          org.flo.paymentchannel.Protos.ReturnRefund.newBuilder(returnRefund_).mergeFrom(value).buildPartial();
+      } else {
+        returnRefund_ = value;
+      }
+      bitField0_ |= 0x00000020;
+    }
+    /**
+     * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
+     */
+    private void clearReturnRefund() {  returnRefund_ = null;
+      bitField0_ = (bitField0_ & ~0x00000020);
     }
 
     public static final int PROVIDE_CONTRACT_FIELD_NUMBER = 7;
@@ -801,13 +717,44 @@ public final class Protos {
      * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
      */
     public org.flo.paymentchannel.Protos.ProvideContract getProvideContract() {
-      return provideContract_;
+      return provideContract_ == null ? org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance() : provideContract_;
     }
     /**
      * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
      */
-    public org.flo.paymentchannel.Protos.ProvideContractOrBuilder getProvideContractOrBuilder() {
-      return provideContract_;
+    private void setProvideContract(org.flo.paymentchannel.Protos.ProvideContract value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      provideContract_ = value;
+      bitField0_ |= 0x00000040;
+      }
+    /**
+     * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
+     */
+    private void setProvideContract(
+        org.flo.paymentchannel.Protos.ProvideContract.Builder builderForValue) {
+      provideContract_ = builderForValue.build();
+      bitField0_ |= 0x00000040;
+    }
+    /**
+     * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
+     */
+    private void mergeProvideContract(org.flo.paymentchannel.Protos.ProvideContract value) {
+      if (provideContract_ != null &&
+          provideContract_ != org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance()) {
+        provideContract_ =
+          org.flo.paymentchannel.Protos.ProvideContract.newBuilder(provideContract_).mergeFrom(value).buildPartial();
+      } else {
+        provideContract_ = value;
+      }
+      bitField0_ |= 0x00000040;
+    }
+    /**
+     * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
+     */
+    private void clearProvideContract() {  provideContract_ = null;
+      bitField0_ = (bitField0_ & ~0x00000040);
     }
 
     public static final int UPDATE_PAYMENT_FIELD_NUMBER = 8;
@@ -822,13 +769,44 @@ public final class Protos {
      * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
      */
     public org.flo.paymentchannel.Protos.UpdatePayment getUpdatePayment() {
-      return updatePayment_;
+      return updatePayment_ == null ? org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance() : updatePayment_;
     }
     /**
      * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
      */
-    public org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder getUpdatePaymentOrBuilder() {
-      return updatePayment_;
+    private void setUpdatePayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      updatePayment_ = value;
+      bitField0_ |= 0x00000080;
+      }
+    /**
+     * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
+     */
+    private void setUpdatePayment(
+        org.flo.paymentchannel.Protos.UpdatePayment.Builder builderForValue) {
+      updatePayment_ = builderForValue.build();
+      bitField0_ |= 0x00000080;
+    }
+    /**
+     * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
+     */
+    private void mergeUpdatePayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
+      if (updatePayment_ != null &&
+          updatePayment_ != org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance()) {
+        updatePayment_ =
+          org.flo.paymentchannel.Protos.UpdatePayment.newBuilder(updatePayment_).mergeFrom(value).buildPartial();
+      } else {
+        updatePayment_ = value;
+      }
+      bitField0_ |= 0x00000080;
+    }
+    /**
+     * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
+     */
+    private void clearUpdatePayment() {  updatePayment_ = null;
+      bitField0_ = (bitField0_ & ~0x00000080);
     }
 
     public static final int PAYMENT_ACK_FIELD_NUMBER = 11;
@@ -843,13 +821,44 @@ public final class Protos {
      * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
      */
     public org.flo.paymentchannel.Protos.PaymentAck getPaymentAck() {
-      return paymentAck_;
+      return paymentAck_ == null ? org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance() : paymentAck_;
     }
     /**
      * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
      */
-    public org.flo.paymentchannel.Protos.PaymentAckOrBuilder getPaymentAckOrBuilder() {
-      return paymentAck_;
+    private void setPaymentAck(org.flo.paymentchannel.Protos.PaymentAck value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      paymentAck_ = value;
+      bitField0_ |= 0x00000100;
+      }
+    /**
+     * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
+     */
+    private void setPaymentAck(
+        org.flo.paymentchannel.Protos.PaymentAck.Builder builderForValue) {
+      paymentAck_ = builderForValue.build();
+      bitField0_ |= 0x00000100;
+    }
+    /**
+     * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
+     */
+    private void mergePaymentAck(org.flo.paymentchannel.Protos.PaymentAck value) {
+      if (paymentAck_ != null &&
+          paymentAck_ != org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance()) {
+        paymentAck_ =
+          org.flo.paymentchannel.Protos.PaymentAck.newBuilder(paymentAck_).mergeFrom(value).buildPartial();
+      } else {
+        paymentAck_ = value;
+      }
+      bitField0_ |= 0x00000100;
+    }
+    /**
+     * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
+     */
+    private void clearPaymentAck() {  paymentAck_ = null;
+      bitField0_ = (bitField0_ & ~0x00000100);
     }
 
     public static final int SETTLEMENT_FIELD_NUMBER = 9;
@@ -864,13 +873,44 @@ public final class Protos {
      * <code>optional .paymentchannels.Settlement settlement = 9;</code>
      */
     public org.flo.paymentchannel.Protos.Settlement getSettlement() {
-      return settlement_;
+      return settlement_ == null ? org.flo.paymentchannel.Protos.Settlement.getDefaultInstance() : settlement_;
     }
     /**
      * <code>optional .paymentchannels.Settlement settlement = 9;</code>
      */
-    public org.flo.paymentchannel.Protos.SettlementOrBuilder getSettlementOrBuilder() {
-      return settlement_;
+    private void setSettlement(org.flo.paymentchannel.Protos.Settlement value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      settlement_ = value;
+      bitField0_ |= 0x00000200;
+      }
+    /**
+     * <code>optional .paymentchannels.Settlement settlement = 9;</code>
+     */
+    private void setSettlement(
+        org.flo.paymentchannel.Protos.Settlement.Builder builderForValue) {
+      settlement_ = builderForValue.build();
+      bitField0_ |= 0x00000200;
+    }
+    /**
+     * <code>optional .paymentchannels.Settlement settlement = 9;</code>
+     */
+    private void mergeSettlement(org.flo.paymentchannel.Protos.Settlement value) {
+      if (settlement_ != null &&
+          settlement_ != org.flo.paymentchannel.Protos.Settlement.getDefaultInstance()) {
+        settlement_ =
+          org.flo.paymentchannel.Protos.Settlement.newBuilder(settlement_).mergeFrom(value).buildPartial();
+      } else {
+        settlement_ = value;
+      }
+      bitField0_ |= 0x00000200;
+    }
+    /**
+     * <code>optional .paymentchannels.Settlement settlement = 9;</code>
+     */
+    private void clearSettlement() {  settlement_ = null;
+      bitField0_ = (bitField0_ & ~0x00000200);
     }
 
     public static final int ERROR_FIELD_NUMBER = 10;
@@ -885,130 +925,84 @@ public final class Protos {
      * <code>optional .paymentchannels.Error error = 10;</code>
      */
     public org.flo.paymentchannel.Protos.Error getError() {
-      return error_;
+      return error_ == null ? org.flo.paymentchannel.Protos.Error.getDefaultInstance() : error_;
     }
     /**
      * <code>optional .paymentchannels.Error error = 10;</code>
      */
-    public org.flo.paymentchannel.Protos.ErrorOrBuilder getErrorOrBuilder() {
-      return error_;
+    private void setError(org.flo.paymentchannel.Protos.Error value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      error_ = value;
+      bitField0_ |= 0x00000400;
+      }
+    /**
+     * <code>optional .paymentchannels.Error error = 10;</code>
+     */
+    private void setError(
+        org.flo.paymentchannel.Protos.Error.Builder builderForValue) {
+      error_ = builderForValue.build();
+      bitField0_ |= 0x00000400;
     }
-
-    private void initFields() {
-      type_ = org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.CLIENT_VERSION;
-      clientVersion_ = org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance();
-      serverVersion_ = org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance();
-      initiate_ = org.flo.paymentchannel.Protos.Initiate.getDefaultInstance();
-      provideRefund_ = org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance();
-      returnRefund_ = org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance();
-      provideContract_ = org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance();
-      updatePayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-      paymentAck_ = org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance();
-      settlement_ = org.flo.paymentchannel.Protos.Settlement.getDefaultInstance();
-      error_ = org.flo.paymentchannel.Protos.Error.getDefaultInstance();
+    /**
+     * <code>optional .paymentchannels.Error error = 10;</code>
+     */
+    private void mergeError(org.flo.paymentchannel.Protos.Error value) {
+      if (error_ != null &&
+          error_ != org.flo.paymentchannel.Protos.Error.getDefaultInstance()) {
+        error_ =
+          org.flo.paymentchannel.Protos.Error.newBuilder(error_).mergeFrom(value).buildPartial();
+      } else {
+        error_ = value;
+      }
+      bitField0_ |= 0x00000400;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasType()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (hasClientVersion()) {
-        if (!getClientVersion().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasServerVersion()) {
-        if (!getServerVersion().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasInitiate()) {
-        if (!getInitiate().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasProvideRefund()) {
-        if (!getProvideRefund().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasReturnRefund()) {
-        if (!getReturnRefund().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasProvideContract()) {
-        if (!getProvideContract().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasUpdatePayment()) {
-        if (!getUpdatePayment().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasSettlement()) {
-        if (!getSettlement().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>optional .paymentchannels.Error error = 10;</code>
+     */
+    private void clearError() {  error_ = null;
+      bitField0_ = (bitField0_ & ~0x00000400);
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, type_.getNumber());
+        output.writeEnum(1, type_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeMessage(2, clientVersion_);
+        output.writeMessage(2, getClientVersion());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeMessage(3, serverVersion_);
+        output.writeMessage(3, getServerVersion());
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeMessage(4, initiate_);
+        output.writeMessage(4, getInitiate());
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeMessage(5, provideRefund_);
+        output.writeMessage(5, getProvideRefund());
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        output.writeMessage(6, returnRefund_);
+        output.writeMessage(6, getReturnRefund());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
-        output.writeMessage(7, provideContract_);
+        output.writeMessage(7, getProvideContract());
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
-        output.writeMessage(8, updatePayment_);
+        output.writeMessage(8, getUpdatePayment());
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
-        output.writeMessage(9, settlement_);
+        output.writeMessage(9, getSettlement());
       }
       if (((bitField0_ & 0x00000400) == 0x00000400)) {
-        output.writeMessage(10, error_);
+        output.writeMessage(10, getError());
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        output.writeMessage(11, paymentAck_);
+        output.writeMessage(11, getPaymentAck());
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -1016,1752 +1010,994 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, type_.getNumber());
+          .computeEnumSize(1, type_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, clientVersion_);
+          .computeMessageSize(2, getClientVersion());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, serverVersion_);
+          .computeMessageSize(3, getServerVersion());
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(4, initiate_);
+          .computeMessageSize(4, getInitiate());
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(5, provideRefund_);
+          .computeMessageSize(5, getProvideRefund());
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(6, returnRefund_);
+          .computeMessageSize(6, getReturnRefund());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(7, provideContract_);
+          .computeMessageSize(7, getProvideContract());
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(8, updatePayment_);
+          .computeMessageSize(8, getUpdatePayment());
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(9, settlement_);
+          .computeMessageSize(9, getSettlement());
       }
       if (((bitField0_ & 0x00000400) == 0x00000400)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(10, error_);
+          .computeMessageSize(10, getError());
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(11, paymentAck_);
+          .computeMessageSize(11, getPaymentAck());
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.TwoWayChannelMessage parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.TwoWayChannelMessage prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.TwoWayChannelMessage}
-     *
      * <pre>
      * This message is designed to be either sent raw over the network (e.g. length prefixed) or embedded inside another
      * protocol that is being extended to support micropayments. In this file "primary" typically can be read as "client"
      * and "secondary" as "server".
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.TwoWayChannelMessage}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.TwoWayChannelMessage, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.TwoWayChannelMessage)
         org.flo.paymentchannel.Protos.TwoWayChannelMessageOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_TwoWayChannelMessage_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_TwoWayChannelMessage_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.TwoWayChannelMessage.class, org.flo.paymentchannel.Protos.TwoWayChannelMessage.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.TwoWayChannelMessage.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getClientVersionFieldBuilder();
-          getServerVersionFieldBuilder();
-          getInitiateFieldBuilder();
-          getProvideRefundFieldBuilder();
-          getReturnRefundFieldBuilder();
-          getProvideContractFieldBuilder();
-          getUpdatePaymentFieldBuilder();
-          getPaymentAckFieldBuilder();
-          getSettlementFieldBuilder();
-          getErrorFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        type_ = org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.CLIENT_VERSION;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        if (clientVersionBuilder_ == null) {
-          clientVersion_ = org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance();
-        } else {
-          clientVersionBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000002);
-        if (serverVersionBuilder_ == null) {
-          serverVersion_ = org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance();
-        } else {
-          serverVersionBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000004);
-        if (initiateBuilder_ == null) {
-          initiate_ = org.flo.paymentchannel.Protos.Initiate.getDefaultInstance();
-        } else {
-          initiateBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000008);
-        if (provideRefundBuilder_ == null) {
-          provideRefund_ = org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance();
-        } else {
-          provideRefundBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000010);
-        if (returnRefundBuilder_ == null) {
-          returnRefund_ = org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance();
-        } else {
-          returnRefundBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000020);
-        if (provideContractBuilder_ == null) {
-          provideContract_ = org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance();
-        } else {
-          provideContractBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000040);
-        if (updatePaymentBuilder_ == null) {
-          updatePayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-        } else {
-          updatePaymentBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000080);
-        if (paymentAckBuilder_ == null) {
-          paymentAck_ = org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance();
-        } else {
-          paymentAckBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000100);
-        if (settlementBuilder_ == null) {
-          settlement_ = org.flo.paymentchannel.Protos.Settlement.getDefaultInstance();
-        } else {
-          settlementBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000200);
-        if (errorBuilder_ == null) {
-          error_ = org.flo.paymentchannel.Protos.Error.getDefaultInstance();
-        } else {
-          errorBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000400);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_TwoWayChannelMessage_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.TwoWayChannelMessage getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.TwoWayChannelMessage.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.TwoWayChannelMessage build() {
-        org.flo.paymentchannel.Protos.TwoWayChannelMessage result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.TwoWayChannelMessage buildPartial() {
-        org.flo.paymentchannel.Protos.TwoWayChannelMessage result = new org.flo.paymentchannel.Protos.TwoWayChannelMessage(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.type_ = type_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        if (clientVersionBuilder_ == null) {
-          result.clientVersion_ = clientVersion_;
-        } else {
-          result.clientVersion_ = clientVersionBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        if (serverVersionBuilder_ == null) {
-          result.serverVersion_ = serverVersion_;
-        } else {
-          result.serverVersion_ = serverVersionBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        if (initiateBuilder_ == null) {
-          result.initiate_ = initiate_;
-        } else {
-          result.initiate_ = initiateBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        if (provideRefundBuilder_ == null) {
-          result.provideRefund_ = provideRefund_;
-        } else {
-          result.provideRefund_ = provideRefundBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        if (returnRefundBuilder_ == null) {
-          result.returnRefund_ = returnRefund_;
-        } else {
-          result.returnRefund_ = returnRefundBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000040;
-        }
-        if (provideContractBuilder_ == null) {
-          result.provideContract_ = provideContract_;
-        } else {
-          result.provideContract_ = provideContractBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-          to_bitField0_ |= 0x00000080;
-        }
-        if (updatePaymentBuilder_ == null) {
-          result.updatePayment_ = updatePayment_;
-        } else {
-          result.updatePayment_ = updatePaymentBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
-          to_bitField0_ |= 0x00000100;
-        }
-        if (paymentAckBuilder_ == null) {
-          result.paymentAck_ = paymentAck_;
-        } else {
-          result.paymentAck_ = paymentAckBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
-          to_bitField0_ |= 0x00000200;
-        }
-        if (settlementBuilder_ == null) {
-          result.settlement_ = settlement_;
-        } else {
-          result.settlement_ = settlementBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
-          to_bitField0_ |= 0x00000400;
-        }
-        if (errorBuilder_ == null) {
-          result.error_ = error_;
-        } else {
-          result.error_ = errorBuilder_.build();
-        }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.TwoWayChannelMessage) {
-          return mergeFrom((org.flo.paymentchannel.Protos.TwoWayChannelMessage)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.TwoWayChannelMessage other) {
-        if (other == org.flo.paymentchannel.Protos.TwoWayChannelMessage.getDefaultInstance()) return this;
-        if (other.hasType()) {
-          setType(other.getType());
-        }
-        if (other.hasClientVersion()) {
-          mergeClientVersion(other.getClientVersion());
-        }
-        if (other.hasServerVersion()) {
-          mergeServerVersion(other.getServerVersion());
-        }
-        if (other.hasInitiate()) {
-          mergeInitiate(other.getInitiate());
-        }
-        if (other.hasProvideRefund()) {
-          mergeProvideRefund(other.getProvideRefund());
-        }
-        if (other.hasReturnRefund()) {
-          mergeReturnRefund(other.getReturnRefund());
-        }
-        if (other.hasProvideContract()) {
-          mergeProvideContract(other.getProvideContract());
-        }
-        if (other.hasUpdatePayment()) {
-          mergeUpdatePayment(other.getUpdatePayment());
-        }
-        if (other.hasPaymentAck()) {
-          mergePaymentAck(other.getPaymentAck());
-        }
-        if (other.hasSettlement()) {
-          mergeSettlement(other.getSettlement());
-        }
-        if (other.hasError()) {
-          mergeError(other.getError());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasType()) {
-          
-          return false;
-        }
-        if (hasClientVersion()) {
-          if (!getClientVersion().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasServerVersion()) {
-          if (!getServerVersion().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasInitiate()) {
-          if (!getInitiate().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasProvideRefund()) {
-          if (!getProvideRefund().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasReturnRefund()) {
-          if (!getReturnRefund().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasProvideContract()) {
-          if (!getProvideContract().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasUpdatePayment()) {
-          if (!getUpdatePayment().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasSettlement()) {
-          if (!getSettlement().isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.TwoWayChannelMessage parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.TwoWayChannelMessage) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType type_ = org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.CLIENT_VERSION;
       /**
-       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-       *
        * <pre>
        * This is required so if a new message type is added in future, old software aborts trying
        * to read the message as early as possible. If the message doesn't parse, the socket should
        * be closed.
        * </pre>
+       *
+       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
        */
       public boolean hasType() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasType();
       }
       /**
-       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-       *
        * <pre>
        * This is required so if a new message type is added in future, old software aborts trying
        * to read the message as early as possible. If the message doesn't parse, the socket should
        * be closed.
        * </pre>
+       *
+       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
        */
       public org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType getType() {
-        return type_;
+        return instance.getType();
       }
       /**
-       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-       *
        * <pre>
        * This is required so if a new message type is added in future, old software aborts trying
        * to read the message as early as possible. If the message doesn't parse, the socket should
        * be closed.
        * </pre>
+       *
+       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
        */
       public Builder setType(org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        type_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setType(value);
         return this;
       }
       /**
-       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
-       *
        * <pre>
        * This is required so if a new message type is added in future, old software aborts trying
        * to read the message as early as possible. If the message doesn't parse, the socket should
        * be closed.
        * </pre>
+       *
+       * <code>required .paymentchannels.TwoWayChannelMessage.MessageType type = 1;</code>
        */
       public Builder clearType() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        type_ = org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.CLIENT_VERSION;
-        onChanged();
+        copyOnWrite();
+        instance.clearType();
         return this;
       }
 
-      private org.flo.paymentchannel.Protos.ClientVersion clientVersion_ = org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ClientVersion, org.flo.paymentchannel.Protos.ClientVersion.Builder, org.flo.paymentchannel.Protos.ClientVersionOrBuilder> clientVersionBuilder_;
       /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
        * <pre>
        * Now one optional field for each message. Only the field specified by type should be read.
        * </pre>
+       *
+       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
        */
       public boolean hasClientVersion() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasClientVersion();
       }
       /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
        * <pre>
        * Now one optional field for each message. Only the field specified by type should be read.
        * </pre>
+       *
+       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
        */
       public org.flo.paymentchannel.Protos.ClientVersion getClientVersion() {
-        if (clientVersionBuilder_ == null) {
-          return clientVersion_;
-        } else {
-          return clientVersionBuilder_.getMessage();
-        }
+        return instance.getClientVersion();
       }
       /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
        * <pre>
        * Now one optional field for each message. Only the field specified by type should be read.
        * </pre>
+       *
+       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
        */
       public Builder setClientVersion(org.flo.paymentchannel.Protos.ClientVersion value) {
-        if (clientVersionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          clientVersion_ = value;
-          onChanged();
-        } else {
-          clientVersionBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000002;
+        copyOnWrite();
+        instance.setClientVersion(value);
         return this;
-      }
+        }
       /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
        * <pre>
        * Now one optional field for each message. Only the field specified by type should be read.
        * </pre>
+       *
+       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
        */
       public Builder setClientVersion(
           org.flo.paymentchannel.Protos.ClientVersion.Builder builderForValue) {
-        if (clientVersionBuilder_ == null) {
-          clientVersion_ = builderForValue.build();
-          onChanged();
-        } else {
-          clientVersionBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000002;
+        copyOnWrite();
+        instance.setClientVersion(builderForValue);
         return this;
       }
       /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
        * <pre>
        * Now one optional field for each message. Only the field specified by type should be read.
        * </pre>
+       *
+       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
        */
       public Builder mergeClientVersion(org.flo.paymentchannel.Protos.ClientVersion value) {
-        if (clientVersionBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
-              clientVersion_ != org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance()) {
-            clientVersion_ =
-              org.flo.paymentchannel.Protos.ClientVersion.newBuilder(clientVersion_).mergeFrom(value).buildPartial();
-          } else {
-            clientVersion_ = value;
-          }
-          onChanged();
-        } else {
-          clientVersionBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000002;
+        copyOnWrite();
+        instance.mergeClientVersion(value);
         return this;
       }
       /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
        * <pre>
        * Now one optional field for each message. Only the field specified by type should be read.
        * </pre>
+       *
+       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
        */
-      public Builder clearClientVersion() {
-        if (clientVersionBuilder_ == null) {
-          clientVersion_ = org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance();
-          onChanged();
-        } else {
-          clientVersionBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000002);
+      public Builder clearClientVersion() {  copyOnWrite();
+        instance.clearClientVersion();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
-       * <pre>
-       * Now one optional field for each message. Only the field specified by type should be read.
-       * </pre>
-       */
-      public org.flo.paymentchannel.Protos.ClientVersion.Builder getClientVersionBuilder() {
-        bitField0_ |= 0x00000002;
-        onChanged();
-        return getClientVersionFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
-       * <pre>
-       * Now one optional field for each message. Only the field specified by type should be read.
-       * </pre>
-       */
-      public org.flo.paymentchannel.Protos.ClientVersionOrBuilder getClientVersionOrBuilder() {
-        if (clientVersionBuilder_ != null) {
-          return clientVersionBuilder_.getMessageOrBuilder();
-        } else {
-          return clientVersion_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.ClientVersion client_version = 2;</code>
-       *
-       * <pre>
-       * Now one optional field for each message. Only the field specified by type should be read.
-       * </pre>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ClientVersion, org.flo.paymentchannel.Protos.ClientVersion.Builder, org.flo.paymentchannel.Protos.ClientVersionOrBuilder> 
-          getClientVersionFieldBuilder() {
-        if (clientVersionBuilder_ == null) {
-          clientVersionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.ClientVersion, org.flo.paymentchannel.Protos.ClientVersion.Builder, org.flo.paymentchannel.Protos.ClientVersionOrBuilder>(
-                  getClientVersion(),
-                  getParentForChildren(),
-                  isClean());
-          clientVersion_ = null;
-        }
-        return clientVersionBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.ServerVersion serverVersion_ = org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ServerVersion, org.flo.paymentchannel.Protos.ServerVersion.Builder, org.flo.paymentchannel.Protos.ServerVersionOrBuilder> serverVersionBuilder_;
       /**
        * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
        */
       public boolean hasServerVersion() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasServerVersion();
       }
       /**
        * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
        */
       public org.flo.paymentchannel.Protos.ServerVersion getServerVersion() {
-        if (serverVersionBuilder_ == null) {
-          return serverVersion_;
-        } else {
-          return serverVersionBuilder_.getMessage();
-        }
+        return instance.getServerVersion();
       }
       /**
        * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
        */
       public Builder setServerVersion(org.flo.paymentchannel.Protos.ServerVersion value) {
-        if (serverVersionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          serverVersion_ = value;
-          onChanged();
-        } else {
-          serverVersionBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000004;
+        copyOnWrite();
+        instance.setServerVersion(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
        */
       public Builder setServerVersion(
           org.flo.paymentchannel.Protos.ServerVersion.Builder builderForValue) {
-        if (serverVersionBuilder_ == null) {
-          serverVersion_ = builderForValue.build();
-          onChanged();
-        } else {
-          serverVersionBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000004;
+        copyOnWrite();
+        instance.setServerVersion(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
        */
       public Builder mergeServerVersion(org.flo.paymentchannel.Protos.ServerVersion value) {
-        if (serverVersionBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
-              serverVersion_ != org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance()) {
-            serverVersion_ =
-              org.flo.paymentchannel.Protos.ServerVersion.newBuilder(serverVersion_).mergeFrom(value).buildPartial();
-          } else {
-            serverVersion_ = value;
-          }
-          onChanged();
-        } else {
-          serverVersionBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000004;
+        copyOnWrite();
+        instance.mergeServerVersion(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
        */
-      public Builder clearServerVersion() {
-        if (serverVersionBuilder_ == null) {
-          serverVersion_ = org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance();
-          onChanged();
-        } else {
-          serverVersionBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000004);
+      public Builder clearServerVersion() {  copyOnWrite();
+        instance.clearServerVersion();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
-       */
-      public org.flo.paymentchannel.Protos.ServerVersion.Builder getServerVersionBuilder() {
-        bitField0_ |= 0x00000004;
-        onChanged();
-        return getServerVersionFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
-       */
-      public org.flo.paymentchannel.Protos.ServerVersionOrBuilder getServerVersionOrBuilder() {
-        if (serverVersionBuilder_ != null) {
-          return serverVersionBuilder_.getMessageOrBuilder();
-        } else {
-          return serverVersion_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.ServerVersion server_version = 3;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ServerVersion, org.flo.paymentchannel.Protos.ServerVersion.Builder, org.flo.paymentchannel.Protos.ServerVersionOrBuilder> 
-          getServerVersionFieldBuilder() {
-        if (serverVersionBuilder_ == null) {
-          serverVersionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.ServerVersion, org.flo.paymentchannel.Protos.ServerVersion.Builder, org.flo.paymentchannel.Protos.ServerVersionOrBuilder>(
-                  getServerVersion(),
-                  getParentForChildren(),
-                  isClean());
-          serverVersion_ = null;
-        }
-        return serverVersionBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.Initiate initiate_ = org.flo.paymentchannel.Protos.Initiate.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.Initiate, org.flo.paymentchannel.Protos.Initiate.Builder, org.flo.paymentchannel.Protos.InitiateOrBuilder> initiateBuilder_;
       /**
        * <code>optional .paymentchannels.Initiate initiate = 4;</code>
        */
       public boolean hasInitiate() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasInitiate();
       }
       /**
        * <code>optional .paymentchannels.Initiate initiate = 4;</code>
        */
       public org.flo.paymentchannel.Protos.Initiate getInitiate() {
-        if (initiateBuilder_ == null) {
-          return initiate_;
-        } else {
-          return initiateBuilder_.getMessage();
-        }
+        return instance.getInitiate();
       }
       /**
        * <code>optional .paymentchannels.Initiate initiate = 4;</code>
        */
       public Builder setInitiate(org.flo.paymentchannel.Protos.Initiate value) {
-        if (initiateBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          initiate_ = value;
-          onChanged();
-        } else {
-          initiateBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000008;
+        copyOnWrite();
+        instance.setInitiate(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.Initiate initiate = 4;</code>
        */
       public Builder setInitiate(
           org.flo.paymentchannel.Protos.Initiate.Builder builderForValue) {
-        if (initiateBuilder_ == null) {
-          initiate_ = builderForValue.build();
-          onChanged();
-        } else {
-          initiateBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000008;
+        copyOnWrite();
+        instance.setInitiate(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.Initiate initiate = 4;</code>
        */
       public Builder mergeInitiate(org.flo.paymentchannel.Protos.Initiate value) {
-        if (initiateBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
-              initiate_ != org.flo.paymentchannel.Protos.Initiate.getDefaultInstance()) {
-            initiate_ =
-              org.flo.paymentchannel.Protos.Initiate.newBuilder(initiate_).mergeFrom(value).buildPartial();
-          } else {
-            initiate_ = value;
-          }
-          onChanged();
-        } else {
-          initiateBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000008;
+        copyOnWrite();
+        instance.mergeInitiate(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.Initiate initiate = 4;</code>
        */
-      public Builder clearInitiate() {
-        if (initiateBuilder_ == null) {
-          initiate_ = org.flo.paymentchannel.Protos.Initiate.getDefaultInstance();
-          onChanged();
-        } else {
-          initiateBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000008);
+      public Builder clearInitiate() {  copyOnWrite();
+        instance.clearInitiate();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.Initiate initiate = 4;</code>
-       */
-      public org.flo.paymentchannel.Protos.Initiate.Builder getInitiateBuilder() {
-        bitField0_ |= 0x00000008;
-        onChanged();
-        return getInitiateFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.Initiate initiate = 4;</code>
-       */
-      public org.flo.paymentchannel.Protos.InitiateOrBuilder getInitiateOrBuilder() {
-        if (initiateBuilder_ != null) {
-          return initiateBuilder_.getMessageOrBuilder();
-        } else {
-          return initiate_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.Initiate initiate = 4;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.Initiate, org.flo.paymentchannel.Protos.Initiate.Builder, org.flo.paymentchannel.Protos.InitiateOrBuilder> 
-          getInitiateFieldBuilder() {
-        if (initiateBuilder_ == null) {
-          initiateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.Initiate, org.flo.paymentchannel.Protos.Initiate.Builder, org.flo.paymentchannel.Protos.InitiateOrBuilder>(
-                  getInitiate(),
-                  getParentForChildren(),
-                  isClean());
-          initiate_ = null;
-        }
-        return initiateBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.ProvideRefund provideRefund_ = org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ProvideRefund, org.flo.paymentchannel.Protos.ProvideRefund.Builder, org.flo.paymentchannel.Protos.ProvideRefundOrBuilder> provideRefundBuilder_;
       /**
        * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
        */
       public boolean hasProvideRefund() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasProvideRefund();
       }
       /**
        * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
        */
       public org.flo.paymentchannel.Protos.ProvideRefund getProvideRefund() {
-        if (provideRefundBuilder_ == null) {
-          return provideRefund_;
-        } else {
-          return provideRefundBuilder_.getMessage();
-        }
+        return instance.getProvideRefund();
       }
       /**
        * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
        */
       public Builder setProvideRefund(org.flo.paymentchannel.Protos.ProvideRefund value) {
-        if (provideRefundBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          provideRefund_ = value;
-          onChanged();
-        } else {
-          provideRefundBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000010;
+        copyOnWrite();
+        instance.setProvideRefund(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
        */
       public Builder setProvideRefund(
           org.flo.paymentchannel.Protos.ProvideRefund.Builder builderForValue) {
-        if (provideRefundBuilder_ == null) {
-          provideRefund_ = builderForValue.build();
-          onChanged();
-        } else {
-          provideRefundBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000010;
+        copyOnWrite();
+        instance.setProvideRefund(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
        */
       public Builder mergeProvideRefund(org.flo.paymentchannel.Protos.ProvideRefund value) {
-        if (provideRefundBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010) &&
-              provideRefund_ != org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance()) {
-            provideRefund_ =
-              org.flo.paymentchannel.Protos.ProvideRefund.newBuilder(provideRefund_).mergeFrom(value).buildPartial();
-          } else {
-            provideRefund_ = value;
-          }
-          onChanged();
-        } else {
-          provideRefundBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000010;
+        copyOnWrite();
+        instance.mergeProvideRefund(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
        */
-      public Builder clearProvideRefund() {
-        if (provideRefundBuilder_ == null) {
-          provideRefund_ = org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance();
-          onChanged();
-        } else {
-          provideRefundBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000010);
+      public Builder clearProvideRefund() {  copyOnWrite();
+        instance.clearProvideRefund();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
-       */
-      public org.flo.paymentchannel.Protos.ProvideRefund.Builder getProvideRefundBuilder() {
-        bitField0_ |= 0x00000010;
-        onChanged();
-        return getProvideRefundFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
-       */
-      public org.flo.paymentchannel.Protos.ProvideRefundOrBuilder getProvideRefundOrBuilder() {
-        if (provideRefundBuilder_ != null) {
-          return provideRefundBuilder_.getMessageOrBuilder();
-        } else {
-          return provideRefund_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.ProvideRefund provide_refund = 5;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ProvideRefund, org.flo.paymentchannel.Protos.ProvideRefund.Builder, org.flo.paymentchannel.Protos.ProvideRefundOrBuilder> 
-          getProvideRefundFieldBuilder() {
-        if (provideRefundBuilder_ == null) {
-          provideRefundBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.ProvideRefund, org.flo.paymentchannel.Protos.ProvideRefund.Builder, org.flo.paymentchannel.Protos.ProvideRefundOrBuilder>(
-                  getProvideRefund(),
-                  getParentForChildren(),
-                  isClean());
-          provideRefund_ = null;
-        }
-        return provideRefundBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.ReturnRefund returnRefund_ = org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ReturnRefund, org.flo.paymentchannel.Protos.ReturnRefund.Builder, org.flo.paymentchannel.Protos.ReturnRefundOrBuilder> returnRefundBuilder_;
       /**
        * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
        */
       public boolean hasReturnRefund() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return instance.hasReturnRefund();
       }
       /**
        * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
        */
       public org.flo.paymentchannel.Protos.ReturnRefund getReturnRefund() {
-        if (returnRefundBuilder_ == null) {
-          return returnRefund_;
-        } else {
-          return returnRefundBuilder_.getMessage();
-        }
+        return instance.getReturnRefund();
       }
       /**
        * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
        */
       public Builder setReturnRefund(org.flo.paymentchannel.Protos.ReturnRefund value) {
-        if (returnRefundBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          returnRefund_ = value;
-          onChanged();
-        } else {
-          returnRefundBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000020;
+        copyOnWrite();
+        instance.setReturnRefund(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
        */
       public Builder setReturnRefund(
           org.flo.paymentchannel.Protos.ReturnRefund.Builder builderForValue) {
-        if (returnRefundBuilder_ == null) {
-          returnRefund_ = builderForValue.build();
-          onChanged();
-        } else {
-          returnRefundBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000020;
+        copyOnWrite();
+        instance.setReturnRefund(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
        */
       public Builder mergeReturnRefund(org.flo.paymentchannel.Protos.ReturnRefund value) {
-        if (returnRefundBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020) &&
-              returnRefund_ != org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance()) {
-            returnRefund_ =
-              org.flo.paymentchannel.Protos.ReturnRefund.newBuilder(returnRefund_).mergeFrom(value).buildPartial();
-          } else {
-            returnRefund_ = value;
-          }
-          onChanged();
-        } else {
-          returnRefundBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000020;
+        copyOnWrite();
+        instance.mergeReturnRefund(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
        */
-      public Builder clearReturnRefund() {
-        if (returnRefundBuilder_ == null) {
-          returnRefund_ = org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance();
-          onChanged();
-        } else {
-          returnRefundBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000020);
+      public Builder clearReturnRefund() {  copyOnWrite();
+        instance.clearReturnRefund();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
-       */
-      public org.flo.paymentchannel.Protos.ReturnRefund.Builder getReturnRefundBuilder() {
-        bitField0_ |= 0x00000020;
-        onChanged();
-        return getReturnRefundFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
-       */
-      public org.flo.paymentchannel.Protos.ReturnRefundOrBuilder getReturnRefundOrBuilder() {
-        if (returnRefundBuilder_ != null) {
-          return returnRefundBuilder_.getMessageOrBuilder();
-        } else {
-          return returnRefund_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.ReturnRefund return_refund = 6;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ReturnRefund, org.flo.paymentchannel.Protos.ReturnRefund.Builder, org.flo.paymentchannel.Protos.ReturnRefundOrBuilder> 
-          getReturnRefundFieldBuilder() {
-        if (returnRefundBuilder_ == null) {
-          returnRefundBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.ReturnRefund, org.flo.paymentchannel.Protos.ReturnRefund.Builder, org.flo.paymentchannel.Protos.ReturnRefundOrBuilder>(
-                  getReturnRefund(),
-                  getParentForChildren(),
-                  isClean());
-          returnRefund_ = null;
-        }
-        return returnRefundBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.ProvideContract provideContract_ = org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ProvideContract, org.flo.paymentchannel.Protos.ProvideContract.Builder, org.flo.paymentchannel.Protos.ProvideContractOrBuilder> provideContractBuilder_;
       /**
        * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
        */
       public boolean hasProvideContract() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return instance.hasProvideContract();
       }
       /**
        * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
        */
       public org.flo.paymentchannel.Protos.ProvideContract getProvideContract() {
-        if (provideContractBuilder_ == null) {
-          return provideContract_;
-        } else {
-          return provideContractBuilder_.getMessage();
-        }
+        return instance.getProvideContract();
       }
       /**
        * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
        */
       public Builder setProvideContract(org.flo.paymentchannel.Protos.ProvideContract value) {
-        if (provideContractBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          provideContract_ = value;
-          onChanged();
-        } else {
-          provideContractBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000040;
+        copyOnWrite();
+        instance.setProvideContract(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
        */
       public Builder setProvideContract(
           org.flo.paymentchannel.Protos.ProvideContract.Builder builderForValue) {
-        if (provideContractBuilder_ == null) {
-          provideContract_ = builderForValue.build();
-          onChanged();
-        } else {
-          provideContractBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000040;
+        copyOnWrite();
+        instance.setProvideContract(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
        */
       public Builder mergeProvideContract(org.flo.paymentchannel.Protos.ProvideContract value) {
-        if (provideContractBuilder_ == null) {
-          if (((bitField0_ & 0x00000040) == 0x00000040) &&
-              provideContract_ != org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance()) {
-            provideContract_ =
-              org.flo.paymentchannel.Protos.ProvideContract.newBuilder(provideContract_).mergeFrom(value).buildPartial();
-          } else {
-            provideContract_ = value;
-          }
-          onChanged();
-        } else {
-          provideContractBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000040;
+        copyOnWrite();
+        instance.mergeProvideContract(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
        */
-      public Builder clearProvideContract() {
-        if (provideContractBuilder_ == null) {
-          provideContract_ = org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance();
-          onChanged();
-        } else {
-          provideContractBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000040);
+      public Builder clearProvideContract() {  copyOnWrite();
+        instance.clearProvideContract();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
-       */
-      public org.flo.paymentchannel.Protos.ProvideContract.Builder getProvideContractBuilder() {
-        bitField0_ |= 0x00000040;
-        onChanged();
-        return getProvideContractFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
-       */
-      public org.flo.paymentchannel.Protos.ProvideContractOrBuilder getProvideContractOrBuilder() {
-        if (provideContractBuilder_ != null) {
-          return provideContractBuilder_.getMessageOrBuilder();
-        } else {
-          return provideContract_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.ProvideContract provide_contract = 7;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.ProvideContract, org.flo.paymentchannel.Protos.ProvideContract.Builder, org.flo.paymentchannel.Protos.ProvideContractOrBuilder> 
-          getProvideContractFieldBuilder() {
-        if (provideContractBuilder_ == null) {
-          provideContractBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.ProvideContract, org.flo.paymentchannel.Protos.ProvideContract.Builder, org.flo.paymentchannel.Protos.ProvideContractOrBuilder>(
-                  getProvideContract(),
-                  getParentForChildren(),
-                  isClean());
-          provideContract_ = null;
-        }
-        return provideContractBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.UpdatePayment updatePayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.UpdatePayment, org.flo.paymentchannel.Protos.UpdatePayment.Builder, org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder> updatePaymentBuilder_;
       /**
        * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
        */
       public boolean hasUpdatePayment() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return instance.hasUpdatePayment();
       }
       /**
        * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
        */
       public org.flo.paymentchannel.Protos.UpdatePayment getUpdatePayment() {
-        if (updatePaymentBuilder_ == null) {
-          return updatePayment_;
-        } else {
-          return updatePaymentBuilder_.getMessage();
-        }
+        return instance.getUpdatePayment();
       }
       /**
        * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
        */
       public Builder setUpdatePayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
-        if (updatePaymentBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          updatePayment_ = value;
-          onChanged();
-        } else {
-          updatePaymentBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000080;
+        copyOnWrite();
+        instance.setUpdatePayment(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
        */
       public Builder setUpdatePayment(
           org.flo.paymentchannel.Protos.UpdatePayment.Builder builderForValue) {
-        if (updatePaymentBuilder_ == null) {
-          updatePayment_ = builderForValue.build();
-          onChanged();
-        } else {
-          updatePaymentBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000080;
+        copyOnWrite();
+        instance.setUpdatePayment(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
        */
       public Builder mergeUpdatePayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
-        if (updatePaymentBuilder_ == null) {
-          if (((bitField0_ & 0x00000080) == 0x00000080) &&
-              updatePayment_ != org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance()) {
-            updatePayment_ =
-              org.flo.paymentchannel.Protos.UpdatePayment.newBuilder(updatePayment_).mergeFrom(value).buildPartial();
-          } else {
-            updatePayment_ = value;
-          }
-          onChanged();
-        } else {
-          updatePaymentBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000080;
+        copyOnWrite();
+        instance.mergeUpdatePayment(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
        */
-      public Builder clearUpdatePayment() {
-        if (updatePaymentBuilder_ == null) {
-          updatePayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-          onChanged();
-        } else {
-          updatePaymentBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000080);
+      public Builder clearUpdatePayment() {  copyOnWrite();
+        instance.clearUpdatePayment();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
-       */
-      public org.flo.paymentchannel.Protos.UpdatePayment.Builder getUpdatePaymentBuilder() {
-        bitField0_ |= 0x00000080;
-        onChanged();
-        return getUpdatePaymentFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
-       */
-      public org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder getUpdatePaymentOrBuilder() {
-        if (updatePaymentBuilder_ != null) {
-          return updatePaymentBuilder_.getMessageOrBuilder();
-        } else {
-          return updatePayment_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.UpdatePayment update_payment = 8;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.UpdatePayment, org.flo.paymentchannel.Protos.UpdatePayment.Builder, org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder> 
-          getUpdatePaymentFieldBuilder() {
-        if (updatePaymentBuilder_ == null) {
-          updatePaymentBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.UpdatePayment, org.flo.paymentchannel.Protos.UpdatePayment.Builder, org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder>(
-                  getUpdatePayment(),
-                  getParentForChildren(),
-                  isClean());
-          updatePayment_ = null;
-        }
-        return updatePaymentBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.PaymentAck paymentAck_ = org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.PaymentAck, org.flo.paymentchannel.Protos.PaymentAck.Builder, org.flo.paymentchannel.Protos.PaymentAckOrBuilder> paymentAckBuilder_;
       /**
        * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
        */
       public boolean hasPaymentAck() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
+        return instance.hasPaymentAck();
       }
       /**
        * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
        */
       public org.flo.paymentchannel.Protos.PaymentAck getPaymentAck() {
-        if (paymentAckBuilder_ == null) {
-          return paymentAck_;
-        } else {
-          return paymentAckBuilder_.getMessage();
-        }
+        return instance.getPaymentAck();
       }
       /**
        * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
        */
       public Builder setPaymentAck(org.flo.paymentchannel.Protos.PaymentAck value) {
-        if (paymentAckBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          paymentAck_ = value;
-          onChanged();
-        } else {
-          paymentAckBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.setPaymentAck(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
        */
       public Builder setPaymentAck(
           org.flo.paymentchannel.Protos.PaymentAck.Builder builderForValue) {
-        if (paymentAckBuilder_ == null) {
-          paymentAck_ = builderForValue.build();
-          onChanged();
-        } else {
-          paymentAckBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.setPaymentAck(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
        */
       public Builder mergePaymentAck(org.flo.paymentchannel.Protos.PaymentAck value) {
-        if (paymentAckBuilder_ == null) {
-          if (((bitField0_ & 0x00000100) == 0x00000100) &&
-              paymentAck_ != org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance()) {
-            paymentAck_ =
-              org.flo.paymentchannel.Protos.PaymentAck.newBuilder(paymentAck_).mergeFrom(value).buildPartial();
-          } else {
-            paymentAck_ = value;
-          }
-          onChanged();
-        } else {
-          paymentAckBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.mergePaymentAck(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
        */
-      public Builder clearPaymentAck() {
-        if (paymentAckBuilder_ == null) {
-          paymentAck_ = org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance();
-          onChanged();
-        } else {
-          paymentAckBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000100);
+      public Builder clearPaymentAck() {  copyOnWrite();
+        instance.clearPaymentAck();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
-       */
-      public org.flo.paymentchannel.Protos.PaymentAck.Builder getPaymentAckBuilder() {
-        bitField0_ |= 0x00000100;
-        onChanged();
-        return getPaymentAckFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
-       */
-      public org.flo.paymentchannel.Protos.PaymentAckOrBuilder getPaymentAckOrBuilder() {
-        if (paymentAckBuilder_ != null) {
-          return paymentAckBuilder_.getMessageOrBuilder();
-        } else {
-          return paymentAck_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.PaymentAck payment_ack = 11;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.PaymentAck, org.flo.paymentchannel.Protos.PaymentAck.Builder, org.flo.paymentchannel.Protos.PaymentAckOrBuilder> 
-          getPaymentAckFieldBuilder() {
-        if (paymentAckBuilder_ == null) {
-          paymentAckBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.PaymentAck, org.flo.paymentchannel.Protos.PaymentAck.Builder, org.flo.paymentchannel.Protos.PaymentAckOrBuilder>(
-                  getPaymentAck(),
-                  getParentForChildren(),
-                  isClean());
-          paymentAck_ = null;
-        }
-        return paymentAckBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.Settlement settlement_ = org.flo.paymentchannel.Protos.Settlement.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.Settlement, org.flo.paymentchannel.Protos.Settlement.Builder, org.flo.paymentchannel.Protos.SettlementOrBuilder> settlementBuilder_;
       /**
        * <code>optional .paymentchannels.Settlement settlement = 9;</code>
        */
       public boolean hasSettlement() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
+        return instance.hasSettlement();
       }
       /**
        * <code>optional .paymentchannels.Settlement settlement = 9;</code>
        */
       public org.flo.paymentchannel.Protos.Settlement getSettlement() {
-        if (settlementBuilder_ == null) {
-          return settlement_;
-        } else {
-          return settlementBuilder_.getMessage();
-        }
+        return instance.getSettlement();
       }
       /**
        * <code>optional .paymentchannels.Settlement settlement = 9;</code>
        */
       public Builder setSettlement(org.flo.paymentchannel.Protos.Settlement value) {
-        if (settlementBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          settlement_ = value;
-          onChanged();
-        } else {
-          settlementBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000200;
+        copyOnWrite();
+        instance.setSettlement(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.Settlement settlement = 9;</code>
        */
       public Builder setSettlement(
           org.flo.paymentchannel.Protos.Settlement.Builder builderForValue) {
-        if (settlementBuilder_ == null) {
-          settlement_ = builderForValue.build();
-          onChanged();
-        } else {
-          settlementBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000200;
+        copyOnWrite();
+        instance.setSettlement(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.Settlement settlement = 9;</code>
        */
       public Builder mergeSettlement(org.flo.paymentchannel.Protos.Settlement value) {
-        if (settlementBuilder_ == null) {
-          if (((bitField0_ & 0x00000200) == 0x00000200) &&
-              settlement_ != org.flo.paymentchannel.Protos.Settlement.getDefaultInstance()) {
-            settlement_ =
-              org.flo.paymentchannel.Protos.Settlement.newBuilder(settlement_).mergeFrom(value).buildPartial();
-          } else {
-            settlement_ = value;
-          }
-          onChanged();
-        } else {
-          settlementBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000200;
+        copyOnWrite();
+        instance.mergeSettlement(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.Settlement settlement = 9;</code>
        */
-      public Builder clearSettlement() {
-        if (settlementBuilder_ == null) {
-          settlement_ = org.flo.paymentchannel.Protos.Settlement.getDefaultInstance();
-          onChanged();
-        } else {
-          settlementBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000200);
+      public Builder clearSettlement() {  copyOnWrite();
+        instance.clearSettlement();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.Settlement settlement = 9;</code>
-       */
-      public org.flo.paymentchannel.Protos.Settlement.Builder getSettlementBuilder() {
-        bitField0_ |= 0x00000200;
-        onChanged();
-        return getSettlementFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.Settlement settlement = 9;</code>
-       */
-      public org.flo.paymentchannel.Protos.SettlementOrBuilder getSettlementOrBuilder() {
-        if (settlementBuilder_ != null) {
-          return settlementBuilder_.getMessageOrBuilder();
-        } else {
-          return settlement_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.Settlement settlement = 9;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.Settlement, org.flo.paymentchannel.Protos.Settlement.Builder, org.flo.paymentchannel.Protos.SettlementOrBuilder> 
-          getSettlementFieldBuilder() {
-        if (settlementBuilder_ == null) {
-          settlementBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.Settlement, org.flo.paymentchannel.Protos.Settlement.Builder, org.flo.paymentchannel.Protos.SettlementOrBuilder>(
-                  getSettlement(),
-                  getParentForChildren(),
-                  isClean());
-          settlement_ = null;
-        }
-        return settlementBuilder_;
       }
 
-      private org.flo.paymentchannel.Protos.Error error_ = org.flo.paymentchannel.Protos.Error.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.Error, org.flo.paymentchannel.Protos.Error.Builder, org.flo.paymentchannel.Protos.ErrorOrBuilder> errorBuilder_;
       /**
        * <code>optional .paymentchannels.Error error = 10;</code>
        */
       public boolean hasError() {
-        return ((bitField0_ & 0x00000400) == 0x00000400);
+        return instance.hasError();
       }
       /**
        * <code>optional .paymentchannels.Error error = 10;</code>
        */
       public org.flo.paymentchannel.Protos.Error getError() {
-        if (errorBuilder_ == null) {
-          return error_;
-        } else {
-          return errorBuilder_.getMessage();
-        }
+        return instance.getError();
       }
       /**
        * <code>optional .paymentchannels.Error error = 10;</code>
        */
       public Builder setError(org.flo.paymentchannel.Protos.Error value) {
-        if (errorBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          error_ = value;
-          onChanged();
-        } else {
-          errorBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000400;
+        copyOnWrite();
+        instance.setError(value);
         return this;
-      }
+        }
       /**
        * <code>optional .paymentchannels.Error error = 10;</code>
        */
       public Builder setError(
           org.flo.paymentchannel.Protos.Error.Builder builderForValue) {
-        if (errorBuilder_ == null) {
-          error_ = builderForValue.build();
-          onChanged();
-        } else {
-          errorBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000400;
+        copyOnWrite();
+        instance.setError(builderForValue);
         return this;
       }
       /**
        * <code>optional .paymentchannels.Error error = 10;</code>
        */
       public Builder mergeError(org.flo.paymentchannel.Protos.Error value) {
-        if (errorBuilder_ == null) {
-          if (((bitField0_ & 0x00000400) == 0x00000400) &&
-              error_ != org.flo.paymentchannel.Protos.Error.getDefaultInstance()) {
-            error_ =
-              org.flo.paymentchannel.Protos.Error.newBuilder(error_).mergeFrom(value).buildPartial();
-          } else {
-            error_ = value;
-          }
-          onChanged();
-        } else {
-          errorBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000400;
+        copyOnWrite();
+        instance.mergeError(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.Error error = 10;</code>
        */
-      public Builder clearError() {
-        if (errorBuilder_ == null) {
-          error_ = org.flo.paymentchannel.Protos.Error.getDefaultInstance();
-          onChanged();
-        } else {
-          errorBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000400);
+      public Builder clearError() {  copyOnWrite();
+        instance.clearError();
         return this;
-      }
-      /**
-       * <code>optional .paymentchannels.Error error = 10;</code>
-       */
-      public org.flo.paymentchannel.Protos.Error.Builder getErrorBuilder() {
-        bitField0_ |= 0x00000400;
-        onChanged();
-        return getErrorFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .paymentchannels.Error error = 10;</code>
-       */
-      public org.flo.paymentchannel.Protos.ErrorOrBuilder getErrorOrBuilder() {
-        if (errorBuilder_ != null) {
-          return errorBuilder_.getMessageOrBuilder();
-        } else {
-          return error_;
-        }
-      }
-      /**
-       * <code>optional .paymentchannels.Error error = 10;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.Error, org.flo.paymentchannel.Protos.Error.Builder, org.flo.paymentchannel.Protos.ErrorOrBuilder> 
-          getErrorFieldBuilder() {
-        if (errorBuilder_ == null) {
-          errorBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.Error, org.flo.paymentchannel.Protos.Error.Builder, org.flo.paymentchannel.Protos.ErrorOrBuilder>(
-                  getError(),
-                  getParentForChildren(),
-                  isClean());
-          error_ = null;
-        }
-        return errorBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.TwoWayChannelMessage)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.TwoWayChannelMessage();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new TwoWayChannelMessage(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasType()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (hasClientVersion()) {
+            if (!getClientVersion().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasServerVersion()) {
+            if (!getServerVersion().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasInitiate()) {
+            if (!getInitiate().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasProvideRefund()) {
+            if (!getProvideRefund().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasReturnRefund()) {
+            if (!getReturnRefund().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasProvideContract()) {
+            if (!getProvideContract().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasUpdatePayment()) {
+            if (!getUpdatePayment().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasSettlement()) {
+            if (!getSettlement().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.TwoWayChannelMessage other = (org.flo.paymentchannel.Protos.TwoWayChannelMessage) arg1;
+          type_ = visitor.visitInt(hasType(), type_,
+              other.hasType(), other.type_);
+          clientVersion_ = visitor.visitMessage(clientVersion_, other.clientVersion_);
+          serverVersion_ = visitor.visitMessage(serverVersion_, other.serverVersion_);
+          initiate_ = visitor.visitMessage(initiate_, other.initiate_);
+          provideRefund_ = visitor.visitMessage(provideRefund_, other.provideRefund_);
+          returnRefund_ = visitor.visitMessage(returnRefund_, other.returnRefund_);
+          provideContract_ = visitor.visitMessage(provideContract_, other.provideContract_);
+          updatePayment_ = visitor.visitMessage(updatePayment_, other.updatePayment_);
+          paymentAck_ = visitor.visitMessage(paymentAck_, other.paymentAck_);
+          settlement_ = visitor.visitMessage(settlement_, other.settlement_);
+          error_ = visitor.visitMessage(error_, other.error_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  int rawValue = input.readEnum();
+                  org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType value = org.flo.paymentchannel.Protos.TwoWayChannelMessage.MessageType.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(1, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000001;
+                    type_ = rawValue;
+                  }
+                  break;
+                }
+                case 18: {
+                  org.flo.paymentchannel.Protos.ClientVersion.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                    subBuilder = clientVersion_.toBuilder();
+                  }
+                  clientVersion_ = input.readMessage(org.flo.paymentchannel.Protos.ClientVersion.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(clientVersion_);
+                    clientVersion_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000002;
+                  break;
+                }
+                case 26: {
+                  org.flo.paymentchannel.Protos.ServerVersion.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000004) == 0x00000004)) {
+                    subBuilder = serverVersion_.toBuilder();
+                  }
+                  serverVersion_ = input.readMessage(org.flo.paymentchannel.Protos.ServerVersion.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(serverVersion_);
+                    serverVersion_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000004;
+                  break;
+                }
+                case 34: {
+                  org.flo.paymentchannel.Protos.Initiate.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000008) == 0x00000008)) {
+                    subBuilder = initiate_.toBuilder();
+                  }
+                  initiate_ = input.readMessage(org.flo.paymentchannel.Protos.Initiate.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(initiate_);
+                    initiate_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000008;
+                  break;
+                }
+                case 42: {
+                  org.flo.paymentchannel.Protos.ProvideRefund.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000010) == 0x00000010)) {
+                    subBuilder = provideRefund_.toBuilder();
+                  }
+                  provideRefund_ = input.readMessage(org.flo.paymentchannel.Protos.ProvideRefund.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(provideRefund_);
+                    provideRefund_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000010;
+                  break;
+                }
+                case 50: {
+                  org.flo.paymentchannel.Protos.ReturnRefund.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                    subBuilder = returnRefund_.toBuilder();
+                  }
+                  returnRefund_ = input.readMessage(org.flo.paymentchannel.Protos.ReturnRefund.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(returnRefund_);
+                    returnRefund_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000020;
+                  break;
+                }
+                case 58: {
+                  org.flo.paymentchannel.Protos.ProvideContract.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000040) == 0x00000040)) {
+                    subBuilder = provideContract_.toBuilder();
+                  }
+                  provideContract_ = input.readMessage(org.flo.paymentchannel.Protos.ProvideContract.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(provideContract_);
+                    provideContract_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000040;
+                  break;
+                }
+                case 66: {
+                  org.flo.paymentchannel.Protos.UpdatePayment.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000080) == 0x00000080)) {
+                    subBuilder = updatePayment_.toBuilder();
+                  }
+                  updatePayment_ = input.readMessage(org.flo.paymentchannel.Protos.UpdatePayment.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(updatePayment_);
+                    updatePayment_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000080;
+                  break;
+                }
+                case 74: {
+                  org.flo.paymentchannel.Protos.Settlement.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000200) == 0x00000200)) {
+                    subBuilder = settlement_.toBuilder();
+                  }
+                  settlement_ = input.readMessage(org.flo.paymentchannel.Protos.Settlement.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(settlement_);
+                    settlement_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000200;
+                  break;
+                }
+                case 82: {
+                  org.flo.paymentchannel.Protos.Error.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000400) == 0x00000400)) {
+                    subBuilder = error_.toBuilder();
+                  }
+                  error_ = input.readMessage(org.flo.paymentchannel.Protos.Error.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(error_);
+                    error_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000400;
+                  break;
+                }
+                case 90: {
+                  org.flo.paymentchannel.Protos.PaymentAck.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000100) == 0x00000100)) {
+                    subBuilder = paymentAck_.toBuilder();
+                  }
+                  paymentAck_ = input.readMessage(org.flo.paymentchannel.Protos.PaymentAck.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(paymentAck_);
+                    paymentAck_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000100;
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.TwoWayChannelMessage.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.TwoWayChannelMessage)
+    private static final org.flo.paymentchannel.Protos.TwoWayChannelMessage DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new TwoWayChannelMessage();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.TwoWayChannelMessage getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<TwoWayChannelMessage> PARSER;
+
+    public static com.google.protobuf.Parser<TwoWayChannelMessage> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ClientVersionOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.ClientVersion)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required int32 major = 1;</code>
@@ -2782,163 +2018,64 @@ public final class Protos {
     int getMinor();
 
     /**
-     * <code>optional bytes previous_channel_contract_hash = 3;</code>
-     *
      * <pre>
      * The hash of the multisig contract of a previous channel. This indicates that the primary
      * wishes to reopen the given channel. If the server is willing to reopen it, it simply
      * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
      * follows SERVER_VERSION with an Initiate representing a new channel
      * </pre>
+     *
+     * <code>optional bytes previous_channel_contract_hash = 3;</code>
      */
     boolean hasPreviousChannelContractHash();
     /**
-     * <code>optional bytes previous_channel_contract_hash = 3;</code>
-     *
      * <pre>
      * The hash of the multisig contract of a previous channel. This indicates that the primary
      * wishes to reopen the given channel. If the server is willing to reopen it, it simply
      * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
      * follows SERVER_VERSION with an Initiate representing a new channel
      * </pre>
+     *
+     * <code>optional bytes previous_channel_contract_hash = 3;</code>
      */
     com.google.protobuf.ByteString getPreviousChannelContractHash();
 
     /**
-     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-     *
      * <pre>
      * How many seconds should the channel be open, only used when a new channel is created.
      * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
      * </pre>
+     *
+     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
      */
     boolean hasTimeWindowSecs();
     /**
-     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-     *
      * <pre>
      * How many seconds should the channel be open, only used when a new channel is created.
      * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
      * </pre>
+     *
+     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
      */
     long getTimeWindowSecs();
   }
   /**
-   * Protobuf type {@code paymentchannels.ClientVersion}
-   *
    * <pre>
    * Sent by primary to secondary on opening the connection. If anything is received before this is
    * sent, the socket is closed.
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.ClientVersion}
    */
-  public static final class ClientVersion extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class ClientVersion extends
+      com.google.protobuf.GeneratedMessageLite<
+          ClientVersion, ClientVersion.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.ClientVersion)
       ClientVersionOrBuilder {
-    // Use ClientVersion.newBuilder() to construct.
-    private ClientVersion(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private ClientVersion() {
+      previousChannelContractHash_ = com.google.protobuf.ByteString.EMPTY;
+      timeWindowSecs_ = 86340L;
     }
-    private ClientVersion(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final ClientVersion defaultInstance;
-    public static ClientVersion getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public ClientVersion getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ClientVersion(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              major_ = input.readInt32();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              minor_ = input.readInt32();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              previousChannelContractHash_ = input.readBytes();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              timeWindowSecs_ = input.readUInt64();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ClientVersion_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ClientVersion_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.ClientVersion.class, org.flo.paymentchannel.Protos.ClientVersion.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<ClientVersion> PARSER =
-        new com.google.protobuf.AbstractParser<ClientVersion>() {
-      public ClientVersion parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ClientVersion(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ClientVersion> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MAJOR_FIELD_NUMBER = 1;
     private int major_;
@@ -2953,6 +2090,20 @@ public final class Protos {
      */
     public int getMajor() {
       return major_;
+    }
+    /**
+     * <code>required int32 major = 1;</code>
+     */
+    private void setMajor(int value) {
+      bitField0_ |= 0x00000001;
+      major_ = value;
+    }
+    /**
+     * <code>required int32 major = 1;</code>
+     */
+    private void clearMajor() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      major_ = 0;
     }
 
     public static final int MINOR_FIELD_NUMBER = 2;
@@ -2969,84 +2120,132 @@ public final class Protos {
     public int getMinor() {
       return minor_;
     }
+    /**
+     * <code>optional int32 minor = 2 [default = 0];</code>
+     */
+    private void setMinor(int value) {
+      bitField0_ |= 0x00000002;
+      minor_ = value;
+    }
+    /**
+     * <code>optional int32 minor = 2 [default = 0];</code>
+     */
+    private void clearMinor() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      minor_ = 0;
+    }
 
     public static final int PREVIOUS_CHANNEL_CONTRACT_HASH_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString previousChannelContractHash_;
     /**
-     * <code>optional bytes previous_channel_contract_hash = 3;</code>
-     *
      * <pre>
      * The hash of the multisig contract of a previous channel. This indicates that the primary
      * wishes to reopen the given channel. If the server is willing to reopen it, it simply
      * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
      * follows SERVER_VERSION with an Initiate representing a new channel
      * </pre>
+     *
+     * <code>optional bytes previous_channel_contract_hash = 3;</code>
      */
     public boolean hasPreviousChannelContractHash() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional bytes previous_channel_contract_hash = 3;</code>
-     *
      * <pre>
      * The hash of the multisig contract of a previous channel. This indicates that the primary
      * wishes to reopen the given channel. If the server is willing to reopen it, it simply
      * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
      * follows SERVER_VERSION with an Initiate representing a new channel
      * </pre>
+     *
+     * <code>optional bytes previous_channel_contract_hash = 3;</code>
      */
     public com.google.protobuf.ByteString getPreviousChannelContractHash() {
       return previousChannelContractHash_;
+    }
+    /**
+     * <pre>
+     * The hash of the multisig contract of a previous channel. This indicates that the primary
+     * wishes to reopen the given channel. If the server is willing to reopen it, it simply
+     * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
+     * follows SERVER_VERSION with an Initiate representing a new channel
+     * </pre>
+     *
+     * <code>optional bytes previous_channel_contract_hash = 3;</code>
+     */
+    private void setPreviousChannelContractHash(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      previousChannelContractHash_ = value;
+    }
+    /**
+     * <pre>
+     * The hash of the multisig contract of a previous channel. This indicates that the primary
+     * wishes to reopen the given channel. If the server is willing to reopen it, it simply
+     * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
+     * follows SERVER_VERSION with an Initiate representing a new channel
+     * </pre>
+     *
+     * <code>optional bytes previous_channel_contract_hash = 3;</code>
+     */
+    private void clearPreviousChannelContractHash() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      previousChannelContractHash_ = getDefaultInstance().getPreviousChannelContractHash();
     }
 
     public static final int TIME_WINDOW_SECS_FIELD_NUMBER = 4;
     private long timeWindowSecs_;
     /**
-     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-     *
      * <pre>
      * How many seconds should the channel be open, only used when a new channel is created.
      * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
      * </pre>
+     *
+     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
      */
     public boolean hasTimeWindowSecs() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-     *
      * <pre>
      * How many seconds should the channel be open, only used when a new channel is created.
      * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
      * </pre>
+     *
+     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
      */
     public long getTimeWindowSecs() {
       return timeWindowSecs_;
     }
-
-    private void initFields() {
-      major_ = 0;
-      minor_ = 0;
-      previousChannelContractHash_ = com.google.protobuf.ByteString.EMPTY;
-      timeWindowSecs_ = 86340L;
+    /**
+     * <pre>
+     * How many seconds should the channel be open, only used when a new channel is created.
+     * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
+     * </pre>
+     *
+     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
+     */
+    private void setTimeWindowSecs(long value) {
+      bitField0_ |= 0x00000008;
+      timeWindowSecs_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasMajor()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * How many seconds should the channel be open, only used when a new channel is created.
+     * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
+     * </pre>
+     *
+     * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
+     */
+    private void clearTimeWindowSecs() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      timeWindowSecs_ = 86340L;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt32(1, major_);
       }
@@ -3059,10 +2258,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeUInt64(4, timeWindowSecs_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -3084,432 +2282,403 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(4, timeWindowSecs_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ClientVersion parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.ClientVersion prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.ClientVersion}
-     *
      * <pre>
      * Sent by primary to secondary on opening the connection. If anything is received before this is
      * sent, the socket is closed.
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.ClientVersion}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.ClientVersion, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.ClientVersion)
         org.flo.paymentchannel.Protos.ClientVersionOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ClientVersion_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ClientVersion_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.ClientVersion.class, org.flo.paymentchannel.Protos.ClientVersion.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.ClientVersion.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        major_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        minor_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        previousChannelContractHash_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        timeWindowSecs_ = 86340L;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ClientVersion_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.ClientVersion getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.ClientVersion build() {
-        org.flo.paymentchannel.Protos.ClientVersion result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.ClientVersion buildPartial() {
-        org.flo.paymentchannel.Protos.ClientVersion result = new org.flo.paymentchannel.Protos.ClientVersion(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.major_ = major_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.minor_ = minor_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.previousChannelContractHash_ = previousChannelContractHash_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.timeWindowSecs_ = timeWindowSecs_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.ClientVersion) {
-          return mergeFrom((org.flo.paymentchannel.Protos.ClientVersion)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.ClientVersion other) {
-        if (other == org.flo.paymentchannel.Protos.ClientVersion.getDefaultInstance()) return this;
-        if (other.hasMajor()) {
-          setMajor(other.getMajor());
-        }
-        if (other.hasMinor()) {
-          setMinor(other.getMinor());
-        }
-        if (other.hasPreviousChannelContractHash()) {
-          setPreviousChannelContractHash(other.getPreviousChannelContractHash());
-        }
-        if (other.hasTimeWindowSecs()) {
-          setTimeWindowSecs(other.getTimeWindowSecs());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasMajor()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.ClientVersion parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.ClientVersion) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private int major_ ;
       /**
        * <code>required int32 major = 1;</code>
        */
       public boolean hasMajor() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasMajor();
       }
       /**
        * <code>required int32 major = 1;</code>
        */
       public int getMajor() {
-        return major_;
+        return instance.getMajor();
       }
       /**
        * <code>required int32 major = 1;</code>
        */
       public Builder setMajor(int value) {
-        bitField0_ |= 0x00000001;
-        major_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMajor(value);
         return this;
       }
       /**
        * <code>required int32 major = 1;</code>
        */
       public Builder clearMajor() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        major_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearMajor();
         return this;
       }
 
-      private int minor_ ;
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public boolean hasMinor() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasMinor();
       }
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public int getMinor() {
-        return minor_;
+        return instance.getMinor();
       }
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public Builder setMinor(int value) {
-        bitField0_ |= 0x00000002;
-        minor_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMinor(value);
         return this;
       }
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public Builder clearMinor() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        minor_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearMinor();
         return this;
       }
 
-      private com.google.protobuf.ByteString previousChannelContractHash_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes previous_channel_contract_hash = 3;</code>
-       *
        * <pre>
        * The hash of the multisig contract of a previous channel. This indicates that the primary
        * wishes to reopen the given channel. If the server is willing to reopen it, it simply
        * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
        * follows SERVER_VERSION with an Initiate representing a new channel
        * </pre>
+       *
+       * <code>optional bytes previous_channel_contract_hash = 3;</code>
        */
       public boolean hasPreviousChannelContractHash() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasPreviousChannelContractHash();
       }
       /**
-       * <code>optional bytes previous_channel_contract_hash = 3;</code>
-       *
        * <pre>
        * The hash of the multisig contract of a previous channel. This indicates that the primary
        * wishes to reopen the given channel. If the server is willing to reopen it, it simply
        * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
        * follows SERVER_VERSION with an Initiate representing a new channel
        * </pre>
+       *
+       * <code>optional bytes previous_channel_contract_hash = 3;</code>
        */
       public com.google.protobuf.ByteString getPreviousChannelContractHash() {
-        return previousChannelContractHash_;
+        return instance.getPreviousChannelContractHash();
       }
       /**
-       * <code>optional bytes previous_channel_contract_hash = 3;</code>
-       *
        * <pre>
        * The hash of the multisig contract of a previous channel. This indicates that the primary
        * wishes to reopen the given channel. If the server is willing to reopen it, it simply
        * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
        * follows SERVER_VERSION with an Initiate representing a new channel
        * </pre>
+       *
+       * <code>optional bytes previous_channel_contract_hash = 3;</code>
        */
       public Builder setPreviousChannelContractHash(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        previousChannelContractHash_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPreviousChannelContractHash(value);
         return this;
       }
       /**
-       * <code>optional bytes previous_channel_contract_hash = 3;</code>
-       *
        * <pre>
        * The hash of the multisig contract of a previous channel. This indicates that the primary
        * wishes to reopen the given channel. If the server is willing to reopen it, it simply
        * responds with a SERVER_VERSION and then immediately sends a CHANNEL_OPEN, it otherwise
        * follows SERVER_VERSION with an Initiate representing a new channel
        * </pre>
+       *
+       * <code>optional bytes previous_channel_contract_hash = 3;</code>
        */
       public Builder clearPreviousChannelContractHash() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        previousChannelContractHash_ = getDefaultInstance().getPreviousChannelContractHash();
-        onChanged();
+        copyOnWrite();
+        instance.clearPreviousChannelContractHash();
         return this;
       }
 
-      private long timeWindowSecs_ = 86340L;
       /**
-       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-       *
        * <pre>
        * How many seconds should the channel be open, only used when a new channel is created.
        * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
        * </pre>
+       *
+       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
        */
       public boolean hasTimeWindowSecs() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasTimeWindowSecs();
       }
       /**
-       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-       *
        * <pre>
        * How many seconds should the channel be open, only used when a new channel is created.
        * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
        * </pre>
+       *
+       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
        */
       public long getTimeWindowSecs() {
-        return timeWindowSecs_;
+        return instance.getTimeWindowSecs();
       }
       /**
-       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-       *
        * <pre>
        * How many seconds should the channel be open, only used when a new channel is created.
        * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
        * </pre>
+       *
+       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
        */
       public Builder setTimeWindowSecs(long value) {
-        bitField0_ |= 0x00000008;
-        timeWindowSecs_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTimeWindowSecs(value);
         return this;
       }
       /**
-       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
-       *
        * <pre>
        * How many seconds should the channel be open, only used when a new channel is created.
        * Defaults to 24 h minus 60 seconds, 24*60*60 - 60
        * </pre>
+       *
+       * <code>optional uint64 time_window_secs = 4 [default = 86340];</code>
        */
       public Builder clearTimeWindowSecs() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        timeWindowSecs_ = 86340L;
-        onChanged();
+        copyOnWrite();
+        instance.clearTimeWindowSecs();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.ClientVersion)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.ClientVersion();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new ClientVersion(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasMajor()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.ClientVersion other = (org.flo.paymentchannel.Protos.ClientVersion) arg1;
+          major_ = visitor.visitInt(
+              hasMajor(), major_,
+              other.hasMajor(), other.major_);
+          minor_ = visitor.visitInt(
+              hasMinor(), minor_,
+              other.hasMinor(), other.minor_);
+          previousChannelContractHash_ = visitor.visitByteString(
+              hasPreviousChannelContractHash(), previousChannelContractHash_,
+              other.hasPreviousChannelContractHash(), other.previousChannelContractHash_);
+          timeWindowSecs_ = visitor.visitLong(
+              hasTimeWindowSecs(), timeWindowSecs_,
+              other.hasTimeWindowSecs(), other.timeWindowSecs_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  major_ = input.readInt32();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  minor_ = input.readInt32();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  previousChannelContractHash_ = input.readBytes();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000008;
+                  timeWindowSecs_ = input.readUInt64();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.ClientVersion.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.ClientVersion)
+    private static final org.flo.paymentchannel.Protos.ClientVersion DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ClientVersion();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.ClientVersion getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<ClientVersion> PARSER;
+
+    public static com.google.protobuf.Parser<ClientVersion> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ServerVersionOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.ServerVersion)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required int32 major = 1;</code>
@@ -3530,8 +2699,6 @@ public final class Protos {
     int getMinor();
   }
   /**
-   * Protobuf type {@code paymentchannels.ServerVersion}
-   *
    * <pre>
    * Send by secondary to primary upon receiving the ClientVersion message. If it is willing to
    * speak the given major version, it sends back the same major version and the minor version it
@@ -3541,105 +2708,16 @@ public final class Protos {
    * should immediately close the connection with a NO_ACCEPTABLE_VERSION Error. Backwards
    * incompatible changes to the protocol bump the major version. Extensions bump the minor version
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.ServerVersion}
    */
-  public static final class ServerVersion extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class ServerVersion extends
+      com.google.protobuf.GeneratedMessageLite<
+          ServerVersion, ServerVersion.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.ServerVersion)
       ServerVersionOrBuilder {
-    // Use ServerVersion.newBuilder() to construct.
-    private ServerVersion(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private ServerVersion() {
     }
-    private ServerVersion(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final ServerVersion defaultInstance;
-    public static ServerVersion getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public ServerVersion getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ServerVersion(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              major_ = input.readInt32();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              minor_ = input.readInt32();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ServerVersion_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ServerVersion_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.ServerVersion.class, org.flo.paymentchannel.Protos.ServerVersion.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<ServerVersion> PARSER =
-        new com.google.protobuf.AbstractParser<ServerVersion>() {
-      public ServerVersion parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ServerVersion(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ServerVersion> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MAJOR_FIELD_NUMBER = 1;
     private int major_;
@@ -3654,6 +2732,20 @@ public final class Protos {
      */
     public int getMajor() {
       return major_;
+    }
+    /**
+     * <code>required int32 major = 1;</code>
+     */
+    private void setMajor(int value) {
+      bitField0_ |= 0x00000001;
+      major_ = value;
+    }
+    /**
+     * <code>required int32 major = 1;</code>
+     */
+    private void clearMajor() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      major_ = 0;
     }
 
     public static final int MINOR_FIELD_NUMBER = 2;
@@ -3670,38 +2762,32 @@ public final class Protos {
     public int getMinor() {
       return minor_;
     }
-
-    private void initFields() {
-      major_ = 0;
-      minor_ = 0;
+    /**
+     * <code>optional int32 minor = 2 [default = 0];</code>
+     */
+    private void setMinor(int value) {
+      bitField0_ |= 0x00000002;
+      minor_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasMajor()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>optional int32 minor = 2 [default = 0];</code>
+     */
+    private void clearMinor() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      minor_ = 0;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt32(1, major_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeInt32(2, minor_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -3715,87 +2801,80 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(2, minor_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ServerVersion parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.ServerVersion prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.ServerVersion}
-     *
      * <pre>
      * Send by secondary to primary upon receiving the ClientVersion message. If it is willing to
      * speak the given major version, it sends back the same major version and the minor version it
@@ -3805,262 +2884,249 @@ public final class Protos {
      * should immediately close the connection with a NO_ACCEPTABLE_VERSION Error. Backwards
      * incompatible changes to the protocol bump the major version. Extensions bump the minor version
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.ServerVersion}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.ServerVersion, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.ServerVersion)
         org.flo.paymentchannel.Protos.ServerVersionOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ServerVersion_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ServerVersion_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.ServerVersion.class, org.flo.paymentchannel.Protos.ServerVersion.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.ServerVersion.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        major_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        minor_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ServerVersion_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.ServerVersion getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.ServerVersion build() {
-        org.flo.paymentchannel.Protos.ServerVersion result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.ServerVersion buildPartial() {
-        org.flo.paymentchannel.Protos.ServerVersion result = new org.flo.paymentchannel.Protos.ServerVersion(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.major_ = major_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.minor_ = minor_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.ServerVersion) {
-          return mergeFrom((org.flo.paymentchannel.Protos.ServerVersion)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.ServerVersion other) {
-        if (other == org.flo.paymentchannel.Protos.ServerVersion.getDefaultInstance()) return this;
-        if (other.hasMajor()) {
-          setMajor(other.getMajor());
-        }
-        if (other.hasMinor()) {
-          setMinor(other.getMinor());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasMajor()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.ServerVersion parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.ServerVersion) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private int major_ ;
       /**
        * <code>required int32 major = 1;</code>
        */
       public boolean hasMajor() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasMajor();
       }
       /**
        * <code>required int32 major = 1;</code>
        */
       public int getMajor() {
-        return major_;
+        return instance.getMajor();
       }
       /**
        * <code>required int32 major = 1;</code>
        */
       public Builder setMajor(int value) {
-        bitField0_ |= 0x00000001;
-        major_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMajor(value);
         return this;
       }
       /**
        * <code>required int32 major = 1;</code>
        */
       public Builder clearMajor() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        major_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearMajor();
         return this;
       }
 
-      private int minor_ ;
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public boolean hasMinor() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasMinor();
       }
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public int getMinor() {
-        return minor_;
+        return instance.getMinor();
       }
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public Builder setMinor(int value) {
-        bitField0_ |= 0x00000002;
-        minor_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMinor(value);
         return this;
       }
       /**
        * <code>optional int32 minor = 2 [default = 0];</code>
        */
       public Builder clearMinor() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        minor_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearMinor();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.ServerVersion)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.ServerVersion();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new ServerVersion(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasMajor()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.ServerVersion other = (org.flo.paymentchannel.Protos.ServerVersion) arg1;
+          major_ = visitor.visitInt(
+              hasMajor(), major_,
+              other.hasMajor(), other.major_);
+          minor_ = visitor.visitInt(
+              hasMinor(), minor_,
+              other.hasMinor(), other.minor_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  major_ = input.readInt32();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  minor_ = input.readInt32();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.ServerVersion.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.ServerVersion)
+    private static final org.flo.paymentchannel.Protos.ServerVersion DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ServerVersion();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.ServerVersion getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<ServerVersion> PARSER;
+
+    public static com.google.protobuf.Parser<ServerVersion> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface InitiateOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.Initiate)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted. It is used only in the creation of the multisig contract, as outputs are
      * created entirely by the secondary
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     boolean hasMultisigKey();
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted. It is used only in the creation of the multisig contract, as outputs are
      * created entirely by the secondary
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     com.google.protobuf.ByteString getMultisigKey();
 
     /**
-     * <code>required uint64 min_accepted_channel_size = 2;</code>
-     *
      * <pre>
      * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
      * size it's willing to accept here. This can be lower to trade off resources against
      * security but shouldn't be so low the transactions get rejected by the network as spam.
      * Zero isn't a sensible value to have here, so we make the field required.
      * </pre>
+     *
+     * <code>required uint64 min_accepted_channel_size = 2;</code>
      */
     boolean hasMinAcceptedChannelSize();
     /**
-     * <code>required uint64 min_accepted_channel_size = 2;</code>
-     *
      * <pre>
      * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
      * size it's willing to accept here. This can be lower to trade off resources against
      * security but shouldn't be so low the transactions get rejected by the network as spam.
      * Zero isn't a sensible value to have here, so we make the field required.
      * </pre>
+     *
+     * <code>required uint64 min_accepted_channel_size = 2;</code>
      */
     long getMinAcceptedChannelSize();
 
     /**
-     * <code>required uint64 expire_time_secs = 3;</code>
-     *
      * <pre>
      * Rough UNIX time for when the channel expires. This is determined by the block header
      * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4070,11 +3136,11 @@ public final class Protos {
      * considers this value too far off (eg more than a day), it may send an ERROR and close the
      * channel.
      * </pre>
+     *
+     * <code>required uint64 expire_time_secs = 3;</code>
      */
     boolean hasExpireTimeSecs();
     /**
-     * <code>required uint64 expire_time_secs = 3;</code>
-     *
      * <pre>
      * Rough UNIX time for when the channel expires. This is determined by the block header
      * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4084,12 +3150,12 @@ public final class Protos {
      * considers this value too far off (eg more than a day), it may send an ERROR and close the
      * channel.
      * </pre>
+     *
+     * <code>required uint64 expire_time_secs = 3;</code>
      */
     long getExpireTimeSecs();
 
     /**
-     * <code>required uint64 min_payment = 4;</code>
-     *
      * <pre>
      * The amount of money the server requires for the initial payment. The act of opening a channel
      * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4098,11 +3164,11 @@ public final class Protos {
      * server tells the client what it thinks it is, and the client is supposed to sanity check this
      * value.
      * </pre>
+     *
+     * <code>required uint64 min_payment = 4;</code>
      */
     boolean hasMinPayment();
     /**
-     * <code>required uint64 min_payment = 4;</code>
-     *
      * <pre>
      * The amount of money the server requires for the initial payment. The act of opening a channel
      * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4111,186 +3177,143 @@ public final class Protos {
      * server tells the client what it thinks it is, and the client is supposed to sanity check this
      * value.
      * </pre>
+     *
+     * <code>required uint64 min_payment = 4;</code>
      */
     long getMinPayment();
   }
   /**
-   * Protobuf type {@code paymentchannels.Initiate}
-   *
    * <pre>
    * Sent from server to client once version nego is done.
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.Initiate}
    */
-  public static final class Initiate extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Initiate extends
+      com.google.protobuf.GeneratedMessageLite<
+          Initiate, Initiate.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.Initiate)
       InitiateOrBuilder {
-    // Use Initiate.newBuilder() to construct.
-    private Initiate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Initiate() {
+      multisigKey_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Initiate(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Initiate defaultInstance;
-    public static Initiate getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Initiate getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Initiate(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              multisigKey_ = input.readBytes();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              minAcceptedChannelSize_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              expireTimeSecs_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              minPayment_ = input.readUInt64();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Initiate_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Initiate_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.Initiate.class, org.flo.paymentchannel.Protos.Initiate.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Initiate> PARSER =
-        new com.google.protobuf.AbstractParser<Initiate>() {
-      public Initiate parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Initiate(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Initiate> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MULTISIG_KEY_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString multisigKey_;
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted. It is used only in the creation of the multisig contract, as outputs are
      * created entirely by the secondary
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     public boolean hasMultisigKey() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted. It is used only in the creation of the multisig contract, as outputs are
      * created entirely by the secondary
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     public com.google.protobuf.ByteString getMultisigKey() {
       return multisigKey_;
+    }
+    /**
+     * <pre>
+     * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
+     * are accepted. It is used only in the creation of the multisig contract, as outputs are
+     * created entirely by the secondary
+     * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
+     */
+    private void setMultisigKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      multisigKey_ = value;
+    }
+    /**
+     * <pre>
+     * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
+     * are accepted. It is used only in the creation of the multisig contract, as outputs are
+     * created entirely by the secondary
+     * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
+     */
+    private void clearMultisigKey() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      multisigKey_ = getDefaultInstance().getMultisigKey();
     }
 
     public static final int MIN_ACCEPTED_CHANNEL_SIZE_FIELD_NUMBER = 2;
     private long minAcceptedChannelSize_;
     /**
-     * <code>required uint64 min_accepted_channel_size = 2;</code>
-     *
      * <pre>
      * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
      * size it's willing to accept here. This can be lower to trade off resources against
      * security but shouldn't be so low the transactions get rejected by the network as spam.
      * Zero isn't a sensible value to have here, so we make the field required.
      * </pre>
+     *
+     * <code>required uint64 min_accepted_channel_size = 2;</code>
      */
     public boolean hasMinAcceptedChannelSize() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required uint64 min_accepted_channel_size = 2;</code>
-     *
      * <pre>
      * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
      * size it's willing to accept here. This can be lower to trade off resources against
      * security but shouldn't be so low the transactions get rejected by the network as spam.
      * Zero isn't a sensible value to have here, so we make the field required.
      * </pre>
+     *
+     * <code>required uint64 min_accepted_channel_size = 2;</code>
      */
     public long getMinAcceptedChannelSize() {
       return minAcceptedChannelSize_;
+    }
+    /**
+     * <pre>
+     * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
+     * size it's willing to accept here. This can be lower to trade off resources against
+     * security but shouldn't be so low the transactions get rejected by the network as spam.
+     * Zero isn't a sensible value to have here, so we make the field required.
+     * </pre>
+     *
+     * <code>required uint64 min_accepted_channel_size = 2;</code>
+     */
+    private void setMinAcceptedChannelSize(long value) {
+      bitField0_ |= 0x00000002;
+      minAcceptedChannelSize_ = value;
+    }
+    /**
+     * <pre>
+     * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
+     * size it's willing to accept here. This can be lower to trade off resources against
+     * security but shouldn't be so low the transactions get rejected by the network as spam.
+     * Zero isn't a sensible value to have here, so we make the field required.
+     * </pre>
+     *
+     * <code>required uint64 min_accepted_channel_size = 2;</code>
+     */
+    private void clearMinAcceptedChannelSize() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      minAcceptedChannelSize_ = 0L;
     }
 
     public static final int EXPIRE_TIME_SECS_FIELD_NUMBER = 3;
     private long expireTimeSecs_;
     /**
-     * <code>required uint64 expire_time_secs = 3;</code>
-     *
      * <pre>
      * Rough UNIX time for when the channel expires. This is determined by the block header
      * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4300,13 +3323,13 @@ public final class Protos {
      * considers this value too far off (eg more than a day), it may send an ERROR and close the
      * channel.
      * </pre>
+     *
+     * <code>required uint64 expire_time_secs = 3;</code>
      */
     public boolean hasExpireTimeSecs() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>required uint64 expire_time_secs = 3;</code>
-     *
      * <pre>
      * Rough UNIX time for when the channel expires. This is determined by the block header
      * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4316,16 +3339,50 @@ public final class Protos {
      * considers this value too far off (eg more than a day), it may send an ERROR and close the
      * channel.
      * </pre>
+     *
+     * <code>required uint64 expire_time_secs = 3;</code>
      */
     public long getExpireTimeSecs() {
       return expireTimeSecs_;
+    }
+    /**
+     * <pre>
+     * Rough UNIX time for when the channel expires. This is determined by the block header
+     * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
+     * Channels could also be specified in terms of block heights but then how do you know the
+     * current chain height if you don't have internet access? Trust the server? Probably opens up
+     * attack vectors. We can assume the client has an independent clock, however. If the client
+     * considers this value too far off (eg more than a day), it may send an ERROR and close the
+     * channel.
+     * </pre>
+     *
+     * <code>required uint64 expire_time_secs = 3;</code>
+     */
+    private void setExpireTimeSecs(long value) {
+      bitField0_ |= 0x00000004;
+      expireTimeSecs_ = value;
+    }
+    /**
+     * <pre>
+     * Rough UNIX time for when the channel expires. This is determined by the block header
+     * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
+     * Channels could also be specified in terms of block heights but then how do you know the
+     * current chain height if you don't have internet access? Trust the server? Probably opens up
+     * attack vectors. We can assume the client has an independent clock, however. If the client
+     * considers this value too far off (eg more than a day), it may send an ERROR and close the
+     * channel.
+     * </pre>
+     *
+     * <code>required uint64 expire_time_secs = 3;</code>
+     */
+    private void clearExpireTimeSecs() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      expireTimeSecs_ = 0L;
     }
 
     public static final int MIN_PAYMENT_FIELD_NUMBER = 4;
     private long minPayment_;
     /**
-     * <code>required uint64 min_payment = 4;</code>
-     *
      * <pre>
      * The amount of money the server requires for the initial payment. The act of opening a channel
      * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4334,13 +3391,13 @@ public final class Protos {
      * server tells the client what it thinks it is, and the client is supposed to sanity check this
      * value.
      * </pre>
+     *
+     * <code>required uint64 min_payment = 4;</code>
      */
     public boolean hasMinPayment() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>required uint64 min_payment = 4;</code>
-     *
      * <pre>
      * The amount of money the server requires for the initial payment. The act of opening a channel
      * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4349,46 +3406,47 @@ public final class Protos {
      * server tells the client what it thinks it is, and the client is supposed to sanity check this
      * value.
      * </pre>
+     *
+     * <code>required uint64 min_payment = 4;</code>
      */
     public long getMinPayment() {
       return minPayment_;
     }
-
-    private void initFields() {
-      multisigKey_ = com.google.protobuf.ByteString.EMPTY;
-      minAcceptedChannelSize_ = 0L;
-      expireTimeSecs_ = 0L;
-      minPayment_ = 0L;
+    /**
+     * <pre>
+     * The amount of money the server requires for the initial payment. The act of opening a channel
+     * always transfers some quantity of money to the server: it's impossible to have a channel with
+     * zero value transferred. This rule ensures that you can't get a channel that can't be settled
+     * due to having paid under the dust limit. Because the dust limit will float in future, the
+     * server tells the client what it thinks it is, and the client is supposed to sanity check this
+     * value.
+     * </pre>
+     *
+     * <code>required uint64 min_payment = 4;</code>
+     */
+    private void setMinPayment(long value) {
+      bitField0_ |= 0x00000008;
+      minPayment_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasMultisigKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasMinAcceptedChannelSize()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasExpireTimeSecs()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasMinPayment()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * The amount of money the server requires for the initial payment. The act of opening a channel
+     * always transfers some quantity of money to the server: it's impossible to have a channel with
+     * zero value transferred. This rule ensures that you can't get a channel that can't be settled
+     * due to having paid under the dust limit. Because the dust limit will float in future, the
+     * server tells the client what it thinks it is, and the client is supposed to sanity check this
+     * value.
+     * </pre>
+     *
+     * <code>required uint64 min_payment = 4;</code>
+     */
+    private void clearMinPayment() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      minPayment_ = 0L;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, multisigKey_);
       }
@@ -4401,10 +3459,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeUInt64(4, minPayment_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -4426,373 +3483,208 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(4, minPayment_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Initiate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.Initiate prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.Initiate}
-     *
      * <pre>
      * Sent from server to client once version nego is done.
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.Initiate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.Initiate, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.Initiate)
         org.flo.paymentchannel.Protos.InitiateOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Initiate_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Initiate_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.Initiate.class, org.flo.paymentchannel.Protos.Initiate.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.Initiate.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        multisigKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        minAcceptedChannelSize_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        expireTimeSecs_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        minPayment_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Initiate_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.Initiate getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.Initiate.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.Initiate build() {
-        org.flo.paymentchannel.Protos.Initiate result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.Initiate buildPartial() {
-        org.flo.paymentchannel.Protos.Initiate result = new org.flo.paymentchannel.Protos.Initiate(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.multisigKey_ = multisigKey_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.minAcceptedChannelSize_ = minAcceptedChannelSize_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.expireTimeSecs_ = expireTimeSecs_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.minPayment_ = minPayment_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.Initiate) {
-          return mergeFrom((org.flo.paymentchannel.Protos.Initiate)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.Initiate other) {
-        if (other == org.flo.paymentchannel.Protos.Initiate.getDefaultInstance()) return this;
-        if (other.hasMultisigKey()) {
-          setMultisigKey(other.getMultisigKey());
-        }
-        if (other.hasMinAcceptedChannelSize()) {
-          setMinAcceptedChannelSize(other.getMinAcceptedChannelSize());
-        }
-        if (other.hasExpireTimeSecs()) {
-          setExpireTimeSecs(other.getExpireTimeSecs());
-        }
-        if (other.hasMinPayment()) {
-          setMinPayment(other.getMinPayment());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasMultisigKey()) {
-          
-          return false;
-        }
-        if (!hasMinAcceptedChannelSize()) {
-          
-          return false;
-        }
-        if (!hasExpireTimeSecs()) {
-          
-          return false;
-        }
-        if (!hasMinPayment()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.Initiate parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.Initiate) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString multisigKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted. It is used only in the creation of the multisig contract, as outputs are
        * created entirely by the secondary
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public boolean hasMultisigKey() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasMultisigKey();
       }
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted. It is used only in the creation of the multisig contract, as outputs are
        * created entirely by the secondary
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public com.google.protobuf.ByteString getMultisigKey() {
-        return multisigKey_;
+        return instance.getMultisigKey();
       }
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted. It is used only in the creation of the multisig contract, as outputs are
        * created entirely by the secondary
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public Builder setMultisigKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        multisigKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMultisigKey(value);
         return this;
       }
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted. It is used only in the creation of the multisig contract, as outputs are
        * created entirely by the secondary
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public Builder clearMultisigKey() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        multisigKey_ = getDefaultInstance().getMultisigKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearMultisigKey();
         return this;
       }
 
-      private long minAcceptedChannelSize_ ;
       /**
-       * <code>required uint64 min_accepted_channel_size = 2;</code>
-       *
        * <pre>
        * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
        * size it's willing to accept here. This can be lower to trade off resources against
        * security but shouldn't be so low the transactions get rejected by the network as spam.
        * Zero isn't a sensible value to have here, so we make the field required.
        * </pre>
+       *
+       * <code>required uint64 min_accepted_channel_size = 2;</code>
        */
       public boolean hasMinAcceptedChannelSize() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasMinAcceptedChannelSize();
       }
       /**
-       * <code>required uint64 min_accepted_channel_size = 2;</code>
-       *
        * <pre>
        * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
        * size it's willing to accept here. This can be lower to trade off resources against
        * security but shouldn't be so low the transactions get rejected by the network as spam.
        * Zero isn't a sensible value to have here, so we make the field required.
        * </pre>
+       *
+       * <code>required uint64 min_accepted_channel_size = 2;</code>
        */
       public long getMinAcceptedChannelSize() {
-        return minAcceptedChannelSize_;
+        return instance.getMinAcceptedChannelSize();
       }
       /**
-       * <code>required uint64 min_accepted_channel_size = 2;</code>
-       *
        * <pre>
        * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
        * size it's willing to accept here. This can be lower to trade off resources against
        * security but shouldn't be so low the transactions get rejected by the network as spam.
        * Zero isn't a sensible value to have here, so we make the field required.
        * </pre>
+       *
+       * <code>required uint64 min_accepted_channel_size = 2;</code>
        */
       public Builder setMinAcceptedChannelSize(long value) {
-        bitField0_ |= 0x00000002;
-        minAcceptedChannelSize_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMinAcceptedChannelSize(value);
         return this;
       }
       /**
-       * <code>required uint64 min_accepted_channel_size = 2;</code>
-       *
        * <pre>
        * Once a channel is exhausted a new one must be set up. So secondary indicates the minimum
        * size it's willing to accept here. This can be lower to trade off resources against
        * security but shouldn't be so low the transactions get rejected by the network as spam.
        * Zero isn't a sensible value to have here, so we make the field required.
        * </pre>
+       *
+       * <code>required uint64 min_accepted_channel_size = 2;</code>
        */
       public Builder clearMinAcceptedChannelSize() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        minAcceptedChannelSize_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearMinAcceptedChannelSize();
         return this;
       }
 
-      private long expireTimeSecs_ ;
       /**
-       * <code>required uint64 expire_time_secs = 3;</code>
-       *
        * <pre>
        * Rough UNIX time for when the channel expires. This is determined by the block header
        * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4802,13 +3694,13 @@ public final class Protos {
        * considers this value too far off (eg more than a day), it may send an ERROR and close the
        * channel.
        * </pre>
+       *
+       * <code>required uint64 expire_time_secs = 3;</code>
        */
       public boolean hasExpireTimeSecs() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasExpireTimeSecs();
       }
       /**
-       * <code>required uint64 expire_time_secs = 3;</code>
-       *
        * <pre>
        * Rough UNIX time for when the channel expires. This is determined by the block header
        * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4818,13 +3710,13 @@ public final class Protos {
        * considers this value too far off (eg more than a day), it may send an ERROR and close the
        * channel.
        * </pre>
+       *
+       * <code>required uint64 expire_time_secs = 3;</code>
        */
       public long getExpireTimeSecs() {
-        return expireTimeSecs_;
+        return instance.getExpireTimeSecs();
       }
       /**
-       * <code>required uint64 expire_time_secs = 3;</code>
-       *
        * <pre>
        * Rough UNIX time for when the channel expires. This is determined by the block header
        * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4834,16 +3726,15 @@ public final class Protos {
        * considers this value too far off (eg more than a day), it may send an ERROR and close the
        * channel.
        * </pre>
+       *
+       * <code>required uint64 expire_time_secs = 3;</code>
        */
       public Builder setExpireTimeSecs(long value) {
-        bitField0_ |= 0x00000004;
-        expireTimeSecs_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setExpireTimeSecs(value);
         return this;
       }
       /**
-       * <code>required uint64 expire_time_secs = 3;</code>
-       *
        * <pre>
        * Rough UNIX time for when the channel expires. This is determined by the block header
        * timestamps which can be very inaccurate when miners use the obsolete RollNTime hack.
@@ -4853,18 +3744,16 @@ public final class Protos {
        * considers this value too far off (eg more than a day), it may send an ERROR and close the
        * channel.
        * </pre>
+       *
+       * <code>required uint64 expire_time_secs = 3;</code>
        */
       public Builder clearExpireTimeSecs() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        expireTimeSecs_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearExpireTimeSecs();
         return this;
       }
 
-      private long minPayment_ ;
       /**
-       * <code>required uint64 min_payment = 4;</code>
-       *
        * <pre>
        * The amount of money the server requires for the initial payment. The act of opening a channel
        * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4873,13 +3762,13 @@ public final class Protos {
        * server tells the client what it thinks it is, and the client is supposed to sanity check this
        * value.
        * </pre>
+       *
+       * <code>required uint64 min_payment = 4;</code>
        */
       public boolean hasMinPayment() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasMinPayment();
       }
       /**
-       * <code>required uint64 min_payment = 4;</code>
-       *
        * <pre>
        * The amount of money the server requires for the initial payment. The act of opening a channel
        * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4888,13 +3777,13 @@ public final class Protos {
        * server tells the client what it thinks it is, and the client is supposed to sanity check this
        * value.
        * </pre>
+       *
+       * <code>required uint64 min_payment = 4;</code>
        */
       public long getMinPayment() {
-        return minPayment_;
+        return instance.getMinPayment();
       }
       /**
-       * <code>required uint64 min_payment = 4;</code>
-       *
        * <pre>
        * The amount of money the server requires for the initial payment. The act of opening a channel
        * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4903,16 +3792,15 @@ public final class Protos {
        * server tells the client what it thinks it is, and the client is supposed to sanity check this
        * value.
        * </pre>
+       *
+       * <code>required uint64 min_payment = 4;</code>
        */
       public Builder setMinPayment(long value) {
-        bitField0_ |= 0x00000008;
-        minPayment_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMinPayment(value);
         return this;
       }
       /**
-       * <code>required uint64 min_payment = 4;</code>
-       *
        * <pre>
        * The amount of money the server requires for the initial payment. The act of opening a channel
        * always transfers some quantity of money to the server: it's impossible to have a channel with
@@ -4921,51 +3809,195 @@ public final class Protos {
        * server tells the client what it thinks it is, and the client is supposed to sanity check this
        * value.
        * </pre>
+       *
+       * <code>required uint64 min_payment = 4;</code>
        */
       public Builder clearMinPayment() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        minPayment_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearMinPayment();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.Initiate)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.Initiate();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Initiate(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasMultisigKey()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasMinAcceptedChannelSize()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasExpireTimeSecs()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasMinPayment()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.Initiate other = (org.flo.paymentchannel.Protos.Initiate) arg1;
+          multisigKey_ = visitor.visitByteString(
+              hasMultisigKey(), multisigKey_,
+              other.hasMultisigKey(), other.multisigKey_);
+          minAcceptedChannelSize_ = visitor.visitLong(
+              hasMinAcceptedChannelSize(), minAcceptedChannelSize_,
+              other.hasMinAcceptedChannelSize(), other.minAcceptedChannelSize_);
+          expireTimeSecs_ = visitor.visitLong(
+              hasExpireTimeSecs(), expireTimeSecs_,
+              other.hasExpireTimeSecs(), other.expireTimeSecs_);
+          minPayment_ = visitor.visitLong(
+              hasMinPayment(), minPayment_,
+              other.hasMinPayment(), other.minPayment_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  multisigKey_ = input.readBytes();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  minAcceptedChannelSize_ = input.readUInt64();
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000004;
+                  expireTimeSecs_ = input.readUInt64();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000008;
+                  minPayment_ = input.readUInt64();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.Initiate.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.Initiate)
+    private static final org.flo.paymentchannel.Protos.Initiate DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Initiate();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.Initiate getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Initiate> PARSER;
+
+    public static com.google.protobuf.Parser<Initiate> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ProvideRefundOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.ProvideRefund)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     boolean hasMultisigKey();
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     com.google.protobuf.ByteString getMultisigKey();
 
     /**
-     * <code>required bytes tx = 2;</code>
-     *
      * <pre>
      * The serialized bytes of the return transaction in Satoshi format.
      * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -4976,11 +4008,11 @@ public final class Protos {
      * * It must have exactly one output which goes back to the primary.  This output's
      *   scriptPubKey will be reused to create payment transactions.
      * </pre>
+     *
+     * <code>required bytes tx = 2;</code>
      */
     boolean hasTx();
     /**
-     * <code>required bytes tx = 2;</code>
-     *
      * <pre>
      * The serialized bytes of the return transaction in Satoshi format.
      * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -4991,145 +4023,83 @@ public final class Protos {
      * * It must have exactly one output which goes back to the primary.  This output's
      *   scriptPubKey will be reused to create payment transactions.
      * </pre>
+     *
+     * <code>required bytes tx = 2;</code>
      */
     com.google.protobuf.ByteString getTx();
   }
   /**
-   * Protobuf type {@code paymentchannels.ProvideRefund}
-   *
    * <pre>
    * Sent from primary to secondary after Initiate to begin the refund transaction signing.
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.ProvideRefund}
    */
-  public static final class ProvideRefund extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class ProvideRefund extends
+      com.google.protobuf.GeneratedMessageLite<
+          ProvideRefund, ProvideRefund.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.ProvideRefund)
       ProvideRefundOrBuilder {
-    // Use ProvideRefund.newBuilder() to construct.
-    private ProvideRefund(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private ProvideRefund() {
+      multisigKey_ = com.google.protobuf.ByteString.EMPTY;
+      tx_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private ProvideRefund(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final ProvideRefund defaultInstance;
-    public static ProvideRefund getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public ProvideRefund getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ProvideRefund(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              multisigKey_ = input.readBytes();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              tx_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideRefund_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideRefund_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.ProvideRefund.class, org.flo.paymentchannel.Protos.ProvideRefund.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<ProvideRefund> PARSER =
-        new com.google.protobuf.AbstractParser<ProvideRefund>() {
-      public ProvideRefund parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ProvideRefund(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ProvideRefund> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MULTISIG_KEY_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString multisigKey_;
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     public boolean hasMultisigKey() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bytes multisig_key = 1;</code>
-     *
      * <pre>
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
      */
     public com.google.protobuf.ByteString getMultisigKey() {
       return multisigKey_;
+    }
+    /**
+     * <pre>
+     * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
+     * are accepted.  It is only used in the creation of the multisig contract.
+     * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
+     */
+    private void setMultisigKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      multisigKey_ = value;
+    }
+    /**
+     * <pre>
+     * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
+     * are accepted.  It is only used in the creation of the multisig contract.
+     * </pre>
+     *
+     * <code>required bytes multisig_key = 1;</code>
+     */
+    private void clearMultisigKey() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      multisigKey_ = getDefaultInstance().getMultisigKey();
     }
 
     public static final int TX_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString tx_;
     /**
-     * <code>required bytes tx = 2;</code>
-     *
      * <pre>
      * The serialized bytes of the return transaction in Satoshi format.
      * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -5140,13 +4110,13 @@ public final class Protos {
      * * It must have exactly one output which goes back to the primary.  This output's
      *   scriptPubKey will be reused to create payment transactions.
      * </pre>
+     *
+     * <code>required bytes tx = 2;</code>
      */
     public boolean hasTx() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required bytes tx = 2;</code>
-     *
      * <pre>
      * The serialized bytes of the return transaction in Satoshi format.
      * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -5157,46 +4127,63 @@ public final class Protos {
      * * It must have exactly one output which goes back to the primary.  This output's
      *   scriptPubKey will be reused to create payment transactions.
      * </pre>
+     *
+     * <code>required bytes tx = 2;</code>
      */
     public com.google.protobuf.ByteString getTx() {
       return tx_;
     }
-
-    private void initFields() {
-      multisigKey_ = com.google.protobuf.ByteString.EMPTY;
-      tx_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * The serialized bytes of the return transaction in Satoshi format.
+     * * It must have exactly one input which spends the multisig output (see ProvideContract for
+     *   details of exactly what that output must look like). This output must have a sequence
+     *   number of 0.
+     * * It must have the lock time set to a time after the min_time_window_secs (from the
+     *   Initiate message).
+     * * It must have exactly one output which goes back to the primary.  This output's
+     *   scriptPubKey will be reused to create payment transactions.
+     * </pre>
+     *
+     * <code>required bytes tx = 2;</code>
+     */
+    private void setTx(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      tx_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasMultisigKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasTx()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * The serialized bytes of the return transaction in Satoshi format.
+     * * It must have exactly one input which spends the multisig output (see ProvideContract for
+     *   details of exactly what that output must look like). This output must have a sequence
+     *   number of 0.
+     * * It must have the lock time set to a time after the min_time_window_secs (from the
+     *   Initiate message).
+     * * It must have exactly one output which goes back to the primary.  This output's
+     *   scriptPubKey will be reused to create payment transactions.
+     * </pre>
+     *
+     * <code>required bytes tx = 2;</code>
+     */
+    private void clearTx() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      tx_ = getDefaultInstance().getTx();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, multisigKey_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, tx_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -5210,283 +4197,147 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, tx_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ProvideRefund parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.ProvideRefund prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.ProvideRefund}
-     *
      * <pre>
      * Sent from primary to secondary after Initiate to begin the refund transaction signing.
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.ProvideRefund}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.ProvideRefund, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.ProvideRefund)
         org.flo.paymentchannel.Protos.ProvideRefundOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideRefund_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideRefund_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.ProvideRefund.class, org.flo.paymentchannel.Protos.ProvideRefund.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.ProvideRefund.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        multisigKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        tx_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideRefund_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.ProvideRefund getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.ProvideRefund build() {
-        org.flo.paymentchannel.Protos.ProvideRefund result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.ProvideRefund buildPartial() {
-        org.flo.paymentchannel.Protos.ProvideRefund result = new org.flo.paymentchannel.Protos.ProvideRefund(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.multisigKey_ = multisigKey_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.tx_ = tx_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.ProvideRefund) {
-          return mergeFrom((org.flo.paymentchannel.Protos.ProvideRefund)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.ProvideRefund other) {
-        if (other == org.flo.paymentchannel.Protos.ProvideRefund.getDefaultInstance()) return this;
-        if (other.hasMultisigKey()) {
-          setMultisigKey(other.getMultisigKey());
-        }
-        if (other.hasTx()) {
-          setTx(other.getTx());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasMultisigKey()) {
-          
-          return false;
-        }
-        if (!hasTx()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.ProvideRefund parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.ProvideRefund) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString multisigKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public boolean hasMultisigKey() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasMultisigKey();
       }
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public com.google.protobuf.ByteString getMultisigKey() {
-        return multisigKey_;
+        return instance.getMultisigKey();
       }
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public Builder setMultisigKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        multisigKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMultisigKey(value);
         return this;
       }
       /**
-       * <code>required bytes multisig_key = 1;</code>
-       *
        * <pre>
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>required bytes multisig_key = 1;</code>
        */
       public Builder clearMultisigKey() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        multisigKey_ = getDefaultInstance().getMultisigKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearMultisigKey();
         return this;
       }
 
-      private com.google.protobuf.ByteString tx_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes tx = 2;</code>
-       *
        * <pre>
        * The serialized bytes of the return transaction in Satoshi format.
        * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -5497,13 +4348,13 @@ public final class Protos {
        * * It must have exactly one output which goes back to the primary.  This output's
        *   scriptPubKey will be reused to create payment transactions.
        * </pre>
+       *
+       * <code>required bytes tx = 2;</code>
        */
       public boolean hasTx() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasTx();
       }
       /**
-       * <code>required bytes tx = 2;</code>
-       *
        * <pre>
        * The serialized bytes of the return transaction in Satoshi format.
        * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -5514,13 +4365,13 @@ public final class Protos {
        * * It must have exactly one output which goes back to the primary.  This output's
        *   scriptPubKey will be reused to create payment transactions.
        * </pre>
+       *
+       * <code>required bytes tx = 2;</code>
        */
       public com.google.protobuf.ByteString getTx() {
-        return tx_;
+        return instance.getTx();
       }
       /**
-       * <code>required bytes tx = 2;</code>
-       *
        * <pre>
        * The serialized bytes of the return transaction in Satoshi format.
        * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -5531,19 +4382,15 @@ public final class Protos {
        * * It must have exactly one output which goes back to the primary.  This output's
        *   scriptPubKey will be reused to create payment transactions.
        * </pre>
+       *
+       * <code>required bytes tx = 2;</code>
        */
       public Builder setTx(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        tx_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTx(value);
         return this;
       }
       /**
-       * <code>required bytes tx = 2;</code>
-       *
        * <pre>
        * The serialized bytes of the return transaction in Satoshi format.
        * * It must have exactly one input which spends the multisig output (see ProvideContract for
@@ -5554,28 +4401,146 @@ public final class Protos {
        * * It must have exactly one output which goes back to the primary.  This output's
        *   scriptPubKey will be reused to create payment transactions.
        * </pre>
+       *
+       * <code>required bytes tx = 2;</code>
        */
       public Builder clearTx() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        tx_ = getDefaultInstance().getTx();
-        onChanged();
+        copyOnWrite();
+        instance.clearTx();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.ProvideRefund)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.ProvideRefund();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new ProvideRefund(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasMultisigKey()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasTx()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.ProvideRefund other = (org.flo.paymentchannel.Protos.ProvideRefund) arg1;
+          multisigKey_ = visitor.visitByteString(
+              hasMultisigKey(), multisigKey_,
+              other.hasMultisigKey(), other.multisigKey_);
+          tx_ = visitor.visitByteString(
+              hasTx(), tx_,
+              other.hasTx(), other.tx_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  multisigKey_ = input.readBytes();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  tx_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.ProvideRefund.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.ProvideRefund)
+    private static final org.flo.paymentchannel.Protos.ProvideRefund DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ProvideRefund();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.ProvideRefund getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<ProvideRefund> PARSER;
+
+    public static com.google.protobuf.Parser<ProvideRefund> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ReturnRefundOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.ReturnRefund)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required bytes signature = 1;</code>
@@ -5587,8 +4552,6 @@ public final class Protos {
     com.google.protobuf.ByteString getSignature();
   }
   /**
-   * Protobuf type {@code paymentchannels.ReturnRefund}
-   *
    * <pre>
    * Sent from secondary to primary after it has done initial verification of the refund
    * transaction. Contains the primary's signature which is required to spend the multisig contract
@@ -5596,100 +4559,17 @@ public final class Protos {
    * the postfix type byte) to allow the client to add any outputs/inputs it wants as long as the
    * input's sequence and transaction's nLockTime remain set.
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.ReturnRefund}
    */
-  public static final class ReturnRefund extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class ReturnRefund extends
+      com.google.protobuf.GeneratedMessageLite<
+          ReturnRefund, ReturnRefund.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.ReturnRefund)
       ReturnRefundOrBuilder {
-    // Use ReturnRefund.newBuilder() to construct.
-    private ReturnRefund(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private ReturnRefund() {
+      signature_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private ReturnRefund(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final ReturnRefund defaultInstance;
-    public static ReturnRefund getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public ReturnRefund getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ReturnRefund(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              signature_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ReturnRefund_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ReturnRefund_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.ReturnRefund.class, org.flo.paymentchannel.Protos.ReturnRefund.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<ReturnRefund> PARSER =
-        new com.google.protobuf.AbstractParser<ReturnRefund>() {
-      public ReturnRefund parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ReturnRefund(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ReturnRefund> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int SIGNATURE_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString signature_;
@@ -5705,34 +4585,32 @@ public final class Protos {
     public com.google.protobuf.ByteString getSignature() {
       return signature_;
     }
-
-    private void initFields() {
-      signature_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <code>required bytes signature = 1;</code>
+     */
+    private void setSignature(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      signature_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasSignature()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>required bytes signature = 1;</code>
+     */
+    private void clearSignature() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      signature_ = getDefaultInstance().getSignature();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, signature_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -5742,87 +4620,80 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, signature_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ReturnRefund parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.ReturnRefund prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.ReturnRefund}
-     *
      * <pre>
      * Sent from secondary to primary after it has done initial verification of the refund
      * transaction. Contains the primary's signature which is required to spend the multisig contract
@@ -5830,180 +4701,168 @@ public final class Protos {
      * the postfix type byte) to allow the client to add any outputs/inputs it wants as long as the
      * input's sequence and transaction's nLockTime remain set.
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.ReturnRefund}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.ReturnRefund, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.ReturnRefund)
         org.flo.paymentchannel.Protos.ReturnRefundOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ReturnRefund_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ReturnRefund_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.ReturnRefund.class, org.flo.paymentchannel.Protos.ReturnRefund.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.ReturnRefund.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        signature_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ReturnRefund_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.ReturnRefund getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.ReturnRefund build() {
-        org.flo.paymentchannel.Protos.ReturnRefund result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.ReturnRefund buildPartial() {
-        org.flo.paymentchannel.Protos.ReturnRefund result = new org.flo.paymentchannel.Protos.ReturnRefund(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.signature_ = signature_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.ReturnRefund) {
-          return mergeFrom((org.flo.paymentchannel.Protos.ReturnRefund)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.ReturnRefund other) {
-        if (other == org.flo.paymentchannel.Protos.ReturnRefund.getDefaultInstance()) return this;
-        if (other.hasSignature()) {
-          setSignature(other.getSignature());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasSignature()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.ReturnRefund parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.ReturnRefund) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString signature_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes signature = 1;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasSignature();
       }
       /**
        * <code>required bytes signature = 1;</code>
        */
       public com.google.protobuf.ByteString getSignature() {
-        return signature_;
+        return instance.getSignature();
       }
       /**
        * <code>required bytes signature = 1;</code>
        */
       public Builder setSignature(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        signature_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSignature(value);
         return this;
       }
       /**
        * <code>required bytes signature = 1;</code>
        */
       public Builder clearSignature() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        signature_ = getDefaultInstance().getSignature();
-        onChanged();
+        copyOnWrite();
+        instance.clearSignature();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.ReturnRefund)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.ReturnRefund();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new ReturnRefund(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasSignature()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.ReturnRefund other = (org.flo.paymentchannel.Protos.ReturnRefund) arg1;
+          signature_ = visitor.visitByteString(
+              hasSignature(), signature_,
+              other.hasSignature(), other.signature_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  signature_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.ReturnRefund.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.ReturnRefund)
+    private static final org.flo.paymentchannel.Protos.ReturnRefund DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ReturnRefund();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.ReturnRefund getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<ReturnRefund> PARSER;
+
+    public static com.google.protobuf.Parser<ReturnRefund> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ProvideContractOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.ProvideContract)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes tx = 1;</code>
-     *
      * <pre>
      * The serialized bytes of the transaction in Satoshi format.
      * For version 1:
@@ -6018,11 +4877,11 @@ public final class Protos {
      * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
      *   primary's and the second being the secondary's.
      * </pre>
+     *
+     * <code>required bytes tx = 1;</code>
      */
     boolean hasTx();
     /**
-     * <code>required bytes tx = 1;</code>
-     *
      * <pre>
      * The serialized bytes of the transaction in Satoshi format.
      * For version 1:
@@ -6037,190 +4896,77 @@ public final class Protos {
      * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
      *   primary's and the second being the secondary's.
      * </pre>
+     *
+     * <code>required bytes tx = 1;</code>
      */
     com.google.protobuf.ByteString getTx();
 
     /**
-     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-     *
      * <pre>
      * To open the channel, an initial payment of the server-specified dust limit value must be
      * provided. This ensures that the channel is never in an un-settleable state due to either
      * no payment tx having been provided at all, or a payment that is smaller than the dust
      * limit being provided.
      * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
      */
     boolean hasInitialPayment();
     /**
-     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-     *
      * <pre>
      * To open the channel, an initial payment of the server-specified dust limit value must be
      * provided. This ensures that the channel is never in an un-settleable state due to either
      * no payment tx having been provided at all, or a payment that is smaller than the dust
      * limit being provided.
      * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
      */
     org.flo.paymentchannel.Protos.UpdatePayment getInitialPayment();
-    /**
-     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-     *
-     * <pre>
-     * To open the channel, an initial payment of the server-specified dust limit value must be
-     * provided. This ensures that the channel is never in an un-settleable state due to either
-     * no payment tx having been provided at all, or a payment that is smaller than the dust
-     * limit being provided.
-     * </pre>
-     */
-    org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder getInitialPaymentOrBuilder();
 
     /**
-     * <code>optional bytes client_key = 3;</code>
-     *
      * <pre>
      * This field is added in protocol version 2 to send the client public key to the server.
      * In version 1 it isn't used.
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>optional bytes client_key = 3;</code>
      */
     boolean hasClientKey();
     /**
-     * <code>optional bytes client_key = 3;</code>
-     *
      * <pre>
      * This field is added in protocol version 2 to send the client public key to the server.
      * In version 1 it isn't used.
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>optional bytes client_key = 3;</code>
      */
     com.google.protobuf.ByteString getClientKey();
   }
   /**
-   * Protobuf type {@code paymentchannels.ProvideContract}
-   *
    * <pre>
    * Sent from the primary to the secondary to complete initialization.
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.ProvideContract}
    */
-  public static final class ProvideContract extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class ProvideContract extends
+      com.google.protobuf.GeneratedMessageLite<
+          ProvideContract, ProvideContract.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.ProvideContract)
       ProvideContractOrBuilder {
-    // Use ProvideContract.newBuilder() to construct.
-    private ProvideContract(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private ProvideContract() {
+      tx_ = com.google.protobuf.ByteString.EMPTY;
+      clientKey_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private ProvideContract(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final ProvideContract defaultInstance;
-    public static ProvideContract getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public ProvideContract getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ProvideContract(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              tx_ = input.readBytes();
-              break;
-            }
-            case 18: {
-              org.flo.paymentchannel.Protos.UpdatePayment.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                subBuilder = initialPayment_.toBuilder();
-              }
-              initialPayment_ = input.readMessage(org.flo.paymentchannel.Protos.UpdatePayment.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(initialPayment_);
-                initialPayment_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000002;
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              clientKey_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideContract_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideContract_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.ProvideContract.class, org.flo.paymentchannel.Protos.ProvideContract.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<ProvideContract> PARSER =
-        new com.google.protobuf.AbstractParser<ProvideContract>() {
-      public ProvideContract parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ProvideContract(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ProvideContract> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int TX_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString tx_;
     /**
-     * <code>required bytes tx = 1;</code>
-     *
      * <pre>
      * The serialized bytes of the transaction in Satoshi format.
      * For version 1:
@@ -6235,13 +4981,13 @@ public final class Protos {
      * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
      *   primary's and the second being the secondary's.
      * </pre>
+     *
+     * <code>required bytes tx = 1;</code>
      */
     public boolean hasTx() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bytes tx = 1;</code>
-     *
      * <pre>
      * The serialized bytes of the transaction in Satoshi format.
      * For version 1:
@@ -6256,125 +5002,228 @@ public final class Protos {
      * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
      *   primary's and the second being the secondary's.
      * </pre>
+     *
+     * <code>required bytes tx = 1;</code>
      */
     public com.google.protobuf.ByteString getTx() {
       return tx_;
+    }
+    /**
+     * <pre>
+     * The serialized bytes of the transaction in Satoshi format.
+     * For version 1:
+     * * It must be signed and completely valid and ready for broadcast (ie it includes the
+     *   necessary fees) TODO: tell the client how much fee it needs
+     * * Its first output must be a 2-of-2 multisig output with the first pubkey being the
+     *   primary's and the second being the secondary's (ie the script must be exactly "OP_2
+     *   ProvideRefund.multisig_key Initiate.multisig_key OP_2 OP_CHECKMULTISIG")
+     * For version 2:
+     * * It must be signed and completely valid and ready for broadcast (ie it includes the
+     *   necessary fees) TODO: tell the client how much fee it needs
+     * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
+     *   primary's and the second being the secondary's.
+     * </pre>
+     *
+     * <code>required bytes tx = 1;</code>
+     */
+    private void setTx(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      tx_ = value;
+    }
+    /**
+     * <pre>
+     * The serialized bytes of the transaction in Satoshi format.
+     * For version 1:
+     * * It must be signed and completely valid and ready for broadcast (ie it includes the
+     *   necessary fees) TODO: tell the client how much fee it needs
+     * * Its first output must be a 2-of-2 multisig output with the first pubkey being the
+     *   primary's and the second being the secondary's (ie the script must be exactly "OP_2
+     *   ProvideRefund.multisig_key Initiate.multisig_key OP_2 OP_CHECKMULTISIG")
+     * For version 2:
+     * * It must be signed and completely valid and ready for broadcast (ie it includes the
+     *   necessary fees) TODO: tell the client how much fee it needs
+     * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
+     *   primary's and the second being the secondary's.
+     * </pre>
+     *
+     * <code>required bytes tx = 1;</code>
+     */
+    private void clearTx() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      tx_ = getDefaultInstance().getTx();
     }
 
     public static final int INITIAL_PAYMENT_FIELD_NUMBER = 2;
     private org.flo.paymentchannel.Protos.UpdatePayment initialPayment_;
     /**
-     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-     *
      * <pre>
      * To open the channel, an initial payment of the server-specified dust limit value must be
      * provided. This ensures that the channel is never in an un-settleable state due to either
      * no payment tx having been provided at all, or a payment that is smaller than the dust
      * limit being provided.
      * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
      */
     public boolean hasInitialPayment() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-     *
      * <pre>
      * To open the channel, an initial payment of the server-specified dust limit value must be
      * provided. This ensures that the channel is never in an un-settleable state due to either
      * no payment tx having been provided at all, or a payment that is smaller than the dust
      * limit being provided.
      * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
      */
     public org.flo.paymentchannel.Protos.UpdatePayment getInitialPayment() {
-      return initialPayment_;
+      return initialPayment_ == null ? org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance() : initialPayment_;
     }
     /**
-     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-     *
      * <pre>
      * To open the channel, an initial payment of the server-specified dust limit value must be
      * provided. This ensures that the channel is never in an un-settleable state due to either
      * no payment tx having been provided at all, or a payment that is smaller than the dust
      * limit being provided.
      * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
      */
-    public org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder getInitialPaymentOrBuilder() {
-      return initialPayment_;
+    private void setInitialPayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      initialPayment_ = value;
+      bitField0_ |= 0x00000002;
+      }
+    /**
+     * <pre>
+     * To open the channel, an initial payment of the server-specified dust limit value must be
+     * provided. This ensures that the channel is never in an un-settleable state due to either
+     * no payment tx having been provided at all, or a payment that is smaller than the dust
+     * limit being provided.
+     * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
+     */
+    private void setInitialPayment(
+        org.flo.paymentchannel.Protos.UpdatePayment.Builder builderForValue) {
+      initialPayment_ = builderForValue.build();
+      bitField0_ |= 0x00000002;
+    }
+    /**
+     * <pre>
+     * To open the channel, an initial payment of the server-specified dust limit value must be
+     * provided. This ensures that the channel is never in an un-settleable state due to either
+     * no payment tx having been provided at all, or a payment that is smaller than the dust
+     * limit being provided.
+     * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
+     */
+    private void mergeInitialPayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
+      if (initialPayment_ != null &&
+          initialPayment_ != org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance()) {
+        initialPayment_ =
+          org.flo.paymentchannel.Protos.UpdatePayment.newBuilder(initialPayment_).mergeFrom(value).buildPartial();
+      } else {
+        initialPayment_ = value;
+      }
+      bitField0_ |= 0x00000002;
+    }
+    /**
+     * <pre>
+     * To open the channel, an initial payment of the server-specified dust limit value must be
+     * provided. This ensures that the channel is never in an un-settleable state due to either
+     * no payment tx having been provided at all, or a payment that is smaller than the dust
+     * limit being provided.
+     * </pre>
+     *
+     * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
+     */
+    private void clearInitialPayment() {  initialPayment_ = null;
+      bitField0_ = (bitField0_ & ~0x00000002);
     }
 
     public static final int CLIENT_KEY_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString clientKey_;
     /**
-     * <code>optional bytes client_key = 3;</code>
-     *
      * <pre>
      * This field is added in protocol version 2 to send the client public key to the server.
      * In version 1 it isn't used.
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>optional bytes client_key = 3;</code>
      */
     public boolean hasClientKey() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional bytes client_key = 3;</code>
-     *
      * <pre>
      * This field is added in protocol version 2 to send the client public key to the server.
      * In version 1 it isn't used.
      * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
      * are accepted.  It is only used in the creation of the multisig contract.
      * </pre>
+     *
+     * <code>optional bytes client_key = 3;</code>
      */
     public com.google.protobuf.ByteString getClientKey() {
       return clientKey_;
     }
-
-    private void initFields() {
-      tx_ = com.google.protobuf.ByteString.EMPTY;
-      initialPayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-      clientKey_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * This field is added in protocol version 2 to send the client public key to the server.
+     * In version 1 it isn't used.
+     * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
+     * are accepted.  It is only used in the creation of the multisig contract.
+     * </pre>
+     *
+     * <code>optional bytes client_key = 3;</code>
+     */
+    private void setClientKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      clientKey_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasTx()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasInitialPayment()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!getInitialPayment().isInitialized()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * This field is added in protocol version 2 to send the client public key to the server.
+     * In version 1 it isn't used.
+     * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
+     * are accepted.  It is only used in the creation of the multisig contract.
+     * </pre>
+     *
+     * <code>optional bytes client_key = 3;</code>
+     */
+    private void clearClientKey() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      clientKey_ = getDefaultInstance().getClientKey();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, tx_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeMessage(2, initialPayment_);
+        output.writeMessage(2, getInitialPayment());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBytes(3, clientKey_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -6386,256 +5235,104 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, initialPayment_);
+          .computeMessageSize(2, getInitialPayment());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, clientKey_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.ProvideContract parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.ProvideContract prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.ProvideContract}
-     *
      * <pre>
      * Sent from the primary to the secondary to complete initialization.
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.ProvideContract}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.ProvideContract, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.ProvideContract)
         org.flo.paymentchannel.Protos.ProvideContractOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideContract_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideContract_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.ProvideContract.class, org.flo.paymentchannel.Protos.ProvideContract.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.ProvideContract.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getInitialPaymentFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        tx_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        if (initialPaymentBuilder_ == null) {
-          initialPayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-        } else {
-          initialPaymentBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000002);
-        clientKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_ProvideContract_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.ProvideContract getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.ProvideContract build() {
-        org.flo.paymentchannel.Protos.ProvideContract result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.ProvideContract buildPartial() {
-        org.flo.paymentchannel.Protos.ProvideContract result = new org.flo.paymentchannel.Protos.ProvideContract(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.tx_ = tx_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        if (initialPaymentBuilder_ == null) {
-          result.initialPayment_ = initialPayment_;
-        } else {
-          result.initialPayment_ = initialPaymentBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.clientKey_ = clientKey_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.ProvideContract) {
-          return mergeFrom((org.flo.paymentchannel.Protos.ProvideContract)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.ProvideContract other) {
-        if (other == org.flo.paymentchannel.Protos.ProvideContract.getDefaultInstance()) return this;
-        if (other.hasTx()) {
-          setTx(other.getTx());
-        }
-        if (other.hasInitialPayment()) {
-          mergeInitialPayment(other.getInitialPayment());
-        }
-        if (other.hasClientKey()) {
-          setClientKey(other.getClientKey());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasTx()) {
-          
-          return false;
-        }
-        if (!hasInitialPayment()) {
-          
-          return false;
-        }
-        if (!getInitialPayment().isInitialized()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.ProvideContract parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.ProvideContract) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString tx_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes tx = 1;</code>
-       *
        * <pre>
        * The serialized bytes of the transaction in Satoshi format.
        * For version 1:
@@ -6650,13 +5347,13 @@ public final class Protos {
        * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
        *   primary's and the second being the secondary's.
        * </pre>
+       *
+       * <code>required bytes tx = 1;</code>
        */
       public boolean hasTx() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasTx();
       }
       /**
-       * <code>required bytes tx = 1;</code>
-       *
        * <pre>
        * The serialized bytes of the transaction in Satoshi format.
        * For version 1:
@@ -6671,13 +5368,13 @@ public final class Protos {
        * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
        *   primary's and the second being the secondary's.
        * </pre>
+       *
+       * <code>required bytes tx = 1;</code>
        */
       public com.google.protobuf.ByteString getTx() {
-        return tx_;
+        return instance.getTx();
       }
       /**
-       * <code>required bytes tx = 1;</code>
-       *
        * <pre>
        * The serialized bytes of the transaction in Satoshi format.
        * For version 1:
@@ -6692,19 +5389,15 @@ public final class Protos {
        * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
        *   primary's and the second being the secondary's.
        * </pre>
+       *
+       * <code>required bytes tx = 1;</code>
        */
       public Builder setTx(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        tx_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTx(value);
         return this;
       }
       /**
-       * <code>required bytes tx = 1;</code>
-       *
        * <pre>
        * The serialized bytes of the transaction in Satoshi format.
        * For version 1:
@@ -6719,333 +5412,371 @@ public final class Protos {
        * * Its first output must be a CHECKLOCKTIMEVERIFY output with the first pubkey being the
        *   primary's and the second being the secondary's.
        * </pre>
+       *
+       * <code>required bytes tx = 1;</code>
        */
       public Builder clearTx() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        tx_ = getDefaultInstance().getTx();
-        onChanged();
+        copyOnWrite();
+        instance.clearTx();
         return this;
       }
 
-      private org.flo.paymentchannel.Protos.UpdatePayment initialPayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.UpdatePayment, org.flo.paymentchannel.Protos.UpdatePayment.Builder, org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder> initialPaymentBuilder_;
       /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
        * <pre>
        * To open the channel, an initial payment of the server-specified dust limit value must be
        * provided. This ensures that the channel is never in an un-settleable state due to either
        * no payment tx having been provided at all, or a payment that is smaller than the dust
        * limit being provided.
        * </pre>
+       *
+       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
        */
       public boolean hasInitialPayment() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasInitialPayment();
       }
       /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
        * <pre>
        * To open the channel, an initial payment of the server-specified dust limit value must be
        * provided. This ensures that the channel is never in an un-settleable state due to either
        * no payment tx having been provided at all, or a payment that is smaller than the dust
        * limit being provided.
        * </pre>
+       *
+       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
        */
       public org.flo.paymentchannel.Protos.UpdatePayment getInitialPayment() {
-        if (initialPaymentBuilder_ == null) {
-          return initialPayment_;
-        } else {
-          return initialPaymentBuilder_.getMessage();
-        }
+        return instance.getInitialPayment();
       }
       /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
        * <pre>
        * To open the channel, an initial payment of the server-specified dust limit value must be
        * provided. This ensures that the channel is never in an un-settleable state due to either
        * no payment tx having been provided at all, or a payment that is smaller than the dust
        * limit being provided.
        * </pre>
+       *
+       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
        */
       public Builder setInitialPayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
-        if (initialPaymentBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          initialPayment_ = value;
-          onChanged();
-        } else {
-          initialPaymentBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000002;
+        copyOnWrite();
+        instance.setInitialPayment(value);
         return this;
-      }
+        }
       /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
        * <pre>
        * To open the channel, an initial payment of the server-specified dust limit value must be
        * provided. This ensures that the channel is never in an un-settleable state due to either
        * no payment tx having been provided at all, or a payment that is smaller than the dust
        * limit being provided.
        * </pre>
+       *
+       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
        */
       public Builder setInitialPayment(
           org.flo.paymentchannel.Protos.UpdatePayment.Builder builderForValue) {
-        if (initialPaymentBuilder_ == null) {
-          initialPayment_ = builderForValue.build();
-          onChanged();
-        } else {
-          initialPaymentBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000002;
+        copyOnWrite();
+        instance.setInitialPayment(builderForValue);
         return this;
       }
       /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
        * <pre>
        * To open the channel, an initial payment of the server-specified dust limit value must be
        * provided. This ensures that the channel is never in an un-settleable state due to either
        * no payment tx having been provided at all, or a payment that is smaller than the dust
        * limit being provided.
        * </pre>
+       *
+       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
        */
       public Builder mergeInitialPayment(org.flo.paymentchannel.Protos.UpdatePayment value) {
-        if (initialPaymentBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
-              initialPayment_ != org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance()) {
-            initialPayment_ =
-              org.flo.paymentchannel.Protos.UpdatePayment.newBuilder(initialPayment_).mergeFrom(value).buildPartial();
-          } else {
-            initialPayment_ = value;
-          }
-          onChanged();
-        } else {
-          initialPaymentBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000002;
+        copyOnWrite();
+        instance.mergeInitialPayment(value);
         return this;
       }
       /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
        * <pre>
        * To open the channel, an initial payment of the server-specified dust limit value must be
        * provided. This ensures that the channel is never in an un-settleable state due to either
        * no payment tx having been provided at all, or a payment that is smaller than the dust
        * limit being provided.
        * </pre>
+       *
+       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
        */
-      public Builder clearInitialPayment() {
-        if (initialPaymentBuilder_ == null) {
-          initialPayment_ = org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-          onChanged();
-        } else {
-          initialPaymentBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000002);
+      public Builder clearInitialPayment() {  copyOnWrite();
+        instance.clearInitialPayment();
         return this;
-      }
-      /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
-       * <pre>
-       * To open the channel, an initial payment of the server-specified dust limit value must be
-       * provided. This ensures that the channel is never in an un-settleable state due to either
-       * no payment tx having been provided at all, or a payment that is smaller than the dust
-       * limit being provided.
-       * </pre>
-       */
-      public org.flo.paymentchannel.Protos.UpdatePayment.Builder getInitialPaymentBuilder() {
-        bitField0_ |= 0x00000002;
-        onChanged();
-        return getInitialPaymentFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
-       * <pre>
-       * To open the channel, an initial payment of the server-specified dust limit value must be
-       * provided. This ensures that the channel is never in an un-settleable state due to either
-       * no payment tx having been provided at all, or a payment that is smaller than the dust
-       * limit being provided.
-       * </pre>
-       */
-      public org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder getInitialPaymentOrBuilder() {
-        if (initialPaymentBuilder_ != null) {
-          return initialPaymentBuilder_.getMessageOrBuilder();
-        } else {
-          return initialPayment_;
-        }
-      }
-      /**
-       * <code>required .paymentchannels.UpdatePayment initial_payment = 2;</code>
-       *
-       * <pre>
-       * To open the channel, an initial payment of the server-specified dust limit value must be
-       * provided. This ensures that the channel is never in an un-settleable state due to either
-       * no payment tx having been provided at all, or a payment that is smaller than the dust
-       * limit being provided.
-       * </pre>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.paymentchannel.Protos.UpdatePayment, org.flo.paymentchannel.Protos.UpdatePayment.Builder, org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder> 
-          getInitialPaymentFieldBuilder() {
-        if (initialPaymentBuilder_ == null) {
-          initialPaymentBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.paymentchannel.Protos.UpdatePayment, org.flo.paymentchannel.Protos.UpdatePayment.Builder, org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder>(
-                  getInitialPayment(),
-                  getParentForChildren(),
-                  isClean());
-          initialPayment_ = null;
-        }
-        return initialPaymentBuilder_;
       }
 
-      private com.google.protobuf.ByteString clientKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes client_key = 3;</code>
-       *
        * <pre>
        * This field is added in protocol version 2 to send the client public key to the server.
        * In version 1 it isn't used.
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>optional bytes client_key = 3;</code>
        */
       public boolean hasClientKey() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasClientKey();
       }
       /**
-       * <code>optional bytes client_key = 3;</code>
-       *
        * <pre>
        * This field is added in protocol version 2 to send the client public key to the server.
        * In version 1 it isn't used.
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>optional bytes client_key = 3;</code>
        */
       public com.google.protobuf.ByteString getClientKey() {
-        return clientKey_;
+        return instance.getClientKey();
       }
       /**
-       * <code>optional bytes client_key = 3;</code>
-       *
        * <pre>
        * This field is added in protocol version 2 to send the client public key to the server.
        * In version 1 it isn't used.
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>optional bytes client_key = 3;</code>
        */
       public Builder setClientKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        clientKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setClientKey(value);
         return this;
       }
       /**
-       * <code>optional bytes client_key = 3;</code>
-       *
        * <pre>
        * This field is added in protocol version 2 to send the client public key to the server.
        * In version 1 it isn't used.
        * This must be a raw pubkey in regular ECDSA form. Both compressed and non-compressed forms
        * are accepted.  It is only used in the creation of the multisig contract.
        * </pre>
+       *
+       * <code>optional bytes client_key = 3;</code>
        */
       public Builder clearClientKey() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        clientKey_ = getDefaultInstance().getClientKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearClientKey();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.ProvideContract)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.ProvideContract();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new ProvideContract(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasTx()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasInitialPayment()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!getInitialPayment().isInitialized()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.ProvideContract other = (org.flo.paymentchannel.Protos.ProvideContract) arg1;
+          tx_ = visitor.visitByteString(
+              hasTx(), tx_,
+              other.hasTx(), other.tx_);
+          initialPayment_ = visitor.visitMessage(initialPayment_, other.initialPayment_);
+          clientKey_ = visitor.visitByteString(
+              hasClientKey(), clientKey_,
+              other.hasClientKey(), other.clientKey_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  tx_ = input.readBytes();
+                  break;
+                }
+                case 18: {
+                  org.flo.paymentchannel.Protos.UpdatePayment.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                    subBuilder = initialPayment_.toBuilder();
+                  }
+                  initialPayment_ = input.readMessage(org.flo.paymentchannel.Protos.UpdatePayment.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(initialPayment_);
+                    initialPayment_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000002;
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  clientKey_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.ProvideContract.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.ProvideContract)
+    private static final org.flo.paymentchannel.Protos.ProvideContract DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ProvideContract();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.ProvideContract getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<ProvideContract> PARSER;
+
+    public static com.google.protobuf.Parser<ProvideContract> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface UpdatePaymentOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.UpdatePayment)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required uint64 client_change_value = 1;</code>
-     *
      * <pre>
      * The value which is sent back to the primary.  The rest of the multisig output is left for
      * the secondary to do with as they wish.
      * </pre>
+     *
+     * <code>required uint64 client_change_value = 1;</code>
      */
     boolean hasClientChangeValue();
     /**
-     * <code>required uint64 client_change_value = 1;</code>
-     *
      * <pre>
      * The value which is sent back to the primary.  The rest of the multisig output is left for
      * the secondary to do with as they wish.
      * </pre>
+     *
+     * <code>required uint64 client_change_value = 1;</code>
      */
     long getClientChangeValue();
 
     /**
-     * <code>required bytes signature = 2;</code>
-     *
      * <pre>
      * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
      * spends the primary's part of the multisig contract's output.  This signature only covers
      * the primary's refund output and thus the secondary is free to do what they wish with their
      * part of the multisig output.
      * </pre>
+     *
+     * <code>required bytes signature = 2;</code>
      */
     boolean hasSignature();
     /**
-     * <code>required bytes signature = 2;</code>
-     *
      * <pre>
      * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
      * spends the primary's part of the multisig contract's output.  This signature only covers
      * the primary's refund output and thus the secondary is free to do what they wish with their
      * part of the multisig output.
      * </pre>
+     *
+     * <code>required bytes signature = 2;</code>
      */
     com.google.protobuf.ByteString getSignature();
 
     /**
-     * <code>optional bytes info = 3;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol.
      * </pre>
+     *
+     * <code>optional bytes info = 3;</code>
      */
     boolean hasInfo();
     /**
-     * <code>optional bytes info = 3;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol.
      * </pre>
+     *
+     * <code>optional bytes info = 3;</code>
      */
     com.google.protobuf.ByteString getInfo();
   }
   /**
-   * Protobuf type {@code paymentchannels.UpdatePayment}
-   *
    * <pre>
    * This message can only be used by the primary after it has received a CHANNEL_OPEN message. It
    * creates a new payment transaction. Note that we don't resubmit the entire TX, this is to avoid
@@ -7061,214 +5792,178 @@ public final class Protos {
    * * Adding any number of additional outputs as desired (leaving sufficient fee, if necessary)
    * * Adding any number of additional inputs as desired (eg to add more fee)
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.UpdatePayment}
    */
-  public static final class UpdatePayment extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class UpdatePayment extends
+      com.google.protobuf.GeneratedMessageLite<
+          UpdatePayment, UpdatePayment.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.UpdatePayment)
       UpdatePaymentOrBuilder {
-    // Use UpdatePayment.newBuilder() to construct.
-    private UpdatePayment(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private UpdatePayment() {
+      signature_ = com.google.protobuf.ByteString.EMPTY;
+      info_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private UpdatePayment(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final UpdatePayment defaultInstance;
-    public static UpdatePayment getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public UpdatePayment getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private UpdatePayment(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              clientChangeValue_ = input.readUInt64();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              signature_ = input.readBytes();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              info_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_UpdatePayment_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_UpdatePayment_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.UpdatePayment.class, org.flo.paymentchannel.Protos.UpdatePayment.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<UpdatePayment> PARSER =
-        new com.google.protobuf.AbstractParser<UpdatePayment>() {
-      public UpdatePayment parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new UpdatePayment(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<UpdatePayment> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int CLIENT_CHANGE_VALUE_FIELD_NUMBER = 1;
     private long clientChangeValue_;
     /**
-     * <code>required uint64 client_change_value = 1;</code>
-     *
      * <pre>
      * The value which is sent back to the primary.  The rest of the multisig output is left for
      * the secondary to do with as they wish.
      * </pre>
+     *
+     * <code>required uint64 client_change_value = 1;</code>
      */
     public boolean hasClientChangeValue() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required uint64 client_change_value = 1;</code>
-     *
      * <pre>
      * The value which is sent back to the primary.  The rest of the multisig output is left for
      * the secondary to do with as they wish.
      * </pre>
+     *
+     * <code>required uint64 client_change_value = 1;</code>
      */
     public long getClientChangeValue() {
       return clientChangeValue_;
+    }
+    /**
+     * <pre>
+     * The value which is sent back to the primary.  The rest of the multisig output is left for
+     * the secondary to do with as they wish.
+     * </pre>
+     *
+     * <code>required uint64 client_change_value = 1;</code>
+     */
+    private void setClientChangeValue(long value) {
+      bitField0_ |= 0x00000001;
+      clientChangeValue_ = value;
+    }
+    /**
+     * <pre>
+     * The value which is sent back to the primary.  The rest of the multisig output is left for
+     * the secondary to do with as they wish.
+     * </pre>
+     *
+     * <code>required uint64 client_change_value = 1;</code>
+     */
+    private void clearClientChangeValue() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      clientChangeValue_ = 0L;
     }
 
     public static final int SIGNATURE_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString signature_;
     /**
-     * <code>required bytes signature = 2;</code>
-     *
      * <pre>
      * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
      * spends the primary's part of the multisig contract's output.  This signature only covers
      * the primary's refund output and thus the secondary is free to do what they wish with their
      * part of the multisig output.
      * </pre>
+     *
+     * <code>required bytes signature = 2;</code>
      */
     public boolean hasSignature() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required bytes signature = 2;</code>
-     *
      * <pre>
      * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
      * spends the primary's part of the multisig contract's output.  This signature only covers
      * the primary's refund output and thus the secondary is free to do what they wish with their
      * part of the multisig output.
      * </pre>
+     *
+     * <code>required bytes signature = 2;</code>
      */
     public com.google.protobuf.ByteString getSignature() {
       return signature_;
+    }
+    /**
+     * <pre>
+     * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
+     * spends the primary's part of the multisig contract's output.  This signature only covers
+     * the primary's refund output and thus the secondary is free to do what they wish with their
+     * part of the multisig output.
+     * </pre>
+     *
+     * <code>required bytes signature = 2;</code>
+     */
+    private void setSignature(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      signature_ = value;
+    }
+    /**
+     * <pre>
+     * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
+     * spends the primary's part of the multisig contract's output.  This signature only covers
+     * the primary's refund output and thus the secondary is free to do what they wish with their
+     * part of the multisig output.
+     * </pre>
+     *
+     * <code>required bytes signature = 2;</code>
+     */
+    private void clearSignature() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      signature_ = getDefaultInstance().getSignature();
     }
 
     public static final int INFO_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString info_;
     /**
-     * <code>optional bytes info = 3;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol.
      * </pre>
+     *
+     * <code>optional bytes info = 3;</code>
      */
     public boolean hasInfo() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional bytes info = 3;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol.
      * </pre>
+     *
+     * <code>optional bytes info = 3;</code>
      */
     public com.google.protobuf.ByteString getInfo() {
       return info_;
     }
-
-    private void initFields() {
-      clientChangeValue_ = 0L;
-      signature_ = com.google.protobuf.ByteString.EMPTY;
-      info_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * Information about this update. Used to extend this protocol.
+     * </pre>
+     *
+     * <code>optional bytes info = 3;</code>
+     */
+    private void setInfo(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      info_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasClientChangeValue()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasSignature()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Information about this update. Used to extend this protocol.
+     * </pre>
+     *
+     * <code>optional bytes info = 3;</code>
+     */
+    private void clearInfo() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      info_ = getDefaultInstance().getInfo();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeUInt64(1, clientChangeValue_);
       }
@@ -7278,10 +5973,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBytes(3, info_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -7299,87 +5993,80 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, info_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.UpdatePayment parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.UpdatePayment prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.UpdatePayment}
-     *
      * <pre>
      * This message can only be used by the primary after it has received a CHANNEL_OPEN message. It
      * creates a new payment transaction. Note that we don't resubmit the entire TX, this is to avoid
@@ -7395,494 +6082,400 @@ public final class Protos {
      * * Adding any number of additional outputs as desired (leaving sufficient fee, if necessary)
      * * Adding any number of additional inputs as desired (eg to add more fee)
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.UpdatePayment}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.UpdatePayment, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.UpdatePayment)
         org.flo.paymentchannel.Protos.UpdatePaymentOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_UpdatePayment_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_UpdatePayment_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.UpdatePayment.class, org.flo.paymentchannel.Protos.UpdatePayment.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.UpdatePayment.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        clientChangeValue_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        signature_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        info_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_UpdatePayment_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.UpdatePayment getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.UpdatePayment build() {
-        org.flo.paymentchannel.Protos.UpdatePayment result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.UpdatePayment buildPartial() {
-        org.flo.paymentchannel.Protos.UpdatePayment result = new org.flo.paymentchannel.Protos.UpdatePayment(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.clientChangeValue_ = clientChangeValue_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.signature_ = signature_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.info_ = info_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.UpdatePayment) {
-          return mergeFrom((org.flo.paymentchannel.Protos.UpdatePayment)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.UpdatePayment other) {
-        if (other == org.flo.paymentchannel.Protos.UpdatePayment.getDefaultInstance()) return this;
-        if (other.hasClientChangeValue()) {
-          setClientChangeValue(other.getClientChangeValue());
-        }
-        if (other.hasSignature()) {
-          setSignature(other.getSignature());
-        }
-        if (other.hasInfo()) {
-          setInfo(other.getInfo());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasClientChangeValue()) {
-          
-          return false;
-        }
-        if (!hasSignature()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.UpdatePayment parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.UpdatePayment) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private long clientChangeValue_ ;
       /**
-       * <code>required uint64 client_change_value = 1;</code>
-       *
        * <pre>
        * The value which is sent back to the primary.  The rest of the multisig output is left for
        * the secondary to do with as they wish.
        * </pre>
+       *
+       * <code>required uint64 client_change_value = 1;</code>
        */
       public boolean hasClientChangeValue() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasClientChangeValue();
       }
       /**
-       * <code>required uint64 client_change_value = 1;</code>
-       *
        * <pre>
        * The value which is sent back to the primary.  The rest of the multisig output is left for
        * the secondary to do with as they wish.
        * </pre>
+       *
+       * <code>required uint64 client_change_value = 1;</code>
        */
       public long getClientChangeValue() {
-        return clientChangeValue_;
+        return instance.getClientChangeValue();
       }
       /**
-       * <code>required uint64 client_change_value = 1;</code>
-       *
        * <pre>
        * The value which is sent back to the primary.  The rest of the multisig output is left for
        * the secondary to do with as they wish.
        * </pre>
+       *
+       * <code>required uint64 client_change_value = 1;</code>
        */
       public Builder setClientChangeValue(long value) {
-        bitField0_ |= 0x00000001;
-        clientChangeValue_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setClientChangeValue(value);
         return this;
       }
       /**
-       * <code>required uint64 client_change_value = 1;</code>
-       *
        * <pre>
        * The value which is sent back to the primary.  The rest of the multisig output is left for
        * the secondary to do with as they wish.
        * </pre>
+       *
+       * <code>required uint64 client_change_value = 1;</code>
        */
       public Builder clearClientChangeValue() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        clientChangeValue_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearClientChangeValue();
         return this;
       }
 
-      private com.google.protobuf.ByteString signature_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes signature = 2;</code>
-       *
        * <pre>
        * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
        * spends the primary's part of the multisig contract's output.  This signature only covers
        * the primary's refund output and thus the secondary is free to do what they wish with their
        * part of the multisig output.
        * </pre>
+       *
+       * <code>required bytes signature = 2;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasSignature();
       }
       /**
-       * <code>required bytes signature = 2;</code>
-       *
        * <pre>
        * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
        * spends the primary's part of the multisig contract's output.  This signature only covers
        * the primary's refund output and thus the secondary is free to do what they wish with their
        * part of the multisig output.
        * </pre>
+       *
+       * <code>required bytes signature = 2;</code>
        */
       public com.google.protobuf.ByteString getSignature() {
-        return signature_;
+        return instance.getSignature();
       }
       /**
-       * <code>required bytes signature = 2;</code>
-       *
        * <pre>
        * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
        * spends the primary's part of the multisig contract's output.  This signature only covers
        * the primary's refund output and thus the secondary is free to do what they wish with their
        * part of the multisig output.
        * </pre>
+       *
+       * <code>required bytes signature = 2;</code>
        */
       public Builder setSignature(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        signature_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSignature(value);
         return this;
       }
       /**
-       * <code>required bytes signature = 2;</code>
-       *
        * <pre>
        * A SIGHASH_SINGLE|SIGHASH_ANYONECANPAY signature (including the postfix type byte) which
        * spends the primary's part of the multisig contract's output.  This signature only covers
        * the primary's refund output and thus the secondary is free to do what they wish with their
        * part of the multisig output.
        * </pre>
+       *
+       * <code>required bytes signature = 2;</code>
        */
       public Builder clearSignature() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        signature_ = getDefaultInstance().getSignature();
-        onChanged();
+        copyOnWrite();
+        instance.clearSignature();
         return this;
       }
 
-      private com.google.protobuf.ByteString info_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes info = 3;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol.
        * </pre>
+       *
+       * <code>optional bytes info = 3;</code>
        */
       public boolean hasInfo() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasInfo();
       }
       /**
-       * <code>optional bytes info = 3;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol.
        * </pre>
+       *
+       * <code>optional bytes info = 3;</code>
        */
       public com.google.protobuf.ByteString getInfo() {
-        return info_;
+        return instance.getInfo();
       }
       /**
-       * <code>optional bytes info = 3;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol.
        * </pre>
+       *
+       * <code>optional bytes info = 3;</code>
        */
       public Builder setInfo(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        info_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setInfo(value);
         return this;
       }
       /**
-       * <code>optional bytes info = 3;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol.
        * </pre>
+       *
+       * <code>optional bytes info = 3;</code>
        */
       public Builder clearInfo() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        info_ = getDefaultInstance().getInfo();
-        onChanged();
+        copyOnWrite();
+        instance.clearInfo();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.UpdatePayment)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.UpdatePayment();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new UpdatePayment(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasClientChangeValue()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasSignature()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.UpdatePayment other = (org.flo.paymentchannel.Protos.UpdatePayment) arg1;
+          clientChangeValue_ = visitor.visitLong(
+              hasClientChangeValue(), clientChangeValue_,
+              other.hasClientChangeValue(), other.clientChangeValue_);
+          signature_ = visitor.visitByteString(
+              hasSignature(), signature_,
+              other.hasSignature(), other.signature_);
+          info_ = visitor.visitByteString(
+              hasInfo(), info_,
+              other.hasInfo(), other.info_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  clientChangeValue_ = input.readUInt64();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  signature_ = input.readBytes();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  info_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.UpdatePayment.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.UpdatePayment)
+    private static final org.flo.paymentchannel.Protos.UpdatePayment DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new UpdatePayment();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.UpdatePayment getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<UpdatePayment> PARSER;
+
+    public static com.google.protobuf.Parser<UpdatePayment> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface PaymentAckOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.PaymentAck)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>optional bytes info = 1;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol
      * </pre>
+     *
+     * <code>optional bytes info = 1;</code>
      */
     boolean hasInfo();
     /**
-     * <code>optional bytes info = 1;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol
      * </pre>
+     *
+     * <code>optional bytes info = 1;</code>
      */
     com.google.protobuf.ByteString getInfo();
   }
   /**
-   * Protobuf type {@code paymentchannels.PaymentAck}
-   *
    * <pre>
    * This message is sent as an acknowledgement of an UpdatePayment message
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.PaymentAck}
    */
-  public static final class PaymentAck extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class PaymentAck extends
+      com.google.protobuf.GeneratedMessageLite<
+          PaymentAck, PaymentAck.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.PaymentAck)
       PaymentAckOrBuilder {
-    // Use PaymentAck.newBuilder() to construct.
-    private PaymentAck(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private PaymentAck() {
+      info_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private PaymentAck(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final PaymentAck defaultInstance;
-    public static PaymentAck getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public PaymentAck getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PaymentAck(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              info_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_PaymentAck_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_PaymentAck_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.PaymentAck.class, org.flo.paymentchannel.Protos.PaymentAck.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<PaymentAck> PARSER =
-        new com.google.protobuf.AbstractParser<PaymentAck>() {
-      public PaymentAck parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PaymentAck(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<PaymentAck> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int INFO_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString info_;
     /**
-     * <code>optional bytes info = 1;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol
      * </pre>
+     *
+     * <code>optional bytes info = 1;</code>
      */
     public boolean hasInfo() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional bytes info = 1;</code>
-     *
      * <pre>
      * Information about this update. Used to extend this protocol
      * </pre>
+     *
+     * <code>optional bytes info = 1;</code>
      */
     public com.google.protobuf.ByteString getInfo() {
       return info_;
     }
-
-    private void initFields() {
-      info_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * Information about this update. Used to extend this protocol
+     * </pre>
+     *
+     * <code>optional bytes info = 1;</code>
+     */
+    private void setInfo(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      info_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Information about this update. Used to extend this protocol
+     * </pre>
+     *
+     * <code>optional bytes info = 1;</code>
+     */
+    private void clearInfo() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      info_ = getDefaultInstance().getInfo();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, info_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -7892,441 +6485,337 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, info_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.PaymentAck parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.PaymentAck prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.PaymentAck}
-     *
      * <pre>
      * This message is sent as an acknowledgement of an UpdatePayment message
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.PaymentAck}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.PaymentAck, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.PaymentAck)
         org.flo.paymentchannel.Protos.PaymentAckOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_PaymentAck_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_PaymentAck_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.PaymentAck.class, org.flo.paymentchannel.Protos.PaymentAck.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.PaymentAck.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        info_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_PaymentAck_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.PaymentAck getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.PaymentAck build() {
-        org.flo.paymentchannel.Protos.PaymentAck result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.PaymentAck buildPartial() {
-        org.flo.paymentchannel.Protos.PaymentAck result = new org.flo.paymentchannel.Protos.PaymentAck(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.info_ = info_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.PaymentAck) {
-          return mergeFrom((org.flo.paymentchannel.Protos.PaymentAck)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.PaymentAck other) {
-        if (other == org.flo.paymentchannel.Protos.PaymentAck.getDefaultInstance()) return this;
-        if (other.hasInfo()) {
-          setInfo(other.getInfo());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.PaymentAck parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.PaymentAck) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString info_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes info = 1;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol
        * </pre>
+       *
+       * <code>optional bytes info = 1;</code>
        */
       public boolean hasInfo() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasInfo();
       }
       /**
-       * <code>optional bytes info = 1;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol
        * </pre>
+       *
+       * <code>optional bytes info = 1;</code>
        */
       public com.google.protobuf.ByteString getInfo() {
-        return info_;
+        return instance.getInfo();
       }
       /**
-       * <code>optional bytes info = 1;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol
        * </pre>
+       *
+       * <code>optional bytes info = 1;</code>
        */
       public Builder setInfo(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        info_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setInfo(value);
         return this;
       }
       /**
-       * <code>optional bytes info = 1;</code>
-       *
        * <pre>
        * Information about this update. Used to extend this protocol
        * </pre>
+       *
+       * <code>optional bytes info = 1;</code>
        */
       public Builder clearInfo() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        info_ = getDefaultInstance().getInfo();
-        onChanged();
+        copyOnWrite();
+        instance.clearInfo();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.PaymentAck)
     }
-
-    static {
-      defaultInstance = new PaymentAck(true);
-      defaultInstance.initFields();
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.PaymentAck();
+        }
+        case IS_INITIALIZED: {
+          return DEFAULT_INSTANCE;
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.PaymentAck other = (org.flo.paymentchannel.Protos.PaymentAck) arg1;
+          info_ = visitor.visitByteString(
+              hasInfo(), info_,
+              other.hasInfo(), other.info_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  info_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.PaymentAck.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.PaymentAck)
+    private static final org.flo.paymentchannel.Protos.PaymentAck DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new PaymentAck();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.PaymentAck getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<PaymentAck> PARSER;
+
+    public static com.google.protobuf.Parser<PaymentAck> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface SettlementOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.Settlement)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes tx = 3;</code>
-     *
      * <pre>
      * A copy of the fully signed final contract that settles the channel. The client can verify
      * the transaction is correct and then commit it to their wallet.
      * </pre>
+     *
+     * <code>required bytes tx = 3;</code>
      */
     boolean hasTx();
     /**
-     * <code>required bytes tx = 3;</code>
-     *
      * <pre>
      * A copy of the fully signed final contract that settles the channel. The client can verify
      * the transaction is correct and then commit it to their wallet.
      * </pre>
+     *
+     * <code>required bytes tx = 3;</code>
      */
     com.google.protobuf.ByteString getTx();
   }
   /**
    * Protobuf type {@code paymentchannels.Settlement}
    */
-  public static final class Settlement extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Settlement extends
+      com.google.protobuf.GeneratedMessageLite<
+          Settlement, Settlement.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.Settlement)
       SettlementOrBuilder {
-    // Use Settlement.newBuilder() to construct.
-    private Settlement(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Settlement() {
+      tx_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Settlement(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Settlement defaultInstance;
-    public static Settlement getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Settlement getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Settlement(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000001;
-              tx_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Settlement_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Settlement_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.Settlement.class, org.flo.paymentchannel.Protos.Settlement.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Settlement> PARSER =
-        new com.google.protobuf.AbstractParser<Settlement>() {
-      public Settlement parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Settlement(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Settlement> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int TX_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString tx_;
     /**
-     * <code>required bytes tx = 3;</code>
-     *
      * <pre>
      * A copy of the fully signed final contract that settles the channel. The client can verify
      * the transaction is correct and then commit it to their wallet.
      * </pre>
+     *
+     * <code>required bytes tx = 3;</code>
      */
     public boolean hasTx() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bytes tx = 3;</code>
-     *
      * <pre>
      * A copy of the fully signed final contract that settles the channel. The client can verify
      * the transaction is correct and then commit it to their wallet.
      * </pre>
+     *
+     * <code>required bytes tx = 3;</code>
      */
     public com.google.protobuf.ByteString getTx() {
       return tx_;
     }
-
-    private void initFields() {
-      tx_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * A copy of the fully signed final contract that settles the channel. The client can verify
+     * the transaction is correct and then commit it to their wallet.
+     * </pre>
+     *
+     * <code>required bytes tx = 3;</code>
+     */
+    private void setTx(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      tx_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasTx()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * A copy of the fully signed final contract that settles the channel. The client can verify
+     * the transaction is correct and then commit it to their wallet.
+     * </pre>
+     *
+     * <code>required bytes tx = 3;</code>
+     */
+    private void clearTx() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      tx_ = getDefaultInstance().getTx();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(3, tx_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -8336,276 +6825,259 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, tx_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Settlement parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.Settlement prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code paymentchannels.Settlement}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.Settlement, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.Settlement)
         org.flo.paymentchannel.Protos.SettlementOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Settlement_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Settlement_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.Settlement.class, org.flo.paymentchannel.Protos.Settlement.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.Settlement.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        tx_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Settlement_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.Settlement getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.Settlement.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.Settlement build() {
-        org.flo.paymentchannel.Protos.Settlement result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.Settlement buildPartial() {
-        org.flo.paymentchannel.Protos.Settlement result = new org.flo.paymentchannel.Protos.Settlement(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.tx_ = tx_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.Settlement) {
-          return mergeFrom((org.flo.paymentchannel.Protos.Settlement)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.Settlement other) {
-        if (other == org.flo.paymentchannel.Protos.Settlement.getDefaultInstance()) return this;
-        if (other.hasTx()) {
-          setTx(other.getTx());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasTx()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.Settlement parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.Settlement) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString tx_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes tx = 3;</code>
-       *
        * <pre>
        * A copy of the fully signed final contract that settles the channel. The client can verify
        * the transaction is correct and then commit it to their wallet.
        * </pre>
+       *
+       * <code>required bytes tx = 3;</code>
        */
       public boolean hasTx() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasTx();
       }
       /**
-       * <code>required bytes tx = 3;</code>
-       *
        * <pre>
        * A copy of the fully signed final contract that settles the channel. The client can verify
        * the transaction is correct and then commit it to their wallet.
        * </pre>
+       *
+       * <code>required bytes tx = 3;</code>
        */
       public com.google.protobuf.ByteString getTx() {
-        return tx_;
+        return instance.getTx();
       }
       /**
-       * <code>required bytes tx = 3;</code>
-       *
        * <pre>
        * A copy of the fully signed final contract that settles the channel. The client can verify
        * the transaction is correct and then commit it to their wallet.
        * </pre>
+       *
+       * <code>required bytes tx = 3;</code>
        */
       public Builder setTx(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        tx_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTx(value);
         return this;
       }
       /**
-       * <code>required bytes tx = 3;</code>
-       *
        * <pre>
        * A copy of the fully signed final contract that settles the channel. The client can verify
        * the transaction is correct and then commit it to their wallet.
        * </pre>
+       *
+       * <code>required bytes tx = 3;</code>
        */
       public Builder clearTx() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        tx_ = getDefaultInstance().getTx();
-        onChanged();
+        copyOnWrite();
+        instance.clearTx();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.Settlement)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.Settlement();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Settlement(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasTx()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.Settlement other = (org.flo.paymentchannel.Protos.Settlement) arg1;
+          tx_ = visitor.visitByteString(
+              hasTx(), tx_,
+              other.hasTx(), other.tx_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000001;
+                  tx_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.Settlement.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.Settlement)
+    private static final org.flo.paymentchannel.Protos.Settlement DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Settlement();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.Settlement getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Settlement> PARSER;
+
+    public static com.google.protobuf.Parser<Settlement> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ErrorOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.Error)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
@@ -8617,290 +7089,189 @@ public final class Protos {
     org.flo.paymentchannel.Protos.Error.ErrorCode getCode();
 
     /**
-     * <code>optional string explanation = 2;</code>
-     *
      * <pre>
      * NOT SAFE FOR HTML WITHOUT ESCAPING
      * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
      */
     boolean hasExplanation();
     /**
-     * <code>optional string explanation = 2;</code>
-     *
      * <pre>
      * NOT SAFE FOR HTML WITHOUT ESCAPING
      * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
      */
     java.lang.String getExplanation();
     /**
-     * <code>optional string explanation = 2;</code>
-     *
      * <pre>
      * NOT SAFE FOR HTML WITHOUT ESCAPING
      * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
      */
     com.google.protobuf.ByteString
         getExplanationBytes();
 
     /**
-     * <code>optional uint64 expected_value = 3;</code>
-     *
      * <pre>
      * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
      * </pre>
+     *
+     * <code>optional uint64 expected_value = 3;</code>
      */
     boolean hasExpectedValue();
     /**
-     * <code>optional uint64 expected_value = 3;</code>
-     *
      * <pre>
      * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
      * </pre>
+     *
+     * <code>optional uint64 expected_value = 3;</code>
      */
     long getExpectedValue();
   }
   /**
-   * Protobuf type {@code paymentchannels.Error}
-   *
    * <pre>
    * An Error can be sent by either party at any time
    * Both parties should make an effort to send either an ERROR or a CLOSE immediately before
    * closing the socket (unless they just received an ERROR or a CLOSE)
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.Error}
    */
-  public static final class Error extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Error extends
+      com.google.protobuf.GeneratedMessageLite<
+          Error, Error.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.Error)
       ErrorOrBuilder {
-    // Use Error.newBuilder() to construct.
-    private Error(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Error() {
+      code_ = 8;
+      explanation_ = "";
     }
-    private Error(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Error defaultInstance;
-    public static Error getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Error getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Error(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              int rawValue = input.readEnum();
-              org.flo.paymentchannel.Protos.Error.ErrorCode value = org.flo.paymentchannel.Protos.Error.ErrorCode.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(1, rawValue);
-              } else {
-                bitField0_ |= 0x00000001;
-                code_ = value;
-              }
-              break;
-            }
-            case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              explanation_ = bs;
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              expectedValue_ = input.readUInt64();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Error_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Error_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.paymentchannel.Protos.Error.class, org.flo.paymentchannel.Protos.Error.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Error> PARSER =
-        new com.google.protobuf.AbstractParser<Error>() {
-      public Error parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Error(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Error> getParserForType() {
-      return PARSER;
-    }
-
     /**
      * Protobuf enum {@code paymentchannels.Error.ErrorCode}
      */
     public enum ErrorCode
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
-       * <code>TIMEOUT = 1;</code>
-       *
        * <pre>
        * Protocol timeout occurred (one party hung).
        * </pre>
-       */
-      TIMEOUT(0, 1),
-      /**
-       * <code>SYNTAX_ERROR = 2;</code>
        *
+       * <code>TIMEOUT = 1;</code>
+       */
+      TIMEOUT(1),
+      /**
        * <pre>
        * Generic error indicating some message was not properly
        * </pre>
-       */
-      SYNTAX_ERROR(1, 2),
-      /**
-       * <code>NO_ACCEPTABLE_VERSION = 3;</code>
        *
+       * <code>SYNTAX_ERROR = 2;</code>
+       */
+      SYNTAX_ERROR(2),
+      /**
        * <pre>
        * formatted or was out of order.
        * </pre>
-       */
-      NO_ACCEPTABLE_VERSION(2, 3),
-      /**
-       * <code>BAD_TRANSACTION = 4;</code>
        *
+       * <code>NO_ACCEPTABLE_VERSION = 3;</code>
+       */
+      NO_ACCEPTABLE_VERSION(3),
+      /**
        * <pre>
        * A provided transaction was not in the proper structure
        * </pre>
-       */
-      BAD_TRANSACTION(3, 4),
-      /**
-       * <code>TIME_WINDOW_UNACCEPTABLE = 5;</code>
        *
+       * <code>BAD_TRANSACTION = 4;</code>
+       */
+      BAD_TRANSACTION(4),
+      /**
        * <pre>
        * (wrong inputs/outputs, sequence, lock time, signature,
        * etc)
        * </pre>
-       */
-      TIME_WINDOW_UNACCEPTABLE(4, 5),
-      /**
-       * <code>CHANNEL_VALUE_TOO_LARGE = 6;</code>
        *
+       * <code>TIME_WINDOW_UNACCEPTABLE = 5;</code>
+       */
+      TIME_WINDOW_UNACCEPTABLE(5),
+      /**
        * <pre>
        * for the primary
        * </pre>
-       */
-      CHANNEL_VALUE_TOO_LARGE(5, 6),
-      /**
-       * <code>MIN_PAYMENT_TOO_LARGE = 7;</code>
        *
+       * <code>CHANNEL_VALUE_TOO_LARGE = 6;</code>
+       */
+      CHANNEL_VALUE_TOO_LARGE(6),
+      /**
        * <pre>
        * too large for the primary
        * </pre>
+       *
+       * <code>MIN_PAYMENT_TOO_LARGE = 7;</code>
        */
-      MIN_PAYMENT_TOO_LARGE(6, 7),
+      MIN_PAYMENT_TOO_LARGE(7),
       /**
        * <code>OTHER = 8;</code>
        */
-      OTHER(7, 8),
+      OTHER(8),
       ;
 
       /**
-       * <code>TIMEOUT = 1;</code>
-       *
        * <pre>
        * Protocol timeout occurred (one party hung).
        * </pre>
+       *
+       * <code>TIMEOUT = 1;</code>
        */
       public static final int TIMEOUT_VALUE = 1;
       /**
-       * <code>SYNTAX_ERROR = 2;</code>
-       *
        * <pre>
        * Generic error indicating some message was not properly
        * </pre>
+       *
+       * <code>SYNTAX_ERROR = 2;</code>
        */
       public static final int SYNTAX_ERROR_VALUE = 2;
       /**
-       * <code>NO_ACCEPTABLE_VERSION = 3;</code>
-       *
        * <pre>
        * formatted or was out of order.
        * </pre>
+       *
+       * <code>NO_ACCEPTABLE_VERSION = 3;</code>
        */
       public static final int NO_ACCEPTABLE_VERSION_VALUE = 3;
       /**
-       * <code>BAD_TRANSACTION = 4;</code>
-       *
        * <pre>
        * A provided transaction was not in the proper structure
        * </pre>
+       *
+       * <code>BAD_TRANSACTION = 4;</code>
        */
       public static final int BAD_TRANSACTION_VALUE = 4;
       /**
-       * <code>TIME_WINDOW_UNACCEPTABLE = 5;</code>
-       *
        * <pre>
        * (wrong inputs/outputs, sequence, lock time, signature,
        * etc)
        * </pre>
+       *
+       * <code>TIME_WINDOW_UNACCEPTABLE = 5;</code>
        */
       public static final int TIME_WINDOW_UNACCEPTABLE_VALUE = 5;
       /**
-       * <code>CHANNEL_VALUE_TOO_LARGE = 6;</code>
-       *
        * <pre>
        * for the primary
        * </pre>
+       *
+       * <code>CHANNEL_VALUE_TOO_LARGE = 6;</code>
        */
       public static final int CHANNEL_VALUE_TOO_LARGE_VALUE = 6;
       /**
-       * <code>MIN_PAYMENT_TOO_LARGE = 7;</code>
-       *
        * <pre>
        * too large for the primary
        * </pre>
+       *
+       * <code>MIN_PAYMENT_TOO_LARGE = 7;</code>
        */
       public static final int MIN_PAYMENT_TOO_LARGE_VALUE = 7;
       /**
@@ -8909,9 +7280,19 @@ public final class Protos {
       public static final int OTHER_VALUE = 8;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static ErrorCode valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static ErrorCode forNumber(int value) {
         switch (value) {
           case 1: return TIMEOUT;
           case 2: return SYNTAX_ERROR;
@@ -8929,43 +7310,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<ErrorCode>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          ErrorCode> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<ErrorCode>() {
               public ErrorCode findValueByNumber(int number) {
-                return ErrorCode.valueOf(number);
+                return ErrorCode.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.Error.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final ErrorCode[] VALUES = values();
-
-      public static ErrorCode valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private ErrorCode(int index, int value) {
-        this.index = index;
+      private ErrorCode(int value) {
         this.value = value;
       }
 
@@ -8974,7 +7329,7 @@ public final class Protos {
 
     private int bitField0_;
     public static final int CODE_FIELD_NUMBER = 1;
-    private org.flo.paymentchannel.Protos.Error.ErrorCode code_;
+    private int code_;
     /**
      * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
      */
@@ -8985,117 +7340,161 @@ public final class Protos {
      * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
      */
     public org.flo.paymentchannel.Protos.Error.ErrorCode getCode() {
-      return code_;
+      org.flo.paymentchannel.Protos.Error.ErrorCode result = org.flo.paymentchannel.Protos.Error.ErrorCode.forNumber(code_);
+      return result == null ? org.flo.paymentchannel.Protos.Error.ErrorCode.OTHER : result;
+    }
+    /**
+     * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
+     */
+    private void setCode(org.flo.paymentchannel.Protos.Error.ErrorCode value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      bitField0_ |= 0x00000001;
+      code_ = value.getNumber();
+    }
+    /**
+     * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
+     */
+    private void clearCode() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      code_ = 8;
     }
 
     public static final int EXPLANATION_FIELD_NUMBER = 2;
-    private java.lang.Object explanation_;
+    private java.lang.String explanation_;
     /**
-     * <code>optional string explanation = 2;</code>
-     *
      * <pre>
      * NOT SAFE FOR HTML WITHOUT ESCAPING
      * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
      */
     public boolean hasExplanation() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional string explanation = 2;</code>
-     *
      * <pre>
      * NOT SAFE FOR HTML WITHOUT ESCAPING
      * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
      */
     public java.lang.String getExplanation() {
-      java.lang.Object ref = explanation_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          explanation_ = s;
-        }
-        return s;
-      }
+      return explanation_;
     }
     /**
-     * <code>optional string explanation = 2;</code>
-     *
      * <pre>
      * NOT SAFE FOR HTML WITHOUT ESCAPING
      * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
      */
     public com.google.protobuf.ByteString
         getExplanationBytes() {
-      java.lang.Object ref = explanation_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        explanation_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(explanation_);
+    }
+    /**
+     * <pre>
+     * NOT SAFE FOR HTML WITHOUT ESCAPING
+     * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
+     */
+    private void setExplanation(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      explanation_ = value;
+    }
+    /**
+     * <pre>
+     * NOT SAFE FOR HTML WITHOUT ESCAPING
+     * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
+     */
+    private void clearExplanation() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      explanation_ = getDefaultInstance().getExplanation();
+    }
+    /**
+     * <pre>
+     * NOT SAFE FOR HTML WITHOUT ESCAPING
+     * </pre>
+     *
+     * <code>optional string explanation = 2;</code>
+     */
+    private void setExplanationBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      explanation_ = value.toStringUtf8();
     }
 
     public static final int EXPECTED_VALUE_FIELD_NUMBER = 3;
     private long expectedValue_;
     /**
-     * <code>optional uint64 expected_value = 3;</code>
-     *
      * <pre>
      * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
      * </pre>
+     *
+     * <code>optional uint64 expected_value = 3;</code>
      */
     public boolean hasExpectedValue() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional uint64 expected_value = 3;</code>
-     *
      * <pre>
      * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
      * </pre>
+     *
+     * <code>optional uint64 expected_value = 3;</code>
      */
     public long getExpectedValue() {
       return expectedValue_;
     }
-
-    private void initFields() {
-      code_ = org.flo.paymentchannel.Protos.Error.ErrorCode.OTHER;
-      explanation_ = "";
-      expectedValue_ = 0L;
+    /**
+     * <pre>
+     * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
+     * </pre>
+     *
+     * <code>optional uint64 expected_value = 3;</code>
+     */
+    private void setExpectedValue(long value) {
+      bitField0_ |= 0x00000004;
+      expectedValue_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
+     * </pre>
+     *
+     * <code>optional uint64 expected_value = 3;</code>
+     */
+    private void clearExpectedValue() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      expectedValue_ = 0L;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, code_.getNumber());
+        output.writeEnum(1, code_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getExplanationBytes());
+        output.writeString(2, getExplanation());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeUInt64(3, expectedValue_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -9103,622 +7502,377 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, code_.getNumber());
+          .computeEnumSize(1, code_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getExplanationBytes());
+          .computeStringSize(2, getExplanation());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(3, expectedValue_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.paymentchannel.Protos.Error parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.Error parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Error parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.paymentchannel.Protos.Error parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Error parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Error parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Error parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Error parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.paymentchannel.Protos.Error parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.paymentchannel.Protos.Error parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.paymentchannel.Protos.Error prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.Error}
-     *
      * <pre>
      * An Error can be sent by either party at any time
      * Both parties should make an effort to send either an ERROR or a CLOSE immediately before
      * closing the socket (unless they just received an ERROR or a CLOSE)
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.Error}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.paymentchannel.Protos.Error, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.Error)
         org.flo.paymentchannel.Protos.ErrorOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Error_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Error_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.paymentchannel.Protos.Error.class, org.flo.paymentchannel.Protos.Error.Builder.class);
-      }
-
       // Construct using org.flo.paymentchannel.Protos.Error.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        code_ = org.flo.paymentchannel.Protos.Error.ErrorCode.OTHER;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        explanation_ = "";
-        bitField0_ = (bitField0_ & ~0x00000002);
-        expectedValue_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.paymentchannel.Protos.internal_static_paymentchannels_Error_descriptor;
-      }
-
-      public org.flo.paymentchannel.Protos.Error getDefaultInstanceForType() {
-        return org.flo.paymentchannel.Protos.Error.getDefaultInstance();
-      }
-
-      public org.flo.paymentchannel.Protos.Error build() {
-        org.flo.paymentchannel.Protos.Error result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.paymentchannel.Protos.Error buildPartial() {
-        org.flo.paymentchannel.Protos.Error result = new org.flo.paymentchannel.Protos.Error(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.code_ = code_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.explanation_ = explanation_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.expectedValue_ = expectedValue_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.paymentchannel.Protos.Error) {
-          return mergeFrom((org.flo.paymentchannel.Protos.Error)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.paymentchannel.Protos.Error other) {
-        if (other == org.flo.paymentchannel.Protos.Error.getDefaultInstance()) return this;
-        if (other.hasCode()) {
-          setCode(other.getCode());
-        }
-        if (other.hasExplanation()) {
-          bitField0_ |= 0x00000002;
-          explanation_ = other.explanation_;
-          onChanged();
-        }
-        if (other.hasExpectedValue()) {
-          setExpectedValue(other.getExpectedValue());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.paymentchannel.Protos.Error parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.paymentchannel.Protos.Error) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private org.flo.paymentchannel.Protos.Error.ErrorCode code_ = org.flo.paymentchannel.Protos.Error.ErrorCode.OTHER;
       /**
        * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
        */
       public boolean hasCode() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasCode();
       }
       /**
        * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
        */
       public org.flo.paymentchannel.Protos.Error.ErrorCode getCode() {
-        return code_;
+        return instance.getCode();
       }
       /**
        * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
        */
       public Builder setCode(org.flo.paymentchannel.Protos.Error.ErrorCode value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        code_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setCode(value);
         return this;
       }
       /**
        * <code>optional .paymentchannels.Error.ErrorCode code = 1 [default = OTHER];</code>
        */
       public Builder clearCode() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        code_ = org.flo.paymentchannel.Protos.Error.ErrorCode.OTHER;
-        onChanged();
+        copyOnWrite();
+        instance.clearCode();
         return this;
       }
 
-      private java.lang.Object explanation_ = "";
       /**
-       * <code>optional string explanation = 2;</code>
-       *
        * <pre>
        * NOT SAFE FOR HTML WITHOUT ESCAPING
        * </pre>
+       *
+       * <code>optional string explanation = 2;</code>
        */
       public boolean hasExplanation() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasExplanation();
       }
       /**
-       * <code>optional string explanation = 2;</code>
-       *
        * <pre>
        * NOT SAFE FOR HTML WITHOUT ESCAPING
        * </pre>
+       *
+       * <code>optional string explanation = 2;</code>
        */
       public java.lang.String getExplanation() {
-        java.lang.Object ref = explanation_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            explanation_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getExplanation();
       }
       /**
-       * <code>optional string explanation = 2;</code>
-       *
        * <pre>
        * NOT SAFE FOR HTML WITHOUT ESCAPING
        * </pre>
+       *
+       * <code>optional string explanation = 2;</code>
        */
       public com.google.protobuf.ByteString
           getExplanationBytes() {
-        java.lang.Object ref = explanation_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          explanation_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getExplanationBytes();
       }
       /**
-       * <code>optional string explanation = 2;</code>
-       *
        * <pre>
        * NOT SAFE FOR HTML WITHOUT ESCAPING
        * </pre>
+       *
+       * <code>optional string explanation = 2;</code>
        */
       public Builder setExplanation(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        explanation_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setExplanation(value);
         return this;
       }
       /**
-       * <code>optional string explanation = 2;</code>
-       *
        * <pre>
        * NOT SAFE FOR HTML WITHOUT ESCAPING
        * </pre>
+       *
+       * <code>optional string explanation = 2;</code>
        */
       public Builder clearExplanation() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        explanation_ = getDefaultInstance().getExplanation();
-        onChanged();
+        copyOnWrite();
+        instance.clearExplanation();
         return this;
       }
       /**
-       * <code>optional string explanation = 2;</code>
-       *
        * <pre>
        * NOT SAFE FOR HTML WITHOUT ESCAPING
        * </pre>
+       *
+       * <code>optional string explanation = 2;</code>
        */
       public Builder setExplanationBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        explanation_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setExplanationBytes(value);
         return this;
       }
 
-      private long expectedValue_ ;
       /**
-       * <code>optional uint64 expected_value = 3;</code>
-       *
        * <pre>
        * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
        * </pre>
+       *
+       * <code>optional uint64 expected_value = 3;</code>
        */
       public boolean hasExpectedValue() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasExpectedValue();
       }
       /**
-       * <code>optional uint64 expected_value = 3;</code>
-       *
        * <pre>
        * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
        * </pre>
+       *
+       * <code>optional uint64 expected_value = 3;</code>
        */
       public long getExpectedValue() {
-        return expectedValue_;
+        return instance.getExpectedValue();
       }
       /**
-       * <code>optional uint64 expected_value = 3;</code>
-       *
        * <pre>
        * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
        * </pre>
+       *
+       * <code>optional uint64 expected_value = 3;</code>
        */
       public Builder setExpectedValue(long value) {
-        bitField0_ |= 0x00000004;
-        expectedValue_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setExpectedValue(value);
         return this;
       }
       /**
-       * <code>optional uint64 expected_value = 3;</code>
-       *
        * <pre>
        * Can be set by the client when erroring to the server if a value was out of range. Can help with debugging.
        * </pre>
+       *
+       * <code>optional uint64 expected_value = 3;</code>
        */
       public Builder clearExpectedValue() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        expectedValue_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearExpectedValue();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.Error)
     }
-
-    static {
-      defaultInstance = new Error(true);
-      defaultInstance.initFields();
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.paymentchannel.Protos.Error();
+        }
+        case IS_INITIALIZED: {
+          return DEFAULT_INSTANCE;
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.paymentchannel.Protos.Error other = (org.flo.paymentchannel.Protos.Error) arg1;
+          code_ = visitor.visitInt(hasCode(), code_,
+              other.hasCode(), other.code_);
+          explanation_ = visitor.visitString(
+              hasExplanation(), explanation_,
+              other.hasExplanation(), other.explanation_);
+          expectedValue_ = visitor.visitLong(
+              hasExpectedValue(), expectedValue_,
+              other.hasExpectedValue(), other.expectedValue_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  int rawValue = input.readEnum();
+                  org.flo.paymentchannel.Protos.Error.ErrorCode value = org.flo.paymentchannel.Protos.Error.ErrorCode.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(1, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000001;
+                    code_ = rawValue;
+                  }
+                  break;
+                }
+                case 18: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000002;
+                  explanation_ = s;
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000004;
+                  expectedValue_ = input.readUInt64();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.paymentchannel.Protos.Error.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.Error)
+    private static final org.flo.paymentchannel.Protos.Error DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Error();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.paymentchannel.Protos.Error getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Error> PARSER;
+
+    public static com.google.protobuf.Parser<Error> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_TwoWayChannelMessage_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_TwoWayChannelMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_ClientVersion_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_ClientVersion_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_ServerVersion_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_ServerVersion_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_Initiate_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_Initiate_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_ProvideRefund_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_ProvideRefund_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_ReturnRefund_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_ReturnRefund_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_ProvideContract_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_ProvideContract_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_UpdatePayment_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_UpdatePayment_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_PaymentAck_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_PaymentAck_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_Settlement_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_Settlement_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_Error_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_Error_fieldAccessorTable;
 
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
-    return descriptor;
-  }
-  private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
   static {
-    java.lang.String[] descriptorData = {
-      "\n\024paymentchannel.proto\022\017paymentchannels\"" +
-      "\260\006\n\024TwoWayChannelMessage\022?\n\004type\030\001 \002(\01621" +
-      ".paymentchannels.TwoWayChannelMessage.Me" +
-      "ssageType\0226\n\016client_version\030\002 \001(\0132\036.paym" +
-      "entchannels.ClientVersion\0226\n\016server_vers" +
-      "ion\030\003 \001(\0132\036.paymentchannels.ServerVersio" +
-      "n\022+\n\010initiate\030\004 \001(\0132\031.paymentchannels.In" +
-      "itiate\0226\n\016provide_refund\030\005 \001(\0132\036.payment" +
-      "channels.ProvideRefund\0224\n\rreturn_refund\030" +
-      "\006 \001(\0132\035.paymentchannels.ReturnRefund\022:\n\020",
-      "provide_contract\030\007 \001(\0132 .paymentchannels" +
-      ".ProvideContract\0226\n\016update_payment\030\010 \001(\013" +
-      "2\036.paymentchannels.UpdatePayment\0220\n\013paym" +
-      "ent_ack\030\013 \001(\0132\033.paymentchannels.PaymentA" +
-      "ck\022/\n\nsettlement\030\t \001(\0132\033.paymentchannels" +
-      ".Settlement\022%\n\005error\030\n \001(\0132\026.paymentchan" +
-      "nels.Error\"\315\001\n\013MessageType\022\022\n\016CLIENT_VER" +
-      "SION\020\001\022\022\n\016SERVER_VERSION\020\002\022\014\n\010INITIATE\020\003" +
-      "\022\022\n\016PROVIDE_REFUND\020\004\022\021\n\rRETURN_REFUND\020\005\022" +
-      "\024\n\020PROVIDE_CONTRACT\020\006\022\020\n\014CHANNEL_OPEN\020\007\022",
-      "\022\n\016UPDATE_PAYMENT\020\010\022\017\n\013PAYMENT_ACK\020\013\022\t\n\005" +
-      "CLOSE\020\t\022\t\n\005ERROR\020\n\"y\n\rClientVersion\022\r\n\005m" +
-      "ajor\030\001 \002(\005\022\020\n\005minor\030\002 \001(\005:\0010\022&\n\036previous" +
-      "_channel_contract_hash\030\003 \001(\014\022\037\n\020time_win" +
-      "dow_secs\030\004 \001(\004:\00586340\"0\n\rServerVersion\022\r" +
-      "\n\005major\030\001 \002(\005\022\020\n\005minor\030\002 \001(\005:\0010\"r\n\010Initi" +
-      "ate\022\024\n\014multisig_key\030\001 \002(\014\022!\n\031min_accepte" +
-      "d_channel_size\030\002 \002(\004\022\030\n\020expire_time_secs" +
-      "\030\003 \002(\004\022\023\n\013min_payment\030\004 \002(\004\"1\n\rProvideRe" +
-      "fund\022\024\n\014multisig_key\030\001 \002(\014\022\n\n\002tx\030\002 \002(\014\"!",
-      "\n\014ReturnRefund\022\021\n\tsignature\030\001 \002(\014\"j\n\017Pro" +
-      "videContract\022\n\n\002tx\030\001 \002(\014\0227\n\017initial_paym" +
-      "ent\030\002 \002(\0132\036.paymentchannels.UpdatePaymen" +
-      "t\022\022\n\nclient_key\030\003 \001(\014\"M\n\rUpdatePayment\022\033" +
-      "\n\023client_change_value\030\001 \002(\004\022\021\n\tsignature" +
-      "\030\002 \002(\014\022\014\n\004info\030\003 \001(\014\"\032\n\nPaymentAck\022\014\n\004in" +
-      "fo\030\001 \001(\014\"\030\n\nSettlement\022\n\n\002tx\030\003 \002(\014\"\251\002\n\005E" +
-      "rror\0225\n\004code\030\001 \001(\0162 .paymentchannels.Err" +
-      "or.ErrorCode:\005OTHER\022\023\n\013explanation\030\002 \001(\t" +
-      "\022\026\n\016expected_value\030\003 \001(\004\"\273\001\n\tErrorCode\022\013",
-      "\n\007TIMEOUT\020\001\022\020\n\014SYNTAX_ERROR\020\002\022\031\n\025NO_ACCE" +
-      "PTABLE_VERSION\020\003\022\023\n\017BAD_TRANSACTION\020\004\022\034\n" +
-      "\030TIME_WINDOW_UNACCEPTABLE\020\005\022\033\n\027CHANNEL_V" +
-      "ALUE_TOO_LARGE\020\006\022\031\n\025MIN_PAYMENT_TOO_LARG" +
-      "E\020\007\022\t\n\005OTHER\020\010B \n\026org.flo.paymentchannel" +
-      "B\006Protos"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-    internal_static_paymentchannels_TwoWayChannelMessage_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_paymentchannels_TwoWayChannelMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_TwoWayChannelMessage_descriptor,
-        new java.lang.String[] { "Type", "ClientVersion", "ServerVersion", "Initiate", "ProvideRefund", "ReturnRefund", "ProvideContract", "UpdatePayment", "PaymentAck", "Settlement", "Error", });
-    internal_static_paymentchannels_ClientVersion_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_paymentchannels_ClientVersion_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_ClientVersion_descriptor,
-        new java.lang.String[] { "Major", "Minor", "PreviousChannelContractHash", "TimeWindowSecs", });
-    internal_static_paymentchannels_ServerVersion_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_paymentchannels_ServerVersion_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_ServerVersion_descriptor,
-        new java.lang.String[] { "Major", "Minor", });
-    internal_static_paymentchannels_Initiate_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_paymentchannels_Initiate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_Initiate_descriptor,
-        new java.lang.String[] { "MultisigKey", "MinAcceptedChannelSize", "ExpireTimeSecs", "MinPayment", });
-    internal_static_paymentchannels_ProvideRefund_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_paymentchannels_ProvideRefund_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_ProvideRefund_descriptor,
-        new java.lang.String[] { "MultisigKey", "Tx", });
-    internal_static_paymentchannels_ReturnRefund_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_paymentchannels_ReturnRefund_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_ReturnRefund_descriptor,
-        new java.lang.String[] { "Signature", });
-    internal_static_paymentchannels_ProvideContract_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_paymentchannels_ProvideContract_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_ProvideContract_descriptor,
-        new java.lang.String[] { "Tx", "InitialPayment", "ClientKey", });
-    internal_static_paymentchannels_UpdatePayment_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_paymentchannels_UpdatePayment_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_UpdatePayment_descriptor,
-        new java.lang.String[] { "ClientChangeValue", "Signature", "Info", });
-    internal_static_paymentchannels_PaymentAck_descriptor =
-      getDescriptor().getMessageTypes().get(8);
-    internal_static_paymentchannels_PaymentAck_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_PaymentAck_descriptor,
-        new java.lang.String[] { "Info", });
-    internal_static_paymentchannels_Settlement_descriptor =
-      getDescriptor().getMessageTypes().get(9);
-    internal_static_paymentchannels_Settlement_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_Settlement_descriptor,
-        new java.lang.String[] { "Tx", });
-    internal_static_paymentchannels_Error_descriptor =
-      getDescriptor().getMessageTypes().get(10);
-    internal_static_paymentchannels_Error_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_Error_descriptor,
-        new java.lang.String[] { "Code", "Explanation", "ExpectedValue", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/floj-core/src/main/java/org/flo/protocols/payments/Protos.java
+++ b/floj-core/src/main/java/org/flo/protocols/payments/Protos.java
@@ -6,229 +6,166 @@ package org.flo.protocols.payments;
 public final class Protos {
   private Protos() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
   }
   public interface OutputOrBuilder extends
       // @@protoc_insertion_point(interface_extends:payments.Output)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>optional uint64 amount = 1 [default = 0];</code>
-     *
      * <pre>
      * amount is integer-number-of-satoshis
      * </pre>
+     *
+     * <code>optional uint64 amount = 1 [default = 0];</code>
      */
     boolean hasAmount();
     /**
-     * <code>optional uint64 amount = 1 [default = 0];</code>
-     *
      * <pre>
      * amount is integer-number-of-satoshis
      * </pre>
+     *
+     * <code>optional uint64 amount = 1 [default = 0];</code>
      */
     long getAmount();
 
     /**
-     * <code>required bytes script = 2;</code>
-     *
      * <pre>
      * usually one of the standard Script forms
      * </pre>
+     *
+     * <code>required bytes script = 2;</code>
      */
     boolean hasScript();
     /**
-     * <code>required bytes script = 2;</code>
-     *
      * <pre>
      * usually one of the standard Script forms
      * </pre>
+     *
+     * <code>required bytes script = 2;</code>
      */
     com.google.protobuf.ByteString getScript();
   }
   /**
-   * Protobuf type {@code payments.Output}
-   *
    * <pre>
    * Generalized form of "send payment to this/these flo addresses"
    * </pre>
+   *
+   * Protobuf type {@code payments.Output}
    */
-  public static final class Output extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Output extends
+      com.google.protobuf.GeneratedMessageLite<
+          Output, Output.Builder> implements
       // @@protoc_insertion_point(message_implements:payments.Output)
       OutputOrBuilder {
-    // Use Output.newBuilder() to construct.
-    private Output(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Output() {
+      script_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Output(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Output defaultInstance;
-    public static Output getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Output getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Output(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              amount_ = input.readUInt64();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              script_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_Output_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_Output_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.protocols.payments.Protos.Output.class, org.flo.protocols.payments.Protos.Output.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Output> PARSER =
-        new com.google.protobuf.AbstractParser<Output>() {
-      public Output parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Output(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Output> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int AMOUNT_FIELD_NUMBER = 1;
     private long amount_;
     /**
-     * <code>optional uint64 amount = 1 [default = 0];</code>
-     *
      * <pre>
      * amount is integer-number-of-satoshis
      * </pre>
+     *
+     * <code>optional uint64 amount = 1 [default = 0];</code>
      */
     public boolean hasAmount() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional uint64 amount = 1 [default = 0];</code>
-     *
      * <pre>
      * amount is integer-number-of-satoshis
      * </pre>
+     *
+     * <code>optional uint64 amount = 1 [default = 0];</code>
      */
     public long getAmount() {
       return amount_;
+    }
+    /**
+     * <pre>
+     * amount is integer-number-of-satoshis
+     * </pre>
+     *
+     * <code>optional uint64 amount = 1 [default = 0];</code>
+     */
+    private void setAmount(long value) {
+      bitField0_ |= 0x00000001;
+      amount_ = value;
+    }
+    /**
+     * <pre>
+     * amount is integer-number-of-satoshis
+     * </pre>
+     *
+     * <code>optional uint64 amount = 1 [default = 0];</code>
+     */
+    private void clearAmount() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      amount_ = 0L;
     }
 
     public static final int SCRIPT_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString script_;
     /**
-     * <code>required bytes script = 2;</code>
-     *
      * <pre>
      * usually one of the standard Script forms
      * </pre>
+     *
+     * <code>required bytes script = 2;</code>
      */
     public boolean hasScript() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required bytes script = 2;</code>
-     *
      * <pre>
      * usually one of the standard Script forms
      * </pre>
+     *
+     * <code>required bytes script = 2;</code>
      */
     public com.google.protobuf.ByteString getScript() {
       return script_;
     }
-
-    private void initFields() {
-      amount_ = 0L;
-      script_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * usually one of the standard Script forms
+     * </pre>
+     *
+     * <code>required bytes script = 2;</code>
+     */
+    private void setScript(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      script_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasScript()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * usually one of the standard Script forms
+     * </pre>
+     *
+     * <code>required bytes script = 2;</code>
+     */
+    private void clearScript() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      script_ = getDefaultInstance().getScript();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeUInt64(1, amount_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, script_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -242,963 +179,1027 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, script_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.protocols.payments.Protos.Output parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.Output parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Output parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.Output parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Output parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.Output parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Output parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.Output parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Output parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.Output parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.protocols.payments.Protos.Output prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code payments.Output}
-     *
      * <pre>
      * Generalized form of "send payment to this/these flo addresses"
      * </pre>
+     *
+     * Protobuf type {@code payments.Output}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.protocols.payments.Protos.Output, Builder> implements
         // @@protoc_insertion_point(builder_implements:payments.Output)
         org.flo.protocols.payments.Protos.OutputOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_Output_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_Output_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.protocols.payments.Protos.Output.class, org.flo.protocols.payments.Protos.Output.Builder.class);
-      }
-
       // Construct using org.flo.protocols.payments.Protos.Output.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        amount_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        script_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_Output_descriptor;
-      }
-
-      public org.flo.protocols.payments.Protos.Output getDefaultInstanceForType() {
-        return org.flo.protocols.payments.Protos.Output.getDefaultInstance();
-      }
-
-      public org.flo.protocols.payments.Protos.Output build() {
-        org.flo.protocols.payments.Protos.Output result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.protocols.payments.Protos.Output buildPartial() {
-        org.flo.protocols.payments.Protos.Output result = new org.flo.protocols.payments.Protos.Output(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.amount_ = amount_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.script_ = script_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.protocols.payments.Protos.Output) {
-          return mergeFrom((org.flo.protocols.payments.Protos.Output)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.protocols.payments.Protos.Output other) {
-        if (other == org.flo.protocols.payments.Protos.Output.getDefaultInstance()) return this;
-        if (other.hasAmount()) {
-          setAmount(other.getAmount());
-        }
-        if (other.hasScript()) {
-          setScript(other.getScript());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasScript()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.protocols.payments.Protos.Output parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.protocols.payments.Protos.Output) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private long amount_ ;
       /**
-       * <code>optional uint64 amount = 1 [default = 0];</code>
-       *
        * <pre>
        * amount is integer-number-of-satoshis
        * </pre>
+       *
+       * <code>optional uint64 amount = 1 [default = 0];</code>
        */
       public boolean hasAmount() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasAmount();
       }
       /**
-       * <code>optional uint64 amount = 1 [default = 0];</code>
-       *
        * <pre>
        * amount is integer-number-of-satoshis
        * </pre>
+       *
+       * <code>optional uint64 amount = 1 [default = 0];</code>
        */
       public long getAmount() {
-        return amount_;
+        return instance.getAmount();
       }
       /**
-       * <code>optional uint64 amount = 1 [default = 0];</code>
-       *
        * <pre>
        * amount is integer-number-of-satoshis
        * </pre>
+       *
+       * <code>optional uint64 amount = 1 [default = 0];</code>
        */
       public Builder setAmount(long value) {
-        bitField0_ |= 0x00000001;
-        amount_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setAmount(value);
         return this;
       }
       /**
-       * <code>optional uint64 amount = 1 [default = 0];</code>
-       *
        * <pre>
        * amount is integer-number-of-satoshis
        * </pre>
+       *
+       * <code>optional uint64 amount = 1 [default = 0];</code>
        */
       public Builder clearAmount() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        amount_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearAmount();
         return this;
       }
 
-      private com.google.protobuf.ByteString script_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes script = 2;</code>
-       *
        * <pre>
        * usually one of the standard Script forms
        * </pre>
+       *
+       * <code>required bytes script = 2;</code>
        */
       public boolean hasScript() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasScript();
       }
       /**
-       * <code>required bytes script = 2;</code>
-       *
        * <pre>
        * usually one of the standard Script forms
        * </pre>
+       *
+       * <code>required bytes script = 2;</code>
        */
       public com.google.protobuf.ByteString getScript() {
-        return script_;
+        return instance.getScript();
       }
       /**
-       * <code>required bytes script = 2;</code>
-       *
        * <pre>
        * usually one of the standard Script forms
        * </pre>
+       *
+       * <code>required bytes script = 2;</code>
        */
       public Builder setScript(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        script_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setScript(value);
         return this;
       }
       /**
-       * <code>required bytes script = 2;</code>
-       *
        * <pre>
        * usually one of the standard Script forms
        * </pre>
+       *
+       * <code>required bytes script = 2;</code>
        */
       public Builder clearScript() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        script_ = getDefaultInstance().getScript();
-        onChanged();
+        copyOnWrite();
+        instance.clearScript();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:payments.Output)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.protocols.payments.Protos.Output();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Output(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasScript()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.protocols.payments.Protos.Output other = (org.flo.protocols.payments.Protos.Output) arg1;
+          amount_ = visitor.visitLong(
+              hasAmount(), amount_,
+              other.hasAmount(), other.amount_);
+          script_ = visitor.visitByteString(
+              hasScript(), script_,
+              other.hasScript(), other.script_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  amount_ = input.readUInt64();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  script_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.protocols.payments.Protos.Output.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:payments.Output)
+    private static final org.flo.protocols.payments.Protos.Output DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Output();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.protocols.payments.Protos.Output getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Output> PARSER;
+
+    public static com.google.protobuf.Parser<Output> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface PaymentDetailsOrBuilder extends
       // @@protoc_insertion_point(interface_extends:payments.PaymentDetails)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>optional string network = 1 [default = "main"];</code>
-     *
      * <pre>
      * "main" or "test"
      * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
      */
     boolean hasNetwork();
     /**
-     * <code>optional string network = 1 [default = "main"];</code>
-     *
      * <pre>
      * "main" or "test"
      * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
      */
     java.lang.String getNetwork();
     /**
-     * <code>optional string network = 1 [default = "main"];</code>
-     *
      * <pre>
      * "main" or "test"
      * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
      */
     com.google.protobuf.ByteString
         getNetworkBytes();
 
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     java.util.List<org.flo.protocols.payments.Protos.Output> 
         getOutputsList();
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     org.flo.protocols.payments.Protos.Output getOutputs(int index);
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     int getOutputsCount();
-    /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
-     * <pre>
-     * Where payment should be sent
-     * </pre>
-     */
-    java.util.List<? extends org.flo.protocols.payments.Protos.OutputOrBuilder> 
-        getOutputsOrBuilderList();
-    /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
-     * <pre>
-     * Where payment should be sent
-     * </pre>
-     */
-    org.flo.protocols.payments.Protos.OutputOrBuilder getOutputsOrBuilder(
-        int index);
 
     /**
-     * <code>required uint64 time = 3;</code>
-     *
      * <pre>
      * Timestamp; when payment request created
      * </pre>
+     *
+     * <code>required uint64 time = 3;</code>
      */
     boolean hasTime();
     /**
-     * <code>required uint64 time = 3;</code>
-     *
      * <pre>
      * Timestamp; when payment request created
      * </pre>
+     *
+     * <code>required uint64 time = 3;</code>
      */
     long getTime();
 
     /**
-     * <code>optional uint64 expires = 4;</code>
-     *
      * <pre>
      * Timestamp; when this request should be considered invalid
      * </pre>
+     *
+     * <code>optional uint64 expires = 4;</code>
      */
     boolean hasExpires();
     /**
-     * <code>optional uint64 expires = 4;</code>
-     *
      * <pre>
      * Timestamp; when this request should be considered invalid
      * </pre>
+     *
+     * <code>optional uint64 expires = 4;</code>
      */
     long getExpires();
 
     /**
-     * <code>optional string memo = 5;</code>
-     *
      * <pre>
      * Human-readable description of request for the customer
      * </pre>
+     *
+     * <code>optional string memo = 5;</code>
      */
     boolean hasMemo();
     /**
-     * <code>optional string memo = 5;</code>
-     *
      * <pre>
      * Human-readable description of request for the customer
      * </pre>
+     *
+     * <code>optional string memo = 5;</code>
      */
     java.lang.String getMemo();
     /**
-     * <code>optional string memo = 5;</code>
-     *
      * <pre>
      * Human-readable description of request for the customer
      * </pre>
+     *
+     * <code>optional string memo = 5;</code>
      */
     com.google.protobuf.ByteString
         getMemoBytes();
 
     /**
-     * <code>optional string payment_url = 6;</code>
-     *
      * <pre>
      * URL to send Payment and get PaymentACK
      * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
      */
     boolean hasPaymentUrl();
     /**
-     * <code>optional string payment_url = 6;</code>
-     *
      * <pre>
      * URL to send Payment and get PaymentACK
      * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
      */
     java.lang.String getPaymentUrl();
     /**
-     * <code>optional string payment_url = 6;</code>
-     *
      * <pre>
      * URL to send Payment and get PaymentACK
      * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
      */
     com.google.protobuf.ByteString
         getPaymentUrlBytes();
 
     /**
-     * <code>optional bytes merchant_data = 7;</code>
-     *
      * <pre>
      * Arbitrary data to include in the Payment message
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 7;</code>
      */
     boolean hasMerchantData();
     /**
-     * <code>optional bytes merchant_data = 7;</code>
-     *
      * <pre>
      * Arbitrary data to include in the Payment message
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 7;</code>
      */
     com.google.protobuf.ByteString getMerchantData();
   }
   /**
    * Protobuf type {@code payments.PaymentDetails}
    */
-  public static final class PaymentDetails extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class PaymentDetails extends
+      com.google.protobuf.GeneratedMessageLite<
+          PaymentDetails, PaymentDetails.Builder> implements
       // @@protoc_insertion_point(message_implements:payments.PaymentDetails)
       PaymentDetailsOrBuilder {
-    // Use PaymentDetails.newBuilder() to construct.
-    private PaymentDetails(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private PaymentDetails() {
+      network_ = "main";
+      outputs_ = emptyProtobufList();
+      memo_ = "";
+      paymentUrl_ = "";
+      merchantData_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private PaymentDetails(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final PaymentDetails defaultInstance;
-    public static PaymentDetails getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public PaymentDetails getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PaymentDetails(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              network_ = bs;
-              break;
-            }
-            case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                outputs_ = new java.util.ArrayList<org.flo.protocols.payments.Protos.Output>();
-                mutable_bitField0_ |= 0x00000002;
-              }
-              outputs_.add(input.readMessage(org.flo.protocols.payments.Protos.Output.PARSER, extensionRegistry));
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000002;
-              time_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000004;
-              expires_ = input.readUInt64();
-              break;
-            }
-            case 42: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000008;
-              memo_ = bs;
-              break;
-            }
-            case 50: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000010;
-              paymentUrl_ = bs;
-              break;
-            }
-            case 58: {
-              bitField0_ |= 0x00000020;
-              merchantData_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-          outputs_ = java.util.Collections.unmodifiableList(outputs_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_PaymentDetails_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_PaymentDetails_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.protocols.payments.Protos.PaymentDetails.class, org.flo.protocols.payments.Protos.PaymentDetails.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<PaymentDetails> PARSER =
-        new com.google.protobuf.AbstractParser<PaymentDetails>() {
-      public PaymentDetails parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PaymentDetails(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<PaymentDetails> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int NETWORK_FIELD_NUMBER = 1;
-    private java.lang.Object network_;
+    private java.lang.String network_;
     /**
-     * <code>optional string network = 1 [default = "main"];</code>
-     *
      * <pre>
      * "main" or "test"
      * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
      */
     public boolean hasNetwork() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional string network = 1 [default = "main"];</code>
-     *
      * <pre>
      * "main" or "test"
      * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
      */
     public java.lang.String getNetwork() {
-      java.lang.Object ref = network_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          network_ = s;
-        }
-        return s;
-      }
+      return network_;
     }
     /**
-     * <code>optional string network = 1 [default = "main"];</code>
-     *
      * <pre>
      * "main" or "test"
      * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
      */
     public com.google.protobuf.ByteString
         getNetworkBytes() {
-      java.lang.Object ref = network_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        network_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(network_);
+    }
+    /**
+     * <pre>
+     * "main" or "test"
+     * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
+     */
+    private void setNetwork(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      network_ = value;
+    }
+    /**
+     * <pre>
+     * "main" or "test"
+     * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
+     */
+    private void clearNetwork() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      network_ = getDefaultInstance().getNetwork();
+    }
+    /**
+     * <pre>
+     * "main" or "test"
+     * </pre>
+     *
+     * <code>optional string network = 1 [default = "main"];</code>
+     */
+    private void setNetworkBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      network_ = value.toStringUtf8();
     }
 
     public static final int OUTPUTS_FIELD_NUMBER = 2;
-    private java.util.List<org.flo.protocols.payments.Protos.Output> outputs_;
+    private com.google.protobuf.Internal.ProtobufList<org.flo.protocols.payments.Protos.Output> outputs_;
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     public java.util.List<org.flo.protocols.payments.Protos.Output> getOutputsList() {
       return outputs_;
     }
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     public java.util.List<? extends org.flo.protocols.payments.Protos.OutputOrBuilder> 
         getOutputsOrBuilderList() {
       return outputs_;
     }
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     public int getOutputsCount() {
       return outputs_.size();
     }
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     public org.flo.protocols.payments.Protos.Output getOutputs(int index) {
       return outputs_.get(index);
     }
     /**
-     * <code>repeated .payments.Output outputs = 2;</code>
-     *
      * <pre>
      * Where payment should be sent
      * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
      */
     public org.flo.protocols.payments.Protos.OutputOrBuilder getOutputsOrBuilder(
         int index) {
       return outputs_.get(index);
     }
+    private void ensureOutputsIsMutable() {
+      if (!outputs_.isModifiable()) {
+        outputs_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(outputs_);
+       }
+    }
+
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void setOutputs(
+        int index, org.flo.protocols.payments.Protos.Output value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureOutputsIsMutable();
+      outputs_.set(index, value);
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void setOutputs(
+        int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
+      ensureOutputsIsMutable();
+      outputs_.set(index, builderForValue.build());
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void addOutputs(org.flo.protocols.payments.Protos.Output value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureOutputsIsMutable();
+      outputs_.add(value);
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void addOutputs(
+        int index, org.flo.protocols.payments.Protos.Output value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureOutputsIsMutable();
+      outputs_.add(index, value);
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void addOutputs(
+        org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
+      ensureOutputsIsMutable();
+      outputs_.add(builderForValue.build());
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void addOutputs(
+        int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
+      ensureOutputsIsMutable();
+      outputs_.add(index, builderForValue.build());
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void addAllOutputs(
+        java.lang.Iterable<? extends org.flo.protocols.payments.Protos.Output> values) {
+      ensureOutputsIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, outputs_);
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void clearOutputs() {
+      outputs_ = emptyProtobufList();
+    }
+    /**
+     * <pre>
+     * Where payment should be sent
+     * </pre>
+     *
+     * <code>repeated .payments.Output outputs = 2;</code>
+     */
+    private void removeOutputs(int index) {
+      ensureOutputsIsMutable();
+      outputs_.remove(index);
+    }
 
     public static final int TIME_FIELD_NUMBER = 3;
     private long time_;
     /**
-     * <code>required uint64 time = 3;</code>
-     *
      * <pre>
      * Timestamp; when payment request created
      * </pre>
+     *
+     * <code>required uint64 time = 3;</code>
      */
     public boolean hasTime() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required uint64 time = 3;</code>
-     *
      * <pre>
      * Timestamp; when payment request created
      * </pre>
+     *
+     * <code>required uint64 time = 3;</code>
      */
     public long getTime() {
       return time_;
+    }
+    /**
+     * <pre>
+     * Timestamp; when payment request created
+     * </pre>
+     *
+     * <code>required uint64 time = 3;</code>
+     */
+    private void setTime(long value) {
+      bitField0_ |= 0x00000002;
+      time_ = value;
+    }
+    /**
+     * <pre>
+     * Timestamp; when payment request created
+     * </pre>
+     *
+     * <code>required uint64 time = 3;</code>
+     */
+    private void clearTime() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      time_ = 0L;
     }
 
     public static final int EXPIRES_FIELD_NUMBER = 4;
     private long expires_;
     /**
-     * <code>optional uint64 expires = 4;</code>
-     *
      * <pre>
      * Timestamp; when this request should be considered invalid
      * </pre>
+     *
+     * <code>optional uint64 expires = 4;</code>
      */
     public boolean hasExpires() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional uint64 expires = 4;</code>
-     *
      * <pre>
      * Timestamp; when this request should be considered invalid
      * </pre>
+     *
+     * <code>optional uint64 expires = 4;</code>
      */
     public long getExpires() {
       return expires_;
     }
+    /**
+     * <pre>
+     * Timestamp; when this request should be considered invalid
+     * </pre>
+     *
+     * <code>optional uint64 expires = 4;</code>
+     */
+    private void setExpires(long value) {
+      bitField0_ |= 0x00000004;
+      expires_ = value;
+    }
+    /**
+     * <pre>
+     * Timestamp; when this request should be considered invalid
+     * </pre>
+     *
+     * <code>optional uint64 expires = 4;</code>
+     */
+    private void clearExpires() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      expires_ = 0L;
+    }
 
     public static final int MEMO_FIELD_NUMBER = 5;
-    private java.lang.Object memo_;
+    private java.lang.String memo_;
     /**
-     * <code>optional string memo = 5;</code>
-     *
      * <pre>
      * Human-readable description of request for the customer
      * </pre>
+     *
+     * <code>optional string memo = 5;</code>
      */
     public boolean hasMemo() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional string memo = 5;</code>
-     *
      * <pre>
      * Human-readable description of request for the customer
      * </pre>
+     *
+     * <code>optional string memo = 5;</code>
      */
     public java.lang.String getMemo() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          memo_ = s;
-        }
-        return s;
-      }
+      return memo_;
     }
     /**
-     * <code>optional string memo = 5;</code>
-     *
      * <pre>
      * Human-readable description of request for the customer
      * </pre>
+     *
+     * <code>optional string memo = 5;</code>
      */
     public com.google.protobuf.ByteString
         getMemoBytes() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        memo_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(memo_);
+    }
+    /**
+     * <pre>
+     * Human-readable description of request for the customer
+     * </pre>
+     *
+     * <code>optional string memo = 5;</code>
+     */
+    private void setMemo(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+      memo_ = value;
+    }
+    /**
+     * <pre>
+     * Human-readable description of request for the customer
+     * </pre>
+     *
+     * <code>optional string memo = 5;</code>
+     */
+    private void clearMemo() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      memo_ = getDefaultInstance().getMemo();
+    }
+    /**
+     * <pre>
+     * Human-readable description of request for the customer
+     * </pre>
+     *
+     * <code>optional string memo = 5;</code>
+     */
+    private void setMemoBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+      memo_ = value.toStringUtf8();
     }
 
     public static final int PAYMENT_URL_FIELD_NUMBER = 6;
-    private java.lang.Object paymentUrl_;
+    private java.lang.String paymentUrl_;
     /**
-     * <code>optional string payment_url = 6;</code>
-     *
      * <pre>
      * URL to send Payment and get PaymentACK
      * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
      */
     public boolean hasPaymentUrl() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional string payment_url = 6;</code>
-     *
      * <pre>
      * URL to send Payment and get PaymentACK
      * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
      */
     public java.lang.String getPaymentUrl() {
-      java.lang.Object ref = paymentUrl_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          paymentUrl_ = s;
-        }
-        return s;
-      }
+      return paymentUrl_;
     }
     /**
-     * <code>optional string payment_url = 6;</code>
-     *
      * <pre>
      * URL to send Payment and get PaymentACK
      * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
      */
     public com.google.protobuf.ByteString
         getPaymentUrlBytes() {
-      java.lang.Object ref = paymentUrl_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        paymentUrl_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(paymentUrl_);
+    }
+    /**
+     * <pre>
+     * URL to send Payment and get PaymentACK
+     * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
+     */
+    private void setPaymentUrl(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+      paymentUrl_ = value;
+    }
+    /**
+     * <pre>
+     * URL to send Payment and get PaymentACK
+     * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
+     */
+    private void clearPaymentUrl() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      paymentUrl_ = getDefaultInstance().getPaymentUrl();
+    }
+    /**
+     * <pre>
+     * URL to send Payment and get PaymentACK
+     * </pre>
+     *
+     * <code>optional string payment_url = 6;</code>
+     */
+    private void setPaymentUrlBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+      paymentUrl_ = value.toStringUtf8();
     }
 
     public static final int MERCHANT_DATA_FIELD_NUMBER = 7;
     private com.google.protobuf.ByteString merchantData_;
     /**
-     * <code>optional bytes merchant_data = 7;</code>
-     *
      * <pre>
      * Arbitrary data to include in the Payment message
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 7;</code>
      */
     public boolean hasMerchantData() {
       return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
-     * <code>optional bytes merchant_data = 7;</code>
-     *
      * <pre>
      * Arbitrary data to include in the Payment message
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 7;</code>
      */
     public com.google.protobuf.ByteString getMerchantData() {
       return merchantData_;
     }
-
-    private void initFields() {
-      network_ = "main";
-      outputs_ = java.util.Collections.emptyList();
-      time_ = 0L;
-      expires_ = 0L;
-      memo_ = "";
-      paymentUrl_ = "";
-      merchantData_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * Arbitrary data to include in the Payment message
+     * </pre>
+     *
+     * <code>optional bytes merchant_data = 7;</code>
+     */
+    private void setMerchantData(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+      merchantData_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasTime()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      for (int i = 0; i < getOutputsCount(); i++) {
-        if (!getOutputs(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Arbitrary data to include in the Payment message
+     * </pre>
+     *
+     * <code>optional bytes merchant_data = 7;</code>
+     */
+    private void clearMerchantData() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      merchantData_ = getDefaultInstance().getMerchantData();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getNetworkBytes());
+        output.writeString(1, getNetwork());
       }
       for (int i = 0; i < outputs_.size(); i++) {
         output.writeMessage(2, outputs_.get(i));
@@ -1210,18 +1211,17 @@ public final class Protos {
         output.writeUInt64(4, expires_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeBytes(5, getMemoBytes());
+        output.writeString(5, getMemo());
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeBytes(6, getPaymentUrlBytes());
+        output.writeString(6, getPaymentUrl());
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeBytes(7, merchantData_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -1229,7 +1229,7 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getNetworkBytes());
+          .computeStringSize(1, getNetwork());
       }
       for (int i = 0; i < outputs_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
@@ -1245,1089 +1245,772 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(5, getMemoBytes());
+          .computeStringSize(5, getMemo());
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(6, getPaymentUrlBytes());
+          .computeStringSize(6, getPaymentUrl());
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(7, merchantData_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentDetails parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.protocols.payments.Protos.PaymentDetails prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code payments.PaymentDetails}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.protocols.payments.Protos.PaymentDetails, Builder> implements
         // @@protoc_insertion_point(builder_implements:payments.PaymentDetails)
         org.flo.protocols.payments.Protos.PaymentDetailsOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentDetails_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentDetails_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.protocols.payments.Protos.PaymentDetails.class, org.flo.protocols.payments.Protos.PaymentDetails.Builder.class);
-      }
-
       // Construct using org.flo.protocols.payments.Protos.PaymentDetails.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getOutputsFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        network_ = "main";
-        bitField0_ = (bitField0_ & ~0x00000001);
-        if (outputsBuilder_ == null) {
-          outputs_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        } else {
-          outputsBuilder_.clear();
-        }
-        time_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        expires_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        memo_ = "";
-        bitField0_ = (bitField0_ & ~0x00000010);
-        paymentUrl_ = "";
-        bitField0_ = (bitField0_ & ~0x00000020);
-        merchantData_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000040);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentDetails_descriptor;
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentDetails getDefaultInstanceForType() {
-        return org.flo.protocols.payments.Protos.PaymentDetails.getDefaultInstance();
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentDetails build() {
-        org.flo.protocols.payments.Protos.PaymentDetails result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentDetails buildPartial() {
-        org.flo.protocols.payments.Protos.PaymentDetails result = new org.flo.protocols.payments.Protos.PaymentDetails(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.network_ = network_;
-        if (outputsBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
-            outputs_ = java.util.Collections.unmodifiableList(outputs_);
-            bitField0_ = (bitField0_ & ~0x00000002);
-          }
-          result.outputs_ = outputs_;
-        } else {
-          result.outputs_ = outputsBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.time_ = time_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.expires_ = expires_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.memo_ = memo_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.paymentUrl_ = paymentUrl_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        result.merchantData_ = merchantData_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.protocols.payments.Protos.PaymentDetails) {
-          return mergeFrom((org.flo.protocols.payments.Protos.PaymentDetails)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.protocols.payments.Protos.PaymentDetails other) {
-        if (other == org.flo.protocols.payments.Protos.PaymentDetails.getDefaultInstance()) return this;
-        if (other.hasNetwork()) {
-          bitField0_ |= 0x00000001;
-          network_ = other.network_;
-          onChanged();
-        }
-        if (outputsBuilder_ == null) {
-          if (!other.outputs_.isEmpty()) {
-            if (outputs_.isEmpty()) {
-              outputs_ = other.outputs_;
-              bitField0_ = (bitField0_ & ~0x00000002);
-            } else {
-              ensureOutputsIsMutable();
-              outputs_.addAll(other.outputs_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.outputs_.isEmpty()) {
-            if (outputsBuilder_.isEmpty()) {
-              outputsBuilder_.dispose();
-              outputsBuilder_ = null;
-              outputs_ = other.outputs_;
-              bitField0_ = (bitField0_ & ~0x00000002);
-              outputsBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getOutputsFieldBuilder() : null;
-            } else {
-              outputsBuilder_.addAllMessages(other.outputs_);
-            }
-          }
-        }
-        if (other.hasTime()) {
-          setTime(other.getTime());
-        }
-        if (other.hasExpires()) {
-          setExpires(other.getExpires());
-        }
-        if (other.hasMemo()) {
-          bitField0_ |= 0x00000010;
-          memo_ = other.memo_;
-          onChanged();
-        }
-        if (other.hasPaymentUrl()) {
-          bitField0_ |= 0x00000020;
-          paymentUrl_ = other.paymentUrl_;
-          onChanged();
-        }
-        if (other.hasMerchantData()) {
-          setMerchantData(other.getMerchantData());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasTime()) {
-          
-          return false;
-        }
-        for (int i = 0; i < getOutputsCount(); i++) {
-          if (!getOutputs(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.protocols.payments.Protos.PaymentDetails parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.protocols.payments.Protos.PaymentDetails) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.lang.Object network_ = "main";
       /**
-       * <code>optional string network = 1 [default = "main"];</code>
-       *
        * <pre>
        * "main" or "test"
        * </pre>
+       *
+       * <code>optional string network = 1 [default = "main"];</code>
        */
       public boolean hasNetwork() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasNetwork();
       }
       /**
-       * <code>optional string network = 1 [default = "main"];</code>
-       *
        * <pre>
        * "main" or "test"
        * </pre>
+       *
+       * <code>optional string network = 1 [default = "main"];</code>
        */
       public java.lang.String getNetwork() {
-        java.lang.Object ref = network_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            network_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getNetwork();
       }
       /**
-       * <code>optional string network = 1 [default = "main"];</code>
-       *
        * <pre>
        * "main" or "test"
        * </pre>
+       *
+       * <code>optional string network = 1 [default = "main"];</code>
        */
       public com.google.protobuf.ByteString
           getNetworkBytes() {
-        java.lang.Object ref = network_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          network_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getNetworkBytes();
       }
       /**
-       * <code>optional string network = 1 [default = "main"];</code>
-       *
        * <pre>
        * "main" or "test"
        * </pre>
+       *
+       * <code>optional string network = 1 [default = "main"];</code>
        */
       public Builder setNetwork(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        network_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setNetwork(value);
         return this;
       }
       /**
-       * <code>optional string network = 1 [default = "main"];</code>
-       *
        * <pre>
        * "main" or "test"
        * </pre>
+       *
+       * <code>optional string network = 1 [default = "main"];</code>
        */
       public Builder clearNetwork() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        network_ = getDefaultInstance().getNetwork();
-        onChanged();
+        copyOnWrite();
+        instance.clearNetwork();
         return this;
       }
       /**
-       * <code>optional string network = 1 [default = "main"];</code>
-       *
        * <pre>
        * "main" or "test"
        * </pre>
+       *
+       * <code>optional string network = 1 [default = "main"];</code>
        */
       public Builder setNetworkBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        network_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setNetworkBytes(value);
         return this;
       }
 
-      private java.util.List<org.flo.protocols.payments.Protos.Output> outputs_ =
-        java.util.Collections.emptyList();
-      private void ensureOutputsIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          outputs_ = new java.util.ArrayList<org.flo.protocols.payments.Protos.Output>(outputs_);
-          bitField0_ |= 0x00000002;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.flo.protocols.payments.Protos.Output, org.flo.protocols.payments.Protos.Output.Builder, org.flo.protocols.payments.Protos.OutputOrBuilder> outputsBuilder_;
-
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public java.util.List<org.flo.protocols.payments.Protos.Output> getOutputsList() {
-        if (outputsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(outputs_);
-        } else {
-          return outputsBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getOutputsList());
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public int getOutputsCount() {
-        if (outputsBuilder_ == null) {
-          return outputs_.size();
-        } else {
-          return outputsBuilder_.getCount();
-        }
-      }
-      /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
+        return instance.getOutputsCount();
+      }/**
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public org.flo.protocols.payments.Protos.Output getOutputs(int index) {
-        if (outputsBuilder_ == null) {
-          return outputs_.get(index);
-        } else {
-          return outputsBuilder_.getMessage(index);
-        }
+        return instance.getOutputs(index);
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder setOutputs(
           int index, org.flo.protocols.payments.Protos.Output value) {
-        if (outputsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureOutputsIsMutable();
-          outputs_.set(index, value);
-          onChanged();
-        } else {
-          outputsBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setOutputs(index, value);
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder setOutputs(
           int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
-        if (outputsBuilder_ == null) {
-          ensureOutputsIsMutable();
-          outputs_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          outputsBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setOutputs(index, builderForValue);
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder addOutputs(org.flo.protocols.payments.Protos.Output value) {
-        if (outputsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureOutputsIsMutable();
-          outputs_.add(value);
-          onChanged();
-        } else {
-          outputsBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addOutputs(value);
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder addOutputs(
           int index, org.flo.protocols.payments.Protos.Output value) {
-        if (outputsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureOutputsIsMutable();
-          outputs_.add(index, value);
-          onChanged();
-        } else {
-          outputsBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addOutputs(index, value);
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder addOutputs(
           org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
-        if (outputsBuilder_ == null) {
-          ensureOutputsIsMutable();
-          outputs_.add(builderForValue.build());
-          onChanged();
-        } else {
-          outputsBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addOutputs(builderForValue);
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder addOutputs(
           int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
-        if (outputsBuilder_ == null) {
-          ensureOutputsIsMutable();
-          outputs_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          outputsBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addOutputs(index, builderForValue);
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder addAllOutputs(
           java.lang.Iterable<? extends org.flo.protocols.payments.Protos.Output> values) {
-        if (outputsBuilder_ == null) {
-          ensureOutputsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, outputs_);
-          onChanged();
-        } else {
-          outputsBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllOutputs(values);
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder clearOutputs() {
-        if (outputsBuilder_ == null) {
-          outputs_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000002);
-          onChanged();
-        } else {
-          outputsBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearOutputs();
         return this;
       }
       /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
        * <pre>
        * Where payment should be sent
        * </pre>
+       *
+       * <code>repeated .payments.Output outputs = 2;</code>
        */
       public Builder removeOutputs(int index) {
-        if (outputsBuilder_ == null) {
-          ensureOutputsIsMutable();
-          outputs_.remove(index);
-          onChanged();
-        } else {
-          outputsBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeOutputs(index);
         return this;
       }
-      /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
-       * <pre>
-       * Where payment should be sent
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.Output.Builder getOutputsBuilder(
-          int index) {
-        return getOutputsFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
-       * <pre>
-       * Where payment should be sent
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.OutputOrBuilder getOutputsOrBuilder(
-          int index) {
-        if (outputsBuilder_ == null) {
-          return outputs_.get(index);  } else {
-          return outputsBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
-       * <pre>
-       * Where payment should be sent
-       * </pre>
-       */
-      public java.util.List<? extends org.flo.protocols.payments.Protos.OutputOrBuilder> 
-           getOutputsOrBuilderList() {
-        if (outputsBuilder_ != null) {
-          return outputsBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(outputs_);
-        }
-      }
-      /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
-       * <pre>
-       * Where payment should be sent
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.Output.Builder addOutputsBuilder() {
-        return getOutputsFieldBuilder().addBuilder(
-            org.flo.protocols.payments.Protos.Output.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
-       * <pre>
-       * Where payment should be sent
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.Output.Builder addOutputsBuilder(
-          int index) {
-        return getOutputsFieldBuilder().addBuilder(
-            index, org.flo.protocols.payments.Protos.Output.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .payments.Output outputs = 2;</code>
-       *
-       * <pre>
-       * Where payment should be sent
-       * </pre>
-       */
-      public java.util.List<org.flo.protocols.payments.Protos.Output.Builder> 
-           getOutputsBuilderList() {
-        return getOutputsFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.flo.protocols.payments.Protos.Output, org.flo.protocols.payments.Protos.Output.Builder, org.flo.protocols.payments.Protos.OutputOrBuilder> 
-          getOutputsFieldBuilder() {
-        if (outputsBuilder_ == null) {
-          outputsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.flo.protocols.payments.Protos.Output, org.flo.protocols.payments.Protos.Output.Builder, org.flo.protocols.payments.Protos.OutputOrBuilder>(
-                  outputs_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
-                  getParentForChildren(),
-                  isClean());
-          outputs_ = null;
-        }
-        return outputsBuilder_;
-      }
 
-      private long time_ ;
       /**
-       * <code>required uint64 time = 3;</code>
-       *
        * <pre>
        * Timestamp; when payment request created
        * </pre>
+       *
+       * <code>required uint64 time = 3;</code>
        */
       public boolean hasTime() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasTime();
       }
       /**
-       * <code>required uint64 time = 3;</code>
-       *
        * <pre>
        * Timestamp; when payment request created
        * </pre>
+       *
+       * <code>required uint64 time = 3;</code>
        */
       public long getTime() {
-        return time_;
+        return instance.getTime();
       }
       /**
-       * <code>required uint64 time = 3;</code>
-       *
        * <pre>
        * Timestamp; when payment request created
        * </pre>
+       *
+       * <code>required uint64 time = 3;</code>
        */
       public Builder setTime(long value) {
-        bitField0_ |= 0x00000004;
-        time_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTime(value);
         return this;
       }
       /**
-       * <code>required uint64 time = 3;</code>
-       *
        * <pre>
        * Timestamp; when payment request created
        * </pre>
+       *
+       * <code>required uint64 time = 3;</code>
        */
       public Builder clearTime() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        time_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearTime();
         return this;
       }
 
-      private long expires_ ;
       /**
-       * <code>optional uint64 expires = 4;</code>
-       *
        * <pre>
        * Timestamp; when this request should be considered invalid
        * </pre>
+       *
+       * <code>optional uint64 expires = 4;</code>
        */
       public boolean hasExpires() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasExpires();
       }
       /**
-       * <code>optional uint64 expires = 4;</code>
-       *
        * <pre>
        * Timestamp; when this request should be considered invalid
        * </pre>
+       *
+       * <code>optional uint64 expires = 4;</code>
        */
       public long getExpires() {
-        return expires_;
+        return instance.getExpires();
       }
       /**
-       * <code>optional uint64 expires = 4;</code>
-       *
        * <pre>
        * Timestamp; when this request should be considered invalid
        * </pre>
+       *
+       * <code>optional uint64 expires = 4;</code>
        */
       public Builder setExpires(long value) {
-        bitField0_ |= 0x00000008;
-        expires_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setExpires(value);
         return this;
       }
       /**
-       * <code>optional uint64 expires = 4;</code>
-       *
        * <pre>
        * Timestamp; when this request should be considered invalid
        * </pre>
+       *
+       * <code>optional uint64 expires = 4;</code>
        */
       public Builder clearExpires() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        expires_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearExpires();
         return this;
       }
 
-      private java.lang.Object memo_ = "";
       /**
-       * <code>optional string memo = 5;</code>
-       *
        * <pre>
        * Human-readable description of request for the customer
        * </pre>
+       *
+       * <code>optional string memo = 5;</code>
        */
       public boolean hasMemo() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasMemo();
       }
       /**
-       * <code>optional string memo = 5;</code>
-       *
        * <pre>
        * Human-readable description of request for the customer
        * </pre>
+       *
+       * <code>optional string memo = 5;</code>
        */
       public java.lang.String getMemo() {
-        java.lang.Object ref = memo_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            memo_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getMemo();
       }
       /**
-       * <code>optional string memo = 5;</code>
-       *
        * <pre>
        * Human-readable description of request for the customer
        * </pre>
+       *
+       * <code>optional string memo = 5;</code>
        */
       public com.google.protobuf.ByteString
           getMemoBytes() {
-        java.lang.Object ref = memo_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          memo_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getMemoBytes();
       }
       /**
-       * <code>optional string memo = 5;</code>
-       *
        * <pre>
        * Human-readable description of request for the customer
        * </pre>
+       *
+       * <code>optional string memo = 5;</code>
        */
       public Builder setMemo(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemo(value);
         return this;
       }
       /**
-       * <code>optional string memo = 5;</code>
-       *
        * <pre>
        * Human-readable description of request for the customer
        * </pre>
+       *
+       * <code>optional string memo = 5;</code>
        */
       public Builder clearMemo() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        memo_ = getDefaultInstance().getMemo();
-        onChanged();
+        copyOnWrite();
+        instance.clearMemo();
         return this;
       }
       /**
-       * <code>optional string memo = 5;</code>
-       *
        * <pre>
        * Human-readable description of request for the customer
        * </pre>
+       *
+       * <code>optional string memo = 5;</code>
        */
       public Builder setMemoBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemoBytes(value);
         return this;
       }
 
-      private java.lang.Object paymentUrl_ = "";
       /**
-       * <code>optional string payment_url = 6;</code>
-       *
        * <pre>
        * URL to send Payment and get PaymentACK
        * </pre>
+       *
+       * <code>optional string payment_url = 6;</code>
        */
       public boolean hasPaymentUrl() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return instance.hasPaymentUrl();
       }
       /**
-       * <code>optional string payment_url = 6;</code>
-       *
        * <pre>
        * URL to send Payment and get PaymentACK
        * </pre>
+       *
+       * <code>optional string payment_url = 6;</code>
        */
       public java.lang.String getPaymentUrl() {
-        java.lang.Object ref = paymentUrl_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            paymentUrl_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getPaymentUrl();
       }
       /**
-       * <code>optional string payment_url = 6;</code>
-       *
        * <pre>
        * URL to send Payment and get PaymentACK
        * </pre>
+       *
+       * <code>optional string payment_url = 6;</code>
        */
       public com.google.protobuf.ByteString
           getPaymentUrlBytes() {
-        java.lang.Object ref = paymentUrl_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          paymentUrl_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getPaymentUrlBytes();
       }
       /**
-       * <code>optional string payment_url = 6;</code>
-       *
        * <pre>
        * URL to send Payment and get PaymentACK
        * </pre>
+       *
+       * <code>optional string payment_url = 6;</code>
        */
       public Builder setPaymentUrl(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000020;
-        paymentUrl_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPaymentUrl(value);
         return this;
       }
       /**
-       * <code>optional string payment_url = 6;</code>
-       *
        * <pre>
        * URL to send Payment and get PaymentACK
        * </pre>
+       *
+       * <code>optional string payment_url = 6;</code>
        */
       public Builder clearPaymentUrl() {
-        bitField0_ = (bitField0_ & ~0x00000020);
-        paymentUrl_ = getDefaultInstance().getPaymentUrl();
-        onChanged();
+        copyOnWrite();
+        instance.clearPaymentUrl();
         return this;
       }
       /**
-       * <code>optional string payment_url = 6;</code>
-       *
        * <pre>
        * URL to send Payment and get PaymentACK
        * </pre>
+       *
+       * <code>optional string payment_url = 6;</code>
        */
       public Builder setPaymentUrlBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000020;
-        paymentUrl_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPaymentUrlBytes(value);
         return this;
       }
 
-      private com.google.protobuf.ByteString merchantData_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes merchant_data = 7;</code>
-       *
        * <pre>
        * Arbitrary data to include in the Payment message
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 7;</code>
        */
       public boolean hasMerchantData() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return instance.hasMerchantData();
       }
       /**
-       * <code>optional bytes merchant_data = 7;</code>
-       *
        * <pre>
        * Arbitrary data to include in the Payment message
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 7;</code>
        */
       public com.google.protobuf.ByteString getMerchantData() {
-        return merchantData_;
+        return instance.getMerchantData();
       }
       /**
-       * <code>optional bytes merchant_data = 7;</code>
-       *
        * <pre>
        * Arbitrary data to include in the Payment message
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 7;</code>
        */
       public Builder setMerchantData(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000040;
-        merchantData_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMerchantData(value);
         return this;
       }
       /**
-       * <code>optional bytes merchant_data = 7;</code>
-       *
        * <pre>
        * Arbitrary data to include in the Payment message
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 7;</code>
        */
       public Builder clearMerchantData() {
-        bitField0_ = (bitField0_ & ~0x00000040);
-        merchantData_ = getDefaultInstance().getMerchantData();
-        onChanged();
+        copyOnWrite();
+        instance.clearMerchantData();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:payments.PaymentDetails)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.protocols.payments.Protos.PaymentDetails();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new PaymentDetails(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasTime()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          for (int i = 0; i < getOutputsCount(); i++) {
+            if (!getOutputs(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          outputs_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.protocols.payments.Protos.PaymentDetails other = (org.flo.protocols.payments.Protos.PaymentDetails) arg1;
+          network_ = visitor.visitString(
+              hasNetwork(), network_,
+              other.hasNetwork(), other.network_);
+          outputs_= visitor.visitList(outputs_, other.outputs_);
+          time_ = visitor.visitLong(
+              hasTime(), time_,
+              other.hasTime(), other.time_);
+          expires_ = visitor.visitLong(
+              hasExpires(), expires_,
+              other.hasExpires(), other.expires_);
+          memo_ = visitor.visitString(
+              hasMemo(), memo_,
+              other.hasMemo(), other.memo_);
+          paymentUrl_ = visitor.visitString(
+              hasPaymentUrl(), paymentUrl_,
+              other.hasPaymentUrl(), other.paymentUrl_);
+          merchantData_ = visitor.visitByteString(
+              hasMerchantData(), merchantData_,
+              other.hasMerchantData(), other.merchantData_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000001;
+                  network_ = s;
+                  break;
+                }
+                case 18: {
+                  if (!outputs_.isModifiable()) {
+                    outputs_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(outputs_);
+                  }
+                  outputs_.add(
+                      input.readMessage(org.flo.protocols.payments.Protos.Output.parser(), extensionRegistry));
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000002;
+                  time_ = input.readUInt64();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000004;
+                  expires_ = input.readUInt64();
+                  break;
+                }
+                case 42: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000008;
+                  memo_ = s;
+                  break;
+                }
+                case 50: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000010;
+                  paymentUrl_ = s;
+                  break;
+                }
+                case 58: {
+                  bitField0_ |= 0x00000020;
+                  merchantData_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.protocols.payments.Protos.PaymentDetails.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:payments.PaymentDetails)
+    private static final org.flo.protocols.payments.Protos.PaymentDetails DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new PaymentDetails();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.protocols.payments.Protos.PaymentDetails getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<PaymentDetails> PARSER;
+
+    public static com.google.protobuf.Parser<PaymentDetails> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface PaymentRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:payments.PaymentRequest)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>optional uint32 payment_details_version = 1 [default = 1];</code>
@@ -2339,199 +2022,97 @@ public final class Protos {
     int getPaymentDetailsVersion();
 
     /**
-     * <code>optional string pki_type = 2 [default = "none"];</code>
-     *
      * <pre>
      * none / x509+sha256 / x509+sha1
      * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
      */
     boolean hasPkiType();
     /**
-     * <code>optional string pki_type = 2 [default = "none"];</code>
-     *
      * <pre>
      * none / x509+sha256 / x509+sha1
      * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
      */
     java.lang.String getPkiType();
     /**
-     * <code>optional string pki_type = 2 [default = "none"];</code>
-     *
      * <pre>
      * none / x509+sha256 / x509+sha1
      * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
      */
     com.google.protobuf.ByteString
         getPkiTypeBytes();
 
     /**
-     * <code>optional bytes pki_data = 3;</code>
-     *
      * <pre>
      * depends on pki_type
      * </pre>
+     *
+     * <code>optional bytes pki_data = 3;</code>
      */
     boolean hasPkiData();
     /**
-     * <code>optional bytes pki_data = 3;</code>
-     *
      * <pre>
      * depends on pki_type
      * </pre>
+     *
+     * <code>optional bytes pki_data = 3;</code>
      */
     com.google.protobuf.ByteString getPkiData();
 
     /**
-     * <code>required bytes serialized_payment_details = 4;</code>
-     *
      * <pre>
      * PaymentDetails
      * </pre>
+     *
+     * <code>required bytes serialized_payment_details = 4;</code>
      */
     boolean hasSerializedPaymentDetails();
     /**
-     * <code>required bytes serialized_payment_details = 4;</code>
-     *
      * <pre>
      * PaymentDetails
      * </pre>
+     *
+     * <code>required bytes serialized_payment_details = 4;</code>
      */
     com.google.protobuf.ByteString getSerializedPaymentDetails();
 
     /**
-     * <code>optional bytes signature = 5;</code>
-     *
      * <pre>
      * pki-dependent signature
      * </pre>
+     *
+     * <code>optional bytes signature = 5;</code>
      */
     boolean hasSignature();
     /**
-     * <code>optional bytes signature = 5;</code>
-     *
      * <pre>
      * pki-dependent signature
      * </pre>
+     *
+     * <code>optional bytes signature = 5;</code>
      */
     com.google.protobuf.ByteString getSignature();
   }
   /**
    * Protobuf type {@code payments.PaymentRequest}
    */
-  public static final class PaymentRequest extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class PaymentRequest extends
+      com.google.protobuf.GeneratedMessageLite<
+          PaymentRequest, PaymentRequest.Builder> implements
       // @@protoc_insertion_point(message_implements:payments.PaymentRequest)
       PaymentRequestOrBuilder {
-    // Use PaymentRequest.newBuilder() to construct.
-    private PaymentRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private PaymentRequest() {
+      paymentDetailsVersion_ = 1;
+      pkiType_ = "none";
+      pkiData_ = com.google.protobuf.ByteString.EMPTY;
+      serializedPaymentDetails_ = com.google.protobuf.ByteString.EMPTY;
+      signature_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private PaymentRequest(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final PaymentRequest defaultInstance;
-    public static PaymentRequest getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public PaymentRequest getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PaymentRequest(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              paymentDetailsVersion_ = input.readUInt32();
-              break;
-            }
-            case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              pkiType_ = bs;
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              pkiData_ = input.readBytes();
-              break;
-            }
-            case 34: {
-              bitField0_ |= 0x00000008;
-              serializedPaymentDetails_ = input.readBytes();
-              break;
-            }
-            case 42: {
-              bitField0_ |= 0x00000010;
-              signature_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_PaymentRequest_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_PaymentRequest_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.protocols.payments.Protos.PaymentRequest.class, org.flo.protocols.payments.Protos.PaymentRequest.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<PaymentRequest> PARSER =
-        new com.google.protobuf.AbstractParser<PaymentRequest>() {
-      public PaymentRequest parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PaymentRequest(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<PaymentRequest> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int PAYMENT_DETAILS_VERSION_FIELD_NUMBER = 1;
     private int paymentDetailsVersion_;
@@ -2547,159 +2128,247 @@ public final class Protos {
     public int getPaymentDetailsVersion() {
       return paymentDetailsVersion_;
     }
+    /**
+     * <code>optional uint32 payment_details_version = 1 [default = 1];</code>
+     */
+    private void setPaymentDetailsVersion(int value) {
+      bitField0_ |= 0x00000001;
+      paymentDetailsVersion_ = value;
+    }
+    /**
+     * <code>optional uint32 payment_details_version = 1 [default = 1];</code>
+     */
+    private void clearPaymentDetailsVersion() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      paymentDetailsVersion_ = 1;
+    }
 
     public static final int PKI_TYPE_FIELD_NUMBER = 2;
-    private java.lang.Object pkiType_;
+    private java.lang.String pkiType_;
     /**
-     * <code>optional string pki_type = 2 [default = "none"];</code>
-     *
      * <pre>
      * none / x509+sha256 / x509+sha1
      * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
      */
     public boolean hasPkiType() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional string pki_type = 2 [default = "none"];</code>
-     *
      * <pre>
      * none / x509+sha256 / x509+sha1
      * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
      */
     public java.lang.String getPkiType() {
-      java.lang.Object ref = pkiType_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          pkiType_ = s;
-        }
-        return s;
-      }
+      return pkiType_;
     }
     /**
-     * <code>optional string pki_type = 2 [default = "none"];</code>
-     *
      * <pre>
      * none / x509+sha256 / x509+sha1
      * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
      */
     public com.google.protobuf.ByteString
         getPkiTypeBytes() {
-      java.lang.Object ref = pkiType_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        pkiType_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(pkiType_);
+    }
+    /**
+     * <pre>
+     * none / x509+sha256 / x509+sha1
+     * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
+     */
+    private void setPkiType(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      pkiType_ = value;
+    }
+    /**
+     * <pre>
+     * none / x509+sha256 / x509+sha1
+     * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
+     */
+    private void clearPkiType() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      pkiType_ = getDefaultInstance().getPkiType();
+    }
+    /**
+     * <pre>
+     * none / x509+sha256 / x509+sha1
+     * </pre>
+     *
+     * <code>optional string pki_type = 2 [default = "none"];</code>
+     */
+    private void setPkiTypeBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      pkiType_ = value.toStringUtf8();
     }
 
     public static final int PKI_DATA_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString pkiData_;
     /**
-     * <code>optional bytes pki_data = 3;</code>
-     *
      * <pre>
      * depends on pki_type
      * </pre>
+     *
+     * <code>optional bytes pki_data = 3;</code>
      */
     public boolean hasPkiData() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional bytes pki_data = 3;</code>
-     *
      * <pre>
      * depends on pki_type
      * </pre>
+     *
+     * <code>optional bytes pki_data = 3;</code>
      */
     public com.google.protobuf.ByteString getPkiData() {
       return pkiData_;
+    }
+    /**
+     * <pre>
+     * depends on pki_type
+     * </pre>
+     *
+     * <code>optional bytes pki_data = 3;</code>
+     */
+    private void setPkiData(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      pkiData_ = value;
+    }
+    /**
+     * <pre>
+     * depends on pki_type
+     * </pre>
+     *
+     * <code>optional bytes pki_data = 3;</code>
+     */
+    private void clearPkiData() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      pkiData_ = getDefaultInstance().getPkiData();
     }
 
     public static final int SERIALIZED_PAYMENT_DETAILS_FIELD_NUMBER = 4;
     private com.google.protobuf.ByteString serializedPaymentDetails_;
     /**
-     * <code>required bytes serialized_payment_details = 4;</code>
-     *
      * <pre>
      * PaymentDetails
      * </pre>
+     *
+     * <code>required bytes serialized_payment_details = 4;</code>
      */
     public boolean hasSerializedPaymentDetails() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>required bytes serialized_payment_details = 4;</code>
-     *
      * <pre>
      * PaymentDetails
      * </pre>
+     *
+     * <code>required bytes serialized_payment_details = 4;</code>
      */
     public com.google.protobuf.ByteString getSerializedPaymentDetails() {
       return serializedPaymentDetails_;
+    }
+    /**
+     * <pre>
+     * PaymentDetails
+     * </pre>
+     *
+     * <code>required bytes serialized_payment_details = 4;</code>
+     */
+    private void setSerializedPaymentDetails(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+      serializedPaymentDetails_ = value;
+    }
+    /**
+     * <pre>
+     * PaymentDetails
+     * </pre>
+     *
+     * <code>required bytes serialized_payment_details = 4;</code>
+     */
+    private void clearSerializedPaymentDetails() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      serializedPaymentDetails_ = getDefaultInstance().getSerializedPaymentDetails();
     }
 
     public static final int SIGNATURE_FIELD_NUMBER = 5;
     private com.google.protobuf.ByteString signature_;
     /**
-     * <code>optional bytes signature = 5;</code>
-     *
      * <pre>
      * pki-dependent signature
      * </pre>
+     *
+     * <code>optional bytes signature = 5;</code>
      */
     public boolean hasSignature() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional bytes signature = 5;</code>
-     *
      * <pre>
      * pki-dependent signature
      * </pre>
+     *
+     * <code>optional bytes signature = 5;</code>
      */
     public com.google.protobuf.ByteString getSignature() {
       return signature_;
     }
-
-    private void initFields() {
-      paymentDetailsVersion_ = 1;
-      pkiType_ = "none";
-      pkiData_ = com.google.protobuf.ByteString.EMPTY;
-      serializedPaymentDetails_ = com.google.protobuf.ByteString.EMPTY;
-      signature_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * pki-dependent signature
+     * </pre>
+     *
+     * <code>optional bytes signature = 5;</code>
+     */
+    private void setSignature(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+      signature_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasSerializedPaymentDetails()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * pki-dependent signature
+     * </pre>
+     *
+     * <code>optional bytes signature = 5;</code>
+     */
+    private void clearSignature() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      signature_ = getDefaultInstance().getSignature();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeUInt32(1, paymentDetailsVersion_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getPkiTypeBytes());
+        output.writeString(2, getPkiType());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBytes(3, pkiData_);
@@ -2710,10 +2379,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeBytes(5, signature_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -2725,7 +2393,7 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getPkiTypeBytes());
+          .computeStringSize(2, getPkiType());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
@@ -2739,729 +2407,614 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, signature_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.protocols.payments.Protos.PaymentRequest prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code payments.PaymentRequest}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.protocols.payments.Protos.PaymentRequest, Builder> implements
         // @@protoc_insertion_point(builder_implements:payments.PaymentRequest)
         org.flo.protocols.payments.Protos.PaymentRequestOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentRequest_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentRequest_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.protocols.payments.Protos.PaymentRequest.class, org.flo.protocols.payments.Protos.PaymentRequest.Builder.class);
-      }
-
       // Construct using org.flo.protocols.payments.Protos.PaymentRequest.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        paymentDetailsVersion_ = 1;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        pkiType_ = "none";
-        bitField0_ = (bitField0_ & ~0x00000002);
-        pkiData_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        serializedPaymentDetails_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        signature_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentRequest_descriptor;
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentRequest getDefaultInstanceForType() {
-        return org.flo.protocols.payments.Protos.PaymentRequest.getDefaultInstance();
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentRequest build() {
-        org.flo.protocols.payments.Protos.PaymentRequest result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentRequest buildPartial() {
-        org.flo.protocols.payments.Protos.PaymentRequest result = new org.flo.protocols.payments.Protos.PaymentRequest(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.paymentDetailsVersion_ = paymentDetailsVersion_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.pkiType_ = pkiType_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.pkiData_ = pkiData_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.serializedPaymentDetails_ = serializedPaymentDetails_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.signature_ = signature_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.protocols.payments.Protos.PaymentRequest) {
-          return mergeFrom((org.flo.protocols.payments.Protos.PaymentRequest)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.protocols.payments.Protos.PaymentRequest other) {
-        if (other == org.flo.protocols.payments.Protos.PaymentRequest.getDefaultInstance()) return this;
-        if (other.hasPaymentDetailsVersion()) {
-          setPaymentDetailsVersion(other.getPaymentDetailsVersion());
-        }
-        if (other.hasPkiType()) {
-          bitField0_ |= 0x00000002;
-          pkiType_ = other.pkiType_;
-          onChanged();
-        }
-        if (other.hasPkiData()) {
-          setPkiData(other.getPkiData());
-        }
-        if (other.hasSerializedPaymentDetails()) {
-          setSerializedPaymentDetails(other.getSerializedPaymentDetails());
-        }
-        if (other.hasSignature()) {
-          setSignature(other.getSignature());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasSerializedPaymentDetails()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.protocols.payments.Protos.PaymentRequest parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.protocols.payments.Protos.PaymentRequest) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private int paymentDetailsVersion_ = 1;
       /**
        * <code>optional uint32 payment_details_version = 1 [default = 1];</code>
        */
       public boolean hasPaymentDetailsVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasPaymentDetailsVersion();
       }
       /**
        * <code>optional uint32 payment_details_version = 1 [default = 1];</code>
        */
       public int getPaymentDetailsVersion() {
-        return paymentDetailsVersion_;
+        return instance.getPaymentDetailsVersion();
       }
       /**
        * <code>optional uint32 payment_details_version = 1 [default = 1];</code>
        */
       public Builder setPaymentDetailsVersion(int value) {
-        bitField0_ |= 0x00000001;
-        paymentDetailsVersion_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPaymentDetailsVersion(value);
         return this;
       }
       /**
        * <code>optional uint32 payment_details_version = 1 [default = 1];</code>
        */
       public Builder clearPaymentDetailsVersion() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        paymentDetailsVersion_ = 1;
-        onChanged();
+        copyOnWrite();
+        instance.clearPaymentDetailsVersion();
         return this;
       }
 
-      private java.lang.Object pkiType_ = "none";
       /**
-       * <code>optional string pki_type = 2 [default = "none"];</code>
-       *
        * <pre>
        * none / x509+sha256 / x509+sha1
        * </pre>
+       *
+       * <code>optional string pki_type = 2 [default = "none"];</code>
        */
       public boolean hasPkiType() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasPkiType();
       }
       /**
-       * <code>optional string pki_type = 2 [default = "none"];</code>
-       *
        * <pre>
        * none / x509+sha256 / x509+sha1
        * </pre>
+       *
+       * <code>optional string pki_type = 2 [default = "none"];</code>
        */
       public java.lang.String getPkiType() {
-        java.lang.Object ref = pkiType_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            pkiType_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getPkiType();
       }
       /**
-       * <code>optional string pki_type = 2 [default = "none"];</code>
-       *
        * <pre>
        * none / x509+sha256 / x509+sha1
        * </pre>
+       *
+       * <code>optional string pki_type = 2 [default = "none"];</code>
        */
       public com.google.protobuf.ByteString
           getPkiTypeBytes() {
-        java.lang.Object ref = pkiType_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          pkiType_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getPkiTypeBytes();
       }
       /**
-       * <code>optional string pki_type = 2 [default = "none"];</code>
-       *
        * <pre>
        * none / x509+sha256 / x509+sha1
        * </pre>
+       *
+       * <code>optional string pki_type = 2 [default = "none"];</code>
        */
       public Builder setPkiType(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        pkiType_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPkiType(value);
         return this;
       }
       /**
-       * <code>optional string pki_type = 2 [default = "none"];</code>
-       *
        * <pre>
        * none / x509+sha256 / x509+sha1
        * </pre>
+       *
+       * <code>optional string pki_type = 2 [default = "none"];</code>
        */
       public Builder clearPkiType() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        pkiType_ = getDefaultInstance().getPkiType();
-        onChanged();
+        copyOnWrite();
+        instance.clearPkiType();
         return this;
       }
       /**
-       * <code>optional string pki_type = 2 [default = "none"];</code>
-       *
        * <pre>
        * none / x509+sha256 / x509+sha1
        * </pre>
+       *
+       * <code>optional string pki_type = 2 [default = "none"];</code>
        */
       public Builder setPkiTypeBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        pkiType_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPkiTypeBytes(value);
         return this;
       }
 
-      private com.google.protobuf.ByteString pkiData_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes pki_data = 3;</code>
-       *
        * <pre>
        * depends on pki_type
        * </pre>
+       *
+       * <code>optional bytes pki_data = 3;</code>
        */
       public boolean hasPkiData() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasPkiData();
       }
       /**
-       * <code>optional bytes pki_data = 3;</code>
-       *
        * <pre>
        * depends on pki_type
        * </pre>
+       *
+       * <code>optional bytes pki_data = 3;</code>
        */
       public com.google.protobuf.ByteString getPkiData() {
-        return pkiData_;
+        return instance.getPkiData();
       }
       /**
-       * <code>optional bytes pki_data = 3;</code>
-       *
        * <pre>
        * depends on pki_type
        * </pre>
+       *
+       * <code>optional bytes pki_data = 3;</code>
        */
       public Builder setPkiData(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        pkiData_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPkiData(value);
         return this;
       }
       /**
-       * <code>optional bytes pki_data = 3;</code>
-       *
        * <pre>
        * depends on pki_type
        * </pre>
+       *
+       * <code>optional bytes pki_data = 3;</code>
        */
       public Builder clearPkiData() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        pkiData_ = getDefaultInstance().getPkiData();
-        onChanged();
+        copyOnWrite();
+        instance.clearPkiData();
         return this;
       }
 
-      private com.google.protobuf.ByteString serializedPaymentDetails_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes serialized_payment_details = 4;</code>
-       *
        * <pre>
        * PaymentDetails
        * </pre>
+       *
+       * <code>required bytes serialized_payment_details = 4;</code>
        */
       public boolean hasSerializedPaymentDetails() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasSerializedPaymentDetails();
       }
       /**
-       * <code>required bytes serialized_payment_details = 4;</code>
-       *
        * <pre>
        * PaymentDetails
        * </pre>
+       *
+       * <code>required bytes serialized_payment_details = 4;</code>
        */
       public com.google.protobuf.ByteString getSerializedPaymentDetails() {
-        return serializedPaymentDetails_;
+        return instance.getSerializedPaymentDetails();
       }
       /**
-       * <code>required bytes serialized_payment_details = 4;</code>
-       *
        * <pre>
        * PaymentDetails
        * </pre>
+       *
+       * <code>required bytes serialized_payment_details = 4;</code>
        */
       public Builder setSerializedPaymentDetails(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        serializedPaymentDetails_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSerializedPaymentDetails(value);
         return this;
       }
       /**
-       * <code>required bytes serialized_payment_details = 4;</code>
-       *
        * <pre>
        * PaymentDetails
        * </pre>
+       *
+       * <code>required bytes serialized_payment_details = 4;</code>
        */
       public Builder clearSerializedPaymentDetails() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        serializedPaymentDetails_ = getDefaultInstance().getSerializedPaymentDetails();
-        onChanged();
+        copyOnWrite();
+        instance.clearSerializedPaymentDetails();
         return this;
       }
 
-      private com.google.protobuf.ByteString signature_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes signature = 5;</code>
-       *
        * <pre>
        * pki-dependent signature
        * </pre>
+       *
+       * <code>optional bytes signature = 5;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasSignature();
       }
       /**
-       * <code>optional bytes signature = 5;</code>
-       *
        * <pre>
        * pki-dependent signature
        * </pre>
+       *
+       * <code>optional bytes signature = 5;</code>
        */
       public com.google.protobuf.ByteString getSignature() {
-        return signature_;
+        return instance.getSignature();
       }
       /**
-       * <code>optional bytes signature = 5;</code>
-       *
        * <pre>
        * pki-dependent signature
        * </pre>
+       *
+       * <code>optional bytes signature = 5;</code>
        */
       public Builder setSignature(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-        signature_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSignature(value);
         return this;
       }
       /**
-       * <code>optional bytes signature = 5;</code>
-       *
        * <pre>
        * pki-dependent signature
        * </pre>
+       *
+       * <code>optional bytes signature = 5;</code>
        */
       public Builder clearSignature() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        signature_ = getDefaultInstance().getSignature();
-        onChanged();
+        copyOnWrite();
+        instance.clearSignature();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:payments.PaymentRequest)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.protocols.payments.Protos.PaymentRequest();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new PaymentRequest(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasSerializedPaymentDetails()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.protocols.payments.Protos.PaymentRequest other = (org.flo.protocols.payments.Protos.PaymentRequest) arg1;
+          paymentDetailsVersion_ = visitor.visitInt(
+              hasPaymentDetailsVersion(), paymentDetailsVersion_,
+              other.hasPaymentDetailsVersion(), other.paymentDetailsVersion_);
+          pkiType_ = visitor.visitString(
+              hasPkiType(), pkiType_,
+              other.hasPkiType(), other.pkiType_);
+          pkiData_ = visitor.visitByteString(
+              hasPkiData(), pkiData_,
+              other.hasPkiData(), other.pkiData_);
+          serializedPaymentDetails_ = visitor.visitByteString(
+              hasSerializedPaymentDetails(), serializedPaymentDetails_,
+              other.hasSerializedPaymentDetails(), other.serializedPaymentDetails_);
+          signature_ = visitor.visitByteString(
+              hasSignature(), signature_,
+              other.hasSignature(), other.signature_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  paymentDetailsVersion_ = input.readUInt32();
+                  break;
+                }
+                case 18: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000002;
+                  pkiType_ = s;
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  pkiData_ = input.readBytes();
+                  break;
+                }
+                case 34: {
+                  bitField0_ |= 0x00000008;
+                  serializedPaymentDetails_ = input.readBytes();
+                  break;
+                }
+                case 42: {
+                  bitField0_ |= 0x00000010;
+                  signature_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.protocols.payments.Protos.PaymentRequest.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:payments.PaymentRequest)
+    private static final org.flo.protocols.payments.Protos.PaymentRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new PaymentRequest();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.protocols.payments.Protos.PaymentRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<PaymentRequest> PARSER;
+
+    public static com.google.protobuf.Parser<PaymentRequest> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface X509CertificatesOrBuilder extends
       // @@protoc_insertion_point(interface_extends:payments.X509Certificates)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>repeated bytes certificate = 1;</code>
-     *
      * <pre>
      * DER-encoded X.509 certificate chain
      * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
      */
     java.util.List<com.google.protobuf.ByteString> getCertificateList();
     /**
-     * <code>repeated bytes certificate = 1;</code>
-     *
      * <pre>
      * DER-encoded X.509 certificate chain
      * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
      */
     int getCertificateCount();
     /**
-     * <code>repeated bytes certificate = 1;</code>
-     *
      * <pre>
      * DER-encoded X.509 certificate chain
      * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
      */
     com.google.protobuf.ByteString getCertificate(int index);
   }
   /**
    * Protobuf type {@code payments.X509Certificates}
    */
-  public static final class X509Certificates extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class X509Certificates extends
+      com.google.protobuf.GeneratedMessageLite<
+          X509Certificates, X509Certificates.Builder> implements
       // @@protoc_insertion_point(message_implements:payments.X509Certificates)
       X509CertificatesOrBuilder {
-    // Use X509Certificates.newBuilder() to construct.
-    private X509Certificates(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private X509Certificates() {
+      certificate_ = emptyProtobufList();
     }
-    private X509Certificates(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final X509Certificates defaultInstance;
-    public static X509Certificates getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public X509Certificates getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private X509Certificates(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                certificate_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              certificate_.add(input.readBytes());
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          certificate_ = java.util.Collections.unmodifiableList(certificate_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_X509Certificates_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_X509Certificates_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.protocols.payments.Protos.X509Certificates.class, org.flo.protocols.payments.Protos.X509Certificates.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<X509Certificates> PARSER =
-        new com.google.protobuf.AbstractParser<X509Certificates>() {
-      public X509Certificates parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new X509Certificates(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<X509Certificates> getParserForType() {
-      return PARSER;
-    }
-
     public static final int CERTIFICATE_FIELD_NUMBER = 1;
-    private java.util.List<com.google.protobuf.ByteString> certificate_;
+    private com.google.protobuf.Internal.ProtobufList<com.google.protobuf.ByteString> certificate_;
     /**
-     * <code>repeated bytes certificate = 1;</code>
-     *
      * <pre>
      * DER-encoded X.509 certificate chain
      * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
      */
     public java.util.List<com.google.protobuf.ByteString>
         getCertificateList() {
       return certificate_;
     }
     /**
-     * <code>repeated bytes certificate = 1;</code>
-     *
      * <pre>
      * DER-encoded X.509 certificate chain
      * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
      */
     public int getCertificateCount() {
       return certificate_.size();
     }
     /**
-     * <code>repeated bytes certificate = 1;</code>
-     *
      * <pre>
      * DER-encoded X.509 certificate chain
      * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
      */
     public com.google.protobuf.ByteString getCertificate(int index) {
       return certificate_.get(index);
     }
-
-    private void initFields() {
-      certificate_ = java.util.Collections.emptyList();
+    private void ensureCertificateIsMutable() {
+      if (!certificate_.isModifiable()) {
+        certificate_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(certificate_);
+       }
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * DER-encoded X.509 certificate chain
+     * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
+     */
+    private void setCertificate(
+        int index, com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificateIsMutable();
+      certificate_.set(index, value);
+    }
+    /**
+     * <pre>
+     * DER-encoded X.509 certificate chain
+     * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
+     */
+    private void addCertificate(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificateIsMutable();
+      certificate_.add(value);
+    }
+    /**
+     * <pre>
+     * DER-encoded X.509 certificate chain
+     * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
+     */
+    private void addAllCertificate(
+        java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
+      ensureCertificateIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, certificate_);
+    }
+    /**
+     * <pre>
+     * DER-encoded X.509 certificate chain
+     * </pre>
+     *
+     * <code>repeated bytes certificate = 1;</code>
+     */
+    private void clearCertificate() {
+      certificate_ = emptyProtobufList();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       for (int i = 0; i < certificate_.size(); i++) {
         output.writeBytes(1, certificate_.get(i));
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -3476,432 +3029,371 @@ public final class Protos {
         size += dataSize;
         size += 1 * getCertificateList().size();
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.X509Certificates parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.protocols.payments.Protos.X509Certificates prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code payments.X509Certificates}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.protocols.payments.Protos.X509Certificates, Builder> implements
         // @@protoc_insertion_point(builder_implements:payments.X509Certificates)
         org.flo.protocols.payments.Protos.X509CertificatesOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_X509Certificates_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_X509Certificates_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.protocols.payments.Protos.X509Certificates.class, org.flo.protocols.payments.Protos.X509Certificates.Builder.class);
-      }
-
       // Construct using org.flo.protocols.payments.Protos.X509Certificates.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        certificate_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000001);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_X509Certificates_descriptor;
-      }
-
-      public org.flo.protocols.payments.Protos.X509Certificates getDefaultInstanceForType() {
-        return org.flo.protocols.payments.Protos.X509Certificates.getDefaultInstance();
-      }
-
-      public org.flo.protocols.payments.Protos.X509Certificates build() {
-        org.flo.protocols.payments.Protos.X509Certificates result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.protocols.payments.Protos.X509Certificates buildPartial() {
-        org.flo.protocols.payments.Protos.X509Certificates result = new org.flo.protocols.payments.Protos.X509Certificates(this);
-        int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          certificate_ = java.util.Collections.unmodifiableList(certificate_);
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.certificate_ = certificate_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.protocols.payments.Protos.X509Certificates) {
-          return mergeFrom((org.flo.protocols.payments.Protos.X509Certificates)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.protocols.payments.Protos.X509Certificates other) {
-        if (other == org.flo.protocols.payments.Protos.X509Certificates.getDefaultInstance()) return this;
-        if (!other.certificate_.isEmpty()) {
-          if (certificate_.isEmpty()) {
-            certificate_ = other.certificate_;
-            bitField0_ = (bitField0_ & ~0x00000001);
-          } else {
-            ensureCertificateIsMutable();
-            certificate_.addAll(other.certificate_);
-          }
-          onChanged();
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.protocols.payments.Protos.X509Certificates parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.protocols.payments.Protos.X509Certificates) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.util.List<com.google.protobuf.ByteString> certificate_ = java.util.Collections.emptyList();
-      private void ensureCertificateIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          certificate_ = new java.util.ArrayList<com.google.protobuf.ByteString>(certificate_);
-          bitField0_ |= 0x00000001;
-         }
-      }
       /**
-       * <code>repeated bytes certificate = 1;</code>
-       *
        * <pre>
        * DER-encoded X.509 certificate chain
        * </pre>
+       *
+       * <code>repeated bytes certificate = 1;</code>
        */
       public java.util.List<com.google.protobuf.ByteString>
           getCertificateList() {
-        return java.util.Collections.unmodifiableList(certificate_);
+        return java.util.Collections.unmodifiableList(
+            instance.getCertificateList());
       }
       /**
-       * <code>repeated bytes certificate = 1;</code>
-       *
        * <pre>
        * DER-encoded X.509 certificate chain
        * </pre>
+       *
+       * <code>repeated bytes certificate = 1;</code>
        */
       public int getCertificateCount() {
-        return certificate_.size();
+        return instance.getCertificateCount();
       }
       /**
-       * <code>repeated bytes certificate = 1;</code>
-       *
        * <pre>
        * DER-encoded X.509 certificate chain
        * </pre>
+       *
+       * <code>repeated bytes certificate = 1;</code>
        */
       public com.google.protobuf.ByteString getCertificate(int index) {
-        return certificate_.get(index);
+        return instance.getCertificate(index);
       }
       /**
-       * <code>repeated bytes certificate = 1;</code>
-       *
        * <pre>
        * DER-encoded X.509 certificate chain
        * </pre>
+       *
+       * <code>repeated bytes certificate = 1;</code>
        */
       public Builder setCertificate(
           int index, com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureCertificateIsMutable();
-        certificate_.set(index, value);
-        onChanged();
+        copyOnWrite();
+        instance.setCertificate(index, value);
         return this;
       }
       /**
-       * <code>repeated bytes certificate = 1;</code>
-       *
        * <pre>
        * DER-encoded X.509 certificate chain
        * </pre>
+       *
+       * <code>repeated bytes certificate = 1;</code>
        */
       public Builder addCertificate(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureCertificateIsMutable();
-        certificate_.add(value);
-        onChanged();
+        copyOnWrite();
+        instance.addCertificate(value);
         return this;
       }
       /**
-       * <code>repeated bytes certificate = 1;</code>
-       *
        * <pre>
        * DER-encoded X.509 certificate chain
        * </pre>
+       *
+       * <code>repeated bytes certificate = 1;</code>
        */
       public Builder addAllCertificate(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
-        ensureCertificateIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, certificate_);
-        onChanged();
+        copyOnWrite();
+        instance.addAllCertificate(values);
         return this;
       }
       /**
-       * <code>repeated bytes certificate = 1;</code>
-       *
        * <pre>
        * DER-encoded X.509 certificate chain
        * </pre>
+       *
+       * <code>repeated bytes certificate = 1;</code>
        */
       public Builder clearCertificate() {
-        certificate_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000001);
-        onChanged();
+        copyOnWrite();
+        instance.clearCertificate();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:payments.X509Certificates)
     }
-
-    static {
-      defaultInstance = new X509Certificates(true);
-      defaultInstance.initFields();
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.protocols.payments.Protos.X509Certificates();
+        }
+        case IS_INITIALIZED: {
+          return DEFAULT_INSTANCE;
+        }
+        case MAKE_IMMUTABLE: {
+          certificate_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.protocols.payments.Protos.X509Certificates other = (org.flo.protocols.payments.Protos.X509Certificates) arg1;
+          certificate_= visitor.visitList(certificate_, other.certificate_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  if (!certificate_.isModifiable()) {
+                    certificate_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(certificate_);
+                  }
+                  certificate_.add(input.readBytes());
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.protocols.payments.Protos.X509Certificates.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:payments.X509Certificates)
+    private static final org.flo.protocols.payments.Protos.X509Certificates DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new X509Certificates();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.protocols.payments.Protos.X509Certificates getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<X509Certificates> PARSER;
+
+    public static com.google.protobuf.Parser<X509Certificates> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface PaymentOrBuilder extends
       // @@protoc_insertion_point(interface_extends:payments.Payment)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>optional bytes merchant_data = 1;</code>
-     *
      * <pre>
      * From PaymentDetails.merchant_data
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 1;</code>
      */
     boolean hasMerchantData();
     /**
-     * <code>optional bytes merchant_data = 1;</code>
-     *
      * <pre>
      * From PaymentDetails.merchant_data
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 1;</code>
      */
     com.google.protobuf.ByteString getMerchantData();
 
     /**
-     * <code>repeated bytes transactions = 2;</code>
-     *
      * <pre>
      * Signed transactions that satisfy PaymentDetails.outputs
      * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
      */
     java.util.List<com.google.protobuf.ByteString> getTransactionsList();
     /**
-     * <code>repeated bytes transactions = 2;</code>
-     *
      * <pre>
      * Signed transactions that satisfy PaymentDetails.outputs
      * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
      */
     int getTransactionsCount();
     /**
-     * <code>repeated bytes transactions = 2;</code>
-     *
      * <pre>
      * Signed transactions that satisfy PaymentDetails.outputs
      * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
      */
     com.google.protobuf.ByteString getTransactions(int index);
 
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     java.util.List<org.flo.protocols.payments.Protos.Output> 
         getRefundToList();
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     org.flo.protocols.payments.Protos.Output getRefundTo(int index);
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     int getRefundToCount();
-    /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
-     * <pre>
-     * Where to send refunds, if a refund is necessary
-     * </pre>
-     */
-    java.util.List<? extends org.flo.protocols.payments.Protos.OutputOrBuilder> 
-        getRefundToOrBuilderList();
-    /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
-     * <pre>
-     * Where to send refunds, if a refund is necessary
-     * </pre>
-     */
-    org.flo.protocols.payments.Protos.OutputOrBuilder getRefundToOrBuilder(
-        int index);
 
     /**
-     * <code>optional string memo = 4;</code>
-     *
      * <pre>
      * Human-readable message for the merchant
      * </pre>
+     *
+     * <code>optional string memo = 4;</code>
      */
     boolean hasMemo();
     /**
-     * <code>optional string memo = 4;</code>
-     *
      * <pre>
      * Human-readable message for the merchant
      * </pre>
+     *
+     * <code>optional string memo = 4;</code>
      */
     java.lang.String getMemo();
     /**
-     * <code>optional string memo = 4;</code>
-     *
      * <pre>
      * Human-readable message for the merchant
      * </pre>
+     *
+     * <code>optional string memo = 4;</code>
      */
     com.google.protobuf.ByteString
         getMemoBytes();
@@ -3909,319 +3401,411 @@ public final class Protos {
   /**
    * Protobuf type {@code payments.Payment}
    */
-  public static final class Payment extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Payment extends
+      com.google.protobuf.GeneratedMessageLite<
+          Payment, Payment.Builder> implements
       // @@protoc_insertion_point(message_implements:payments.Payment)
       PaymentOrBuilder {
-    // Use Payment.newBuilder() to construct.
-    private Payment(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Payment() {
+      merchantData_ = com.google.protobuf.ByteString.EMPTY;
+      transactions_ = emptyProtobufList();
+      refundTo_ = emptyProtobufList();
+      memo_ = "";
     }
-    private Payment(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Payment defaultInstance;
-    public static Payment getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Payment getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Payment(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              merchantData_ = input.readBytes();
-              break;
-            }
-            case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                transactions_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
-                mutable_bitField0_ |= 0x00000002;
-              }
-              transactions_.add(input.readBytes());
-              break;
-            }
-            case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                refundTo_ = new java.util.ArrayList<org.flo.protocols.payments.Protos.Output>();
-                mutable_bitField0_ |= 0x00000004;
-              }
-              refundTo_.add(input.readMessage(org.flo.protocols.payments.Protos.Output.PARSER, extensionRegistry));
-              break;
-            }
-            case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              memo_ = bs;
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-          transactions_ = java.util.Collections.unmodifiableList(transactions_);
-        }
-        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-          refundTo_ = java.util.Collections.unmodifiableList(refundTo_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_Payment_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_Payment_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.protocols.payments.Protos.Payment.class, org.flo.protocols.payments.Protos.Payment.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Payment> PARSER =
-        new com.google.protobuf.AbstractParser<Payment>() {
-      public Payment parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Payment(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Payment> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MERCHANT_DATA_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString merchantData_;
     /**
-     * <code>optional bytes merchant_data = 1;</code>
-     *
      * <pre>
      * From PaymentDetails.merchant_data
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 1;</code>
      */
     public boolean hasMerchantData() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional bytes merchant_data = 1;</code>
-     *
      * <pre>
      * From PaymentDetails.merchant_data
      * </pre>
+     *
+     * <code>optional bytes merchant_data = 1;</code>
      */
     public com.google.protobuf.ByteString getMerchantData() {
       return merchantData_;
     }
+    /**
+     * <pre>
+     * From PaymentDetails.merchant_data
+     * </pre>
+     *
+     * <code>optional bytes merchant_data = 1;</code>
+     */
+    private void setMerchantData(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      merchantData_ = value;
+    }
+    /**
+     * <pre>
+     * From PaymentDetails.merchant_data
+     * </pre>
+     *
+     * <code>optional bytes merchant_data = 1;</code>
+     */
+    private void clearMerchantData() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      merchantData_ = getDefaultInstance().getMerchantData();
+    }
 
     public static final int TRANSACTIONS_FIELD_NUMBER = 2;
-    private java.util.List<com.google.protobuf.ByteString> transactions_;
+    private com.google.protobuf.Internal.ProtobufList<com.google.protobuf.ByteString> transactions_;
     /**
-     * <code>repeated bytes transactions = 2;</code>
-     *
      * <pre>
      * Signed transactions that satisfy PaymentDetails.outputs
      * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
      */
     public java.util.List<com.google.protobuf.ByteString>
         getTransactionsList() {
       return transactions_;
     }
     /**
-     * <code>repeated bytes transactions = 2;</code>
-     *
      * <pre>
      * Signed transactions that satisfy PaymentDetails.outputs
      * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
      */
     public int getTransactionsCount() {
       return transactions_.size();
     }
     /**
-     * <code>repeated bytes transactions = 2;</code>
-     *
      * <pre>
      * Signed transactions that satisfy PaymentDetails.outputs
      * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
      */
     public com.google.protobuf.ByteString getTransactions(int index) {
       return transactions_.get(index);
     }
+    private void ensureTransactionsIsMutable() {
+      if (!transactions_.isModifiable()) {
+        transactions_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(transactions_);
+       }
+    }
+    /**
+     * <pre>
+     * Signed transactions that satisfy PaymentDetails.outputs
+     * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
+     */
+    private void setTransactions(
+        int index, com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTransactionsIsMutable();
+      transactions_.set(index, value);
+    }
+    /**
+     * <pre>
+     * Signed transactions that satisfy PaymentDetails.outputs
+     * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
+     */
+    private void addTransactions(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTransactionsIsMutable();
+      transactions_.add(value);
+    }
+    /**
+     * <pre>
+     * Signed transactions that satisfy PaymentDetails.outputs
+     * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
+     */
+    private void addAllTransactions(
+        java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
+      ensureTransactionsIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, transactions_);
+    }
+    /**
+     * <pre>
+     * Signed transactions that satisfy PaymentDetails.outputs
+     * </pre>
+     *
+     * <code>repeated bytes transactions = 2;</code>
+     */
+    private void clearTransactions() {
+      transactions_ = emptyProtobufList();
+    }
 
     public static final int REFUND_TO_FIELD_NUMBER = 3;
-    private java.util.List<org.flo.protocols.payments.Protos.Output> refundTo_;
+    private com.google.protobuf.Internal.ProtobufList<org.flo.protocols.payments.Protos.Output> refundTo_;
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     public java.util.List<org.flo.protocols.payments.Protos.Output> getRefundToList() {
       return refundTo_;
     }
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     public java.util.List<? extends org.flo.protocols.payments.Protos.OutputOrBuilder> 
         getRefundToOrBuilderList() {
       return refundTo_;
     }
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     public int getRefundToCount() {
       return refundTo_.size();
     }
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     public org.flo.protocols.payments.Protos.Output getRefundTo(int index) {
       return refundTo_.get(index);
     }
     /**
-     * <code>repeated .payments.Output refund_to = 3;</code>
-     *
      * <pre>
      * Where to send refunds, if a refund is necessary
      * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
      */
     public org.flo.protocols.payments.Protos.OutputOrBuilder getRefundToOrBuilder(
         int index) {
       return refundTo_.get(index);
     }
+    private void ensureRefundToIsMutable() {
+      if (!refundTo_.isModifiable()) {
+        refundTo_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(refundTo_);
+       }
+    }
+
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void setRefundTo(
+        int index, org.flo.protocols.payments.Protos.Output value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureRefundToIsMutable();
+      refundTo_.set(index, value);
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void setRefundTo(
+        int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
+      ensureRefundToIsMutable();
+      refundTo_.set(index, builderForValue.build());
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void addRefundTo(org.flo.protocols.payments.Protos.Output value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureRefundToIsMutable();
+      refundTo_.add(value);
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void addRefundTo(
+        int index, org.flo.protocols.payments.Protos.Output value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureRefundToIsMutable();
+      refundTo_.add(index, value);
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void addRefundTo(
+        org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
+      ensureRefundToIsMutable();
+      refundTo_.add(builderForValue.build());
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void addRefundTo(
+        int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
+      ensureRefundToIsMutable();
+      refundTo_.add(index, builderForValue.build());
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void addAllRefundTo(
+        java.lang.Iterable<? extends org.flo.protocols.payments.Protos.Output> values) {
+      ensureRefundToIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, refundTo_);
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void clearRefundTo() {
+      refundTo_ = emptyProtobufList();
+    }
+    /**
+     * <pre>
+     * Where to send refunds, if a refund is necessary
+     * </pre>
+     *
+     * <code>repeated .payments.Output refund_to = 3;</code>
+     */
+    private void removeRefundTo(int index) {
+      ensureRefundToIsMutable();
+      refundTo_.remove(index);
+    }
 
     public static final int MEMO_FIELD_NUMBER = 4;
-    private java.lang.Object memo_;
+    private java.lang.String memo_;
     /**
-     * <code>optional string memo = 4;</code>
-     *
      * <pre>
      * Human-readable message for the merchant
      * </pre>
+     *
+     * <code>optional string memo = 4;</code>
      */
     public boolean hasMemo() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional string memo = 4;</code>
-     *
      * <pre>
      * Human-readable message for the merchant
      * </pre>
+     *
+     * <code>optional string memo = 4;</code>
      */
     public java.lang.String getMemo() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          memo_ = s;
-        }
-        return s;
-      }
+      return memo_;
     }
     /**
-     * <code>optional string memo = 4;</code>
-     *
      * <pre>
      * Human-readable message for the merchant
      * </pre>
+     *
+     * <code>optional string memo = 4;</code>
      */
     public com.google.protobuf.ByteString
         getMemoBytes() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        memo_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(memo_);
     }
-
-    private void initFields() {
-      merchantData_ = com.google.protobuf.ByteString.EMPTY;
-      transactions_ = java.util.Collections.emptyList();
-      refundTo_ = java.util.Collections.emptyList();
-      memo_ = "";
+    /**
+     * <pre>
+     * Human-readable message for the merchant
+     * </pre>
+     *
+     * <code>optional string memo = 4;</code>
+     */
+    private void setMemo(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      memo_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      for (int i = 0; i < getRefundToCount(); i++) {
-        if (!getRefundTo(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Human-readable message for the merchant
+     * </pre>
+     *
+     * <code>optional string memo = 4;</code>
+     */
+    private void clearMemo() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      memo_ = getDefaultInstance().getMemo();
+    }
+    /**
+     * <pre>
+     * Human-readable message for the merchant
+     * </pre>
+     *
+     * <code>optional string memo = 4;</code>
+     */
+    private void setMemoBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      memo_ = value.toStringUtf8();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, merchantData_);
       }
@@ -4232,12 +3816,11 @@ public final class Protos {
         output.writeMessage(3, refundTo_.get(i));
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(4, getMemoBytes());
+        output.writeString(4, getMemo());
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -4262,906 +3845,627 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(4, getMemoBytes());
+          .computeStringSize(4, getMemo());
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.protocols.payments.Protos.Payment parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.Payment parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Payment parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.Payment parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Payment parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.Payment parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Payment parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.Payment parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.Payment parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.Payment parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.protocols.payments.Protos.Payment prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code payments.Payment}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.protocols.payments.Protos.Payment, Builder> implements
         // @@protoc_insertion_point(builder_implements:payments.Payment)
         org.flo.protocols.payments.Protos.PaymentOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_Payment_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_Payment_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.protocols.payments.Protos.Payment.class, org.flo.protocols.payments.Protos.Payment.Builder.class);
-      }
-
       // Construct using org.flo.protocols.payments.Protos.Payment.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getRefundToFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        merchantData_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        transactions_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
-        if (refundToBuilder_ == null) {
-          refundTo_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000004);
-        } else {
-          refundToBuilder_.clear();
-        }
-        memo_ = "";
-        bitField0_ = (bitField0_ & ~0x00000008);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_Payment_descriptor;
-      }
-
-      public org.flo.protocols.payments.Protos.Payment getDefaultInstanceForType() {
-        return org.flo.protocols.payments.Protos.Payment.getDefaultInstance();
-      }
-
-      public org.flo.protocols.payments.Protos.Payment build() {
-        org.flo.protocols.payments.Protos.Payment result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.protocols.payments.Protos.Payment buildPartial() {
-        org.flo.protocols.payments.Protos.Payment result = new org.flo.protocols.payments.Protos.Payment(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.merchantData_ = merchantData_;
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          transactions_ = java.util.Collections.unmodifiableList(transactions_);
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.transactions_ = transactions_;
-        if (refundToBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004)) {
-            refundTo_ = java.util.Collections.unmodifiableList(refundTo_);
-            bitField0_ = (bitField0_ & ~0x00000004);
-          }
-          result.refundTo_ = refundTo_;
-        } else {
-          result.refundTo_ = refundToBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.memo_ = memo_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.protocols.payments.Protos.Payment) {
-          return mergeFrom((org.flo.protocols.payments.Protos.Payment)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.protocols.payments.Protos.Payment other) {
-        if (other == org.flo.protocols.payments.Protos.Payment.getDefaultInstance()) return this;
-        if (other.hasMerchantData()) {
-          setMerchantData(other.getMerchantData());
-        }
-        if (!other.transactions_.isEmpty()) {
-          if (transactions_.isEmpty()) {
-            transactions_ = other.transactions_;
-            bitField0_ = (bitField0_ & ~0x00000002);
-          } else {
-            ensureTransactionsIsMutable();
-            transactions_.addAll(other.transactions_);
-          }
-          onChanged();
-        }
-        if (refundToBuilder_ == null) {
-          if (!other.refundTo_.isEmpty()) {
-            if (refundTo_.isEmpty()) {
-              refundTo_ = other.refundTo_;
-              bitField0_ = (bitField0_ & ~0x00000004);
-            } else {
-              ensureRefundToIsMutable();
-              refundTo_.addAll(other.refundTo_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.refundTo_.isEmpty()) {
-            if (refundToBuilder_.isEmpty()) {
-              refundToBuilder_.dispose();
-              refundToBuilder_ = null;
-              refundTo_ = other.refundTo_;
-              bitField0_ = (bitField0_ & ~0x00000004);
-              refundToBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getRefundToFieldBuilder() : null;
-            } else {
-              refundToBuilder_.addAllMessages(other.refundTo_);
-            }
-          }
-        }
-        if (other.hasMemo()) {
-          bitField0_ |= 0x00000008;
-          memo_ = other.memo_;
-          onChanged();
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        for (int i = 0; i < getRefundToCount(); i++) {
-          if (!getRefundTo(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.protocols.payments.Protos.Payment parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.protocols.payments.Protos.Payment) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString merchantData_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes merchant_data = 1;</code>
-       *
        * <pre>
        * From PaymentDetails.merchant_data
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 1;</code>
        */
       public boolean hasMerchantData() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasMerchantData();
       }
       /**
-       * <code>optional bytes merchant_data = 1;</code>
-       *
        * <pre>
        * From PaymentDetails.merchant_data
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 1;</code>
        */
       public com.google.protobuf.ByteString getMerchantData() {
-        return merchantData_;
+        return instance.getMerchantData();
       }
       /**
-       * <code>optional bytes merchant_data = 1;</code>
-       *
        * <pre>
        * From PaymentDetails.merchant_data
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 1;</code>
        */
       public Builder setMerchantData(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        merchantData_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMerchantData(value);
         return this;
       }
       /**
-       * <code>optional bytes merchant_data = 1;</code>
-       *
        * <pre>
        * From PaymentDetails.merchant_data
        * </pre>
+       *
+       * <code>optional bytes merchant_data = 1;</code>
        */
       public Builder clearMerchantData() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        merchantData_ = getDefaultInstance().getMerchantData();
-        onChanged();
+        copyOnWrite();
+        instance.clearMerchantData();
         return this;
       }
 
-      private java.util.List<com.google.protobuf.ByteString> transactions_ = java.util.Collections.emptyList();
-      private void ensureTransactionsIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          transactions_ = new java.util.ArrayList<com.google.protobuf.ByteString>(transactions_);
-          bitField0_ |= 0x00000002;
-         }
-      }
       /**
-       * <code>repeated bytes transactions = 2;</code>
-       *
        * <pre>
        * Signed transactions that satisfy PaymentDetails.outputs
        * </pre>
+       *
+       * <code>repeated bytes transactions = 2;</code>
        */
       public java.util.List<com.google.protobuf.ByteString>
           getTransactionsList() {
-        return java.util.Collections.unmodifiableList(transactions_);
+        return java.util.Collections.unmodifiableList(
+            instance.getTransactionsList());
       }
       /**
-       * <code>repeated bytes transactions = 2;</code>
-       *
        * <pre>
        * Signed transactions that satisfy PaymentDetails.outputs
        * </pre>
+       *
+       * <code>repeated bytes transactions = 2;</code>
        */
       public int getTransactionsCount() {
-        return transactions_.size();
+        return instance.getTransactionsCount();
       }
       /**
-       * <code>repeated bytes transactions = 2;</code>
-       *
        * <pre>
        * Signed transactions that satisfy PaymentDetails.outputs
        * </pre>
+       *
+       * <code>repeated bytes transactions = 2;</code>
        */
       public com.google.protobuf.ByteString getTransactions(int index) {
-        return transactions_.get(index);
+        return instance.getTransactions(index);
       }
       /**
-       * <code>repeated bytes transactions = 2;</code>
-       *
        * <pre>
        * Signed transactions that satisfy PaymentDetails.outputs
        * </pre>
+       *
+       * <code>repeated bytes transactions = 2;</code>
        */
       public Builder setTransactions(
           int index, com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureTransactionsIsMutable();
-        transactions_.set(index, value);
-        onChanged();
+        copyOnWrite();
+        instance.setTransactions(index, value);
         return this;
       }
       /**
-       * <code>repeated bytes transactions = 2;</code>
-       *
        * <pre>
        * Signed transactions that satisfy PaymentDetails.outputs
        * </pre>
+       *
+       * <code>repeated bytes transactions = 2;</code>
        */
       public Builder addTransactions(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureTransactionsIsMutable();
-        transactions_.add(value);
-        onChanged();
+        copyOnWrite();
+        instance.addTransactions(value);
         return this;
       }
       /**
-       * <code>repeated bytes transactions = 2;</code>
-       *
        * <pre>
        * Signed transactions that satisfy PaymentDetails.outputs
        * </pre>
+       *
+       * <code>repeated bytes transactions = 2;</code>
        */
       public Builder addAllTransactions(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
-        ensureTransactionsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, transactions_);
-        onChanged();
+        copyOnWrite();
+        instance.addAllTransactions(values);
         return this;
       }
       /**
-       * <code>repeated bytes transactions = 2;</code>
-       *
        * <pre>
        * Signed transactions that satisfy PaymentDetails.outputs
        * </pre>
+       *
+       * <code>repeated bytes transactions = 2;</code>
        */
       public Builder clearTransactions() {
-        transactions_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
-        onChanged();
+        copyOnWrite();
+        instance.clearTransactions();
         return this;
       }
 
-      private java.util.List<org.flo.protocols.payments.Protos.Output> refundTo_ =
-        java.util.Collections.emptyList();
-      private void ensureRefundToIsMutable() {
-        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-          refundTo_ = new java.util.ArrayList<org.flo.protocols.payments.Protos.Output>(refundTo_);
-          bitField0_ |= 0x00000004;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.flo.protocols.payments.Protos.Output, org.flo.protocols.payments.Protos.Output.Builder, org.flo.protocols.payments.Protos.OutputOrBuilder> refundToBuilder_;
-
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public java.util.List<org.flo.protocols.payments.Protos.Output> getRefundToList() {
-        if (refundToBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(refundTo_);
-        } else {
-          return refundToBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getRefundToList());
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public int getRefundToCount() {
-        if (refundToBuilder_ == null) {
-          return refundTo_.size();
-        } else {
-          return refundToBuilder_.getCount();
-        }
-      }
-      /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
+        return instance.getRefundToCount();
+      }/**
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public org.flo.protocols.payments.Protos.Output getRefundTo(int index) {
-        if (refundToBuilder_ == null) {
-          return refundTo_.get(index);
-        } else {
-          return refundToBuilder_.getMessage(index);
-        }
+        return instance.getRefundTo(index);
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder setRefundTo(
           int index, org.flo.protocols.payments.Protos.Output value) {
-        if (refundToBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRefundToIsMutable();
-          refundTo_.set(index, value);
-          onChanged();
-        } else {
-          refundToBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setRefundTo(index, value);
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder setRefundTo(
           int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
-        if (refundToBuilder_ == null) {
-          ensureRefundToIsMutable();
-          refundTo_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          refundToBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setRefundTo(index, builderForValue);
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder addRefundTo(org.flo.protocols.payments.Protos.Output value) {
-        if (refundToBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRefundToIsMutable();
-          refundTo_.add(value);
-          onChanged();
-        } else {
-          refundToBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addRefundTo(value);
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder addRefundTo(
           int index, org.flo.protocols.payments.Protos.Output value) {
-        if (refundToBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRefundToIsMutable();
-          refundTo_.add(index, value);
-          onChanged();
-        } else {
-          refundToBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addRefundTo(index, value);
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder addRefundTo(
           org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
-        if (refundToBuilder_ == null) {
-          ensureRefundToIsMutable();
-          refundTo_.add(builderForValue.build());
-          onChanged();
-        } else {
-          refundToBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addRefundTo(builderForValue);
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder addRefundTo(
           int index, org.flo.protocols.payments.Protos.Output.Builder builderForValue) {
-        if (refundToBuilder_ == null) {
-          ensureRefundToIsMutable();
-          refundTo_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          refundToBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addRefundTo(index, builderForValue);
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder addAllRefundTo(
           java.lang.Iterable<? extends org.flo.protocols.payments.Protos.Output> values) {
-        if (refundToBuilder_ == null) {
-          ensureRefundToIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, refundTo_);
-          onChanged();
-        } else {
-          refundToBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllRefundTo(values);
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder clearRefundTo() {
-        if (refundToBuilder_ == null) {
-          refundTo_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000004);
-          onChanged();
-        } else {
-          refundToBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearRefundTo();
         return this;
       }
       /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
        * <pre>
        * Where to send refunds, if a refund is necessary
        * </pre>
+       *
+       * <code>repeated .payments.Output refund_to = 3;</code>
        */
       public Builder removeRefundTo(int index) {
-        if (refundToBuilder_ == null) {
-          ensureRefundToIsMutable();
-          refundTo_.remove(index);
-          onChanged();
-        } else {
-          refundToBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeRefundTo(index);
         return this;
       }
-      /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
-       * <pre>
-       * Where to send refunds, if a refund is necessary
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.Output.Builder getRefundToBuilder(
-          int index) {
-        return getRefundToFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
-       * <pre>
-       * Where to send refunds, if a refund is necessary
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.OutputOrBuilder getRefundToOrBuilder(
-          int index) {
-        if (refundToBuilder_ == null) {
-          return refundTo_.get(index);  } else {
-          return refundToBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
-       * <pre>
-       * Where to send refunds, if a refund is necessary
-       * </pre>
-       */
-      public java.util.List<? extends org.flo.protocols.payments.Protos.OutputOrBuilder> 
-           getRefundToOrBuilderList() {
-        if (refundToBuilder_ != null) {
-          return refundToBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(refundTo_);
-        }
-      }
-      /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
-       * <pre>
-       * Where to send refunds, if a refund is necessary
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.Output.Builder addRefundToBuilder() {
-        return getRefundToFieldBuilder().addBuilder(
-            org.flo.protocols.payments.Protos.Output.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
-       * <pre>
-       * Where to send refunds, if a refund is necessary
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.Output.Builder addRefundToBuilder(
-          int index) {
-        return getRefundToFieldBuilder().addBuilder(
-            index, org.flo.protocols.payments.Protos.Output.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .payments.Output refund_to = 3;</code>
-       *
-       * <pre>
-       * Where to send refunds, if a refund is necessary
-       * </pre>
-       */
-      public java.util.List<org.flo.protocols.payments.Protos.Output.Builder> 
-           getRefundToBuilderList() {
-        return getRefundToFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.flo.protocols.payments.Protos.Output, org.flo.protocols.payments.Protos.Output.Builder, org.flo.protocols.payments.Protos.OutputOrBuilder> 
-          getRefundToFieldBuilder() {
-        if (refundToBuilder_ == null) {
-          refundToBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.flo.protocols.payments.Protos.Output, org.flo.protocols.payments.Protos.Output.Builder, org.flo.protocols.payments.Protos.OutputOrBuilder>(
-                  refundTo_,
-                  ((bitField0_ & 0x00000004) == 0x00000004),
-                  getParentForChildren(),
-                  isClean());
-          refundTo_ = null;
-        }
-        return refundToBuilder_;
-      }
 
-      private java.lang.Object memo_ = "";
       /**
-       * <code>optional string memo = 4;</code>
-       *
        * <pre>
        * Human-readable message for the merchant
        * </pre>
+       *
+       * <code>optional string memo = 4;</code>
        */
       public boolean hasMemo() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasMemo();
       }
       /**
-       * <code>optional string memo = 4;</code>
-       *
        * <pre>
        * Human-readable message for the merchant
        * </pre>
+       *
+       * <code>optional string memo = 4;</code>
        */
       public java.lang.String getMemo() {
-        java.lang.Object ref = memo_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            memo_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getMemo();
       }
       /**
-       * <code>optional string memo = 4;</code>
-       *
        * <pre>
        * Human-readable message for the merchant
        * </pre>
+       *
+       * <code>optional string memo = 4;</code>
        */
       public com.google.protobuf.ByteString
           getMemoBytes() {
-        java.lang.Object ref = memo_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          memo_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getMemoBytes();
       }
       /**
-       * <code>optional string memo = 4;</code>
-       *
        * <pre>
        * Human-readable message for the merchant
        * </pre>
+       *
+       * <code>optional string memo = 4;</code>
        */
       public Builder setMemo(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemo(value);
         return this;
       }
       /**
-       * <code>optional string memo = 4;</code>
-       *
        * <pre>
        * Human-readable message for the merchant
        * </pre>
+       *
+       * <code>optional string memo = 4;</code>
        */
       public Builder clearMemo() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        memo_ = getDefaultInstance().getMemo();
-        onChanged();
+        copyOnWrite();
+        instance.clearMemo();
         return this;
       }
       /**
-       * <code>optional string memo = 4;</code>
-       *
        * <pre>
        * Human-readable message for the merchant
        * </pre>
+       *
+       * <code>optional string memo = 4;</code>
        */
       public Builder setMemoBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemoBytes(value);
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:payments.Payment)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.protocols.payments.Protos.Payment();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Payment(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          for (int i = 0; i < getRefundToCount(); i++) {
+            if (!getRefundTo(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          transactions_.makeImmutable();
+          refundTo_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.protocols.payments.Protos.Payment other = (org.flo.protocols.payments.Protos.Payment) arg1;
+          merchantData_ = visitor.visitByteString(
+              hasMerchantData(), merchantData_,
+              other.hasMerchantData(), other.merchantData_);
+          transactions_= visitor.visitList(transactions_, other.transactions_);
+          refundTo_= visitor.visitList(refundTo_, other.refundTo_);
+          memo_ = visitor.visitString(
+              hasMemo(), memo_,
+              other.hasMemo(), other.memo_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  merchantData_ = input.readBytes();
+                  break;
+                }
+                case 18: {
+                  if (!transactions_.isModifiable()) {
+                    transactions_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(transactions_);
+                  }
+                  transactions_.add(input.readBytes());
+                  break;
+                }
+                case 26: {
+                  if (!refundTo_.isModifiable()) {
+                    refundTo_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(refundTo_);
+                  }
+                  refundTo_.add(
+                      input.readMessage(org.flo.protocols.payments.Protos.Output.parser(), extensionRegistry));
+                  break;
+                }
+                case 34: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000002;
+                  memo_ = s;
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.protocols.payments.Protos.Payment.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:payments.Payment)
+    private static final org.flo.protocols.payments.Protos.Payment DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Payment();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.protocols.payments.Protos.Payment getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Payment> PARSER;
+
+    public static com.google.protobuf.Parser<Payment> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface PaymentACKOrBuilder extends
       // @@protoc_insertion_point(interface_extends:payments.PaymentACK)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required .payments.Payment payment = 1;</code>
-     *
      * <pre>
      * Payment message that triggered this ACK
      * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
      */
     boolean hasPayment();
     /**
-     * <code>required .payments.Payment payment = 1;</code>
-     *
      * <pre>
      * Payment message that triggered this ACK
      * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
      */
     org.flo.protocols.payments.Protos.Payment getPayment();
-    /**
-     * <code>required .payments.Payment payment = 1;</code>
-     *
-     * <pre>
-     * Payment message that triggered this ACK
-     * </pre>
-     */
-    org.flo.protocols.payments.Protos.PaymentOrBuilder getPaymentOrBuilder();
 
     /**
-     * <code>optional string memo = 2;</code>
-     *
      * <pre>
      * human-readable message for customer
      * </pre>
+     *
+     * <code>optional string memo = 2;</code>
      */
     boolean hasMemo();
     /**
-     * <code>optional string memo = 2;</code>
-     *
      * <pre>
      * human-readable message for customer
      * </pre>
+     *
+     * <code>optional string memo = 2;</code>
      */
     java.lang.String getMemo();
     /**
-     * <code>optional string memo = 2;</code>
-     *
      * <pre>
      * human-readable message for customer
      * </pre>
+     *
+     * <code>optional string memo = 2;</code>
      */
     com.google.protobuf.ByteString
         getMemoBytes();
@@ -5169,236 +4473,177 @@ public final class Protos {
   /**
    * Protobuf type {@code payments.PaymentACK}
    */
-  public static final class PaymentACK extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class PaymentACK extends
+      com.google.protobuf.GeneratedMessageLite<
+          PaymentACK, PaymentACK.Builder> implements
       // @@protoc_insertion_point(message_implements:payments.PaymentACK)
       PaymentACKOrBuilder {
-    // Use PaymentACK.newBuilder() to construct.
-    private PaymentACK(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private PaymentACK() {
+      memo_ = "";
     }
-    private PaymentACK(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final PaymentACK defaultInstance;
-    public static PaymentACK getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public PaymentACK getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PaymentACK(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              org.flo.protocols.payments.Protos.Payment.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                subBuilder = payment_.toBuilder();
-              }
-              payment_ = input.readMessage(org.flo.protocols.payments.Protos.Payment.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(payment_);
-                payment_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000001;
-              break;
-            }
-            case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              memo_ = bs;
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_PaymentACK_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.flo.protocols.payments.Protos.internal_static_payments_PaymentACK_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.flo.protocols.payments.Protos.PaymentACK.class, org.flo.protocols.payments.Protos.PaymentACK.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<PaymentACK> PARSER =
-        new com.google.protobuf.AbstractParser<PaymentACK>() {
-      public PaymentACK parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PaymentACK(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<PaymentACK> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int PAYMENT_FIELD_NUMBER = 1;
     private org.flo.protocols.payments.Protos.Payment payment_;
     /**
-     * <code>required .payments.Payment payment = 1;</code>
-     *
      * <pre>
      * Payment message that triggered this ACK
      * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
      */
     public boolean hasPayment() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required .payments.Payment payment = 1;</code>
-     *
      * <pre>
      * Payment message that triggered this ACK
      * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
      */
     public org.flo.protocols.payments.Protos.Payment getPayment() {
-      return payment_;
+      return payment_ == null ? org.flo.protocols.payments.Protos.Payment.getDefaultInstance() : payment_;
     }
     /**
-     * <code>required .payments.Payment payment = 1;</code>
-     *
      * <pre>
      * Payment message that triggered this ACK
      * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
      */
-    public org.flo.protocols.payments.Protos.PaymentOrBuilder getPaymentOrBuilder() {
-      return payment_;
+    private void setPayment(org.flo.protocols.payments.Protos.Payment value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      payment_ = value;
+      bitField0_ |= 0x00000001;
+      }
+    /**
+     * <pre>
+     * Payment message that triggered this ACK
+     * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
+     */
+    private void setPayment(
+        org.flo.protocols.payments.Protos.Payment.Builder builderForValue) {
+      payment_ = builderForValue.build();
+      bitField0_ |= 0x00000001;
+    }
+    /**
+     * <pre>
+     * Payment message that triggered this ACK
+     * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
+     */
+    private void mergePayment(org.flo.protocols.payments.Protos.Payment value) {
+      if (payment_ != null &&
+          payment_ != org.flo.protocols.payments.Protos.Payment.getDefaultInstance()) {
+        payment_ =
+          org.flo.protocols.payments.Protos.Payment.newBuilder(payment_).mergeFrom(value).buildPartial();
+      } else {
+        payment_ = value;
+      }
+      bitField0_ |= 0x00000001;
+    }
+    /**
+     * <pre>
+     * Payment message that triggered this ACK
+     * </pre>
+     *
+     * <code>required .payments.Payment payment = 1;</code>
+     */
+    private void clearPayment() {  payment_ = null;
+      bitField0_ = (bitField0_ & ~0x00000001);
     }
 
     public static final int MEMO_FIELD_NUMBER = 2;
-    private java.lang.Object memo_;
+    private java.lang.String memo_;
     /**
-     * <code>optional string memo = 2;</code>
-     *
      * <pre>
      * human-readable message for customer
      * </pre>
+     *
+     * <code>optional string memo = 2;</code>
      */
     public boolean hasMemo() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional string memo = 2;</code>
-     *
      * <pre>
      * human-readable message for customer
      * </pre>
+     *
+     * <code>optional string memo = 2;</code>
      */
     public java.lang.String getMemo() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          memo_ = s;
-        }
-        return s;
-      }
+      return memo_;
     }
     /**
-     * <code>optional string memo = 2;</code>
-     *
      * <pre>
      * human-readable message for customer
      * </pre>
+     *
+     * <code>optional string memo = 2;</code>
      */
     public com.google.protobuf.ByteString
         getMemoBytes() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        memo_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(memo_);
     }
-
-    private void initFields() {
-      payment_ = org.flo.protocols.payments.Protos.Payment.getDefaultInstance();
-      memo_ = "";
+    /**
+     * <pre>
+     * human-readable message for customer
+     * </pre>
+     *
+     * <code>optional string memo = 2;</code>
+     */
+    private void setMemo(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      memo_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasPayment()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!getPayment().isInitialized()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * human-readable message for customer
+     * </pre>
+     *
+     * <code>optional string memo = 2;</code>
+     */
+    private void clearMemo() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      memo_ = getDefaultInstance().getMemo();
+    }
+    /**
+     * <pre>
+     * human-readable message for customer
+     * </pre>
+     *
+     * <code>optional string memo = 2;</code>
+     */
+    private void setMemoBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      memo_ = value.toStringUtf8();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeMessage(1, payment_);
+        output.writeMessage(1, getPayment());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getMemoBytes());
+        output.writeString(2, getMemo());
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -5406,605 +4651,375 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, payment_);
+          .computeMessageSize(1, getPayment());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getMemoBytes());
+          .computeStringSize(2, getMemo());
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.flo.protocols.payments.Protos.PaymentACK parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.flo.protocols.payments.Protos.PaymentACK prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code payments.PaymentACK}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.flo.protocols.payments.Protos.PaymentACK, Builder> implements
         // @@protoc_insertion_point(builder_implements:payments.PaymentACK)
         org.flo.protocols.payments.Protos.PaymentACKOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentACK_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentACK_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.flo.protocols.payments.Protos.PaymentACK.class, org.flo.protocols.payments.Protos.PaymentACK.Builder.class);
-      }
-
       // Construct using org.flo.protocols.payments.Protos.PaymentACK.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getPaymentFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        if (paymentBuilder_ == null) {
-          payment_ = org.flo.protocols.payments.Protos.Payment.getDefaultInstance();
-        } else {
-          paymentBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000001);
-        memo_ = "";
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.flo.protocols.payments.Protos.internal_static_payments_PaymentACK_descriptor;
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentACK getDefaultInstanceForType() {
-        return org.flo.protocols.payments.Protos.PaymentACK.getDefaultInstance();
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentACK build() {
-        org.flo.protocols.payments.Protos.PaymentACK result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.flo.protocols.payments.Protos.PaymentACK buildPartial() {
-        org.flo.protocols.payments.Protos.PaymentACK result = new org.flo.protocols.payments.Protos.PaymentACK(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        if (paymentBuilder_ == null) {
-          result.payment_ = payment_;
-        } else {
-          result.payment_ = paymentBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.memo_ = memo_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.flo.protocols.payments.Protos.PaymentACK) {
-          return mergeFrom((org.flo.protocols.payments.Protos.PaymentACK)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.flo.protocols.payments.Protos.PaymentACK other) {
-        if (other == org.flo.protocols.payments.Protos.PaymentACK.getDefaultInstance()) return this;
-        if (other.hasPayment()) {
-          mergePayment(other.getPayment());
-        }
-        if (other.hasMemo()) {
-          bitField0_ |= 0x00000002;
-          memo_ = other.memo_;
-          onChanged();
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasPayment()) {
-          
-          return false;
-        }
-        if (!getPayment().isInitialized()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.flo.protocols.payments.Protos.PaymentACK parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.flo.protocols.payments.Protos.PaymentACK) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private org.flo.protocols.payments.Protos.Payment payment_ = org.flo.protocols.payments.Protos.Payment.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.protocols.payments.Protos.Payment, org.flo.protocols.payments.Protos.Payment.Builder, org.flo.protocols.payments.Protos.PaymentOrBuilder> paymentBuilder_;
       /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
        * <pre>
        * Payment message that triggered this ACK
        * </pre>
+       *
+       * <code>required .payments.Payment payment = 1;</code>
        */
       public boolean hasPayment() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasPayment();
       }
       /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
        * <pre>
        * Payment message that triggered this ACK
        * </pre>
+       *
+       * <code>required .payments.Payment payment = 1;</code>
        */
       public org.flo.protocols.payments.Protos.Payment getPayment() {
-        if (paymentBuilder_ == null) {
-          return payment_;
-        } else {
-          return paymentBuilder_.getMessage();
-        }
+        return instance.getPayment();
       }
       /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
        * <pre>
        * Payment message that triggered this ACK
        * </pre>
+       *
+       * <code>required .payments.Payment payment = 1;</code>
        */
       public Builder setPayment(org.flo.protocols.payments.Protos.Payment value) {
-        if (paymentBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          payment_ = value;
-          onChanged();
-        } else {
-          paymentBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000001;
+        copyOnWrite();
+        instance.setPayment(value);
         return this;
-      }
+        }
       /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
        * <pre>
        * Payment message that triggered this ACK
        * </pre>
+       *
+       * <code>required .payments.Payment payment = 1;</code>
        */
       public Builder setPayment(
           org.flo.protocols.payments.Protos.Payment.Builder builderForValue) {
-        if (paymentBuilder_ == null) {
-          payment_ = builderForValue.build();
-          onChanged();
-        } else {
-          paymentBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000001;
+        copyOnWrite();
+        instance.setPayment(builderForValue);
         return this;
       }
       /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
        * <pre>
        * Payment message that triggered this ACK
        * </pre>
+       *
+       * <code>required .payments.Payment payment = 1;</code>
        */
       public Builder mergePayment(org.flo.protocols.payments.Protos.Payment value) {
-        if (paymentBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
-              payment_ != org.flo.protocols.payments.Protos.Payment.getDefaultInstance()) {
-            payment_ =
-              org.flo.protocols.payments.Protos.Payment.newBuilder(payment_).mergeFrom(value).buildPartial();
-          } else {
-            payment_ = value;
-          }
-          onChanged();
-        } else {
-          paymentBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000001;
+        copyOnWrite();
+        instance.mergePayment(value);
         return this;
       }
       /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
        * <pre>
        * Payment message that triggered this ACK
        * </pre>
+       *
+       * <code>required .payments.Payment payment = 1;</code>
        */
-      public Builder clearPayment() {
-        if (paymentBuilder_ == null) {
-          payment_ = org.flo.protocols.payments.Protos.Payment.getDefaultInstance();
-          onChanged();
-        } else {
-          paymentBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000001);
+      public Builder clearPayment() {  copyOnWrite();
+        instance.clearPayment();
         return this;
-      }
-      /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
-       * <pre>
-       * Payment message that triggered this ACK
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.Payment.Builder getPaymentBuilder() {
-        bitField0_ |= 0x00000001;
-        onChanged();
-        return getPaymentFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
-       * <pre>
-       * Payment message that triggered this ACK
-       * </pre>
-       */
-      public org.flo.protocols.payments.Protos.PaymentOrBuilder getPaymentOrBuilder() {
-        if (paymentBuilder_ != null) {
-          return paymentBuilder_.getMessageOrBuilder();
-        } else {
-          return payment_;
-        }
-      }
-      /**
-       * <code>required .payments.Payment payment = 1;</code>
-       *
-       * <pre>
-       * Payment message that triggered this ACK
-       * </pre>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.flo.protocols.payments.Protos.Payment, org.flo.protocols.payments.Protos.Payment.Builder, org.flo.protocols.payments.Protos.PaymentOrBuilder> 
-          getPaymentFieldBuilder() {
-        if (paymentBuilder_ == null) {
-          paymentBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.flo.protocols.payments.Protos.Payment, org.flo.protocols.payments.Protos.Payment.Builder, org.flo.protocols.payments.Protos.PaymentOrBuilder>(
-                  getPayment(),
-                  getParentForChildren(),
-                  isClean());
-          payment_ = null;
-        }
-        return paymentBuilder_;
       }
 
-      private java.lang.Object memo_ = "";
       /**
-       * <code>optional string memo = 2;</code>
-       *
        * <pre>
        * human-readable message for customer
        * </pre>
+       *
+       * <code>optional string memo = 2;</code>
        */
       public boolean hasMemo() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasMemo();
       }
       /**
-       * <code>optional string memo = 2;</code>
-       *
        * <pre>
        * human-readable message for customer
        * </pre>
+       *
+       * <code>optional string memo = 2;</code>
        */
       public java.lang.String getMemo() {
-        java.lang.Object ref = memo_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            memo_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getMemo();
       }
       /**
-       * <code>optional string memo = 2;</code>
-       *
        * <pre>
        * human-readable message for customer
        * </pre>
+       *
+       * <code>optional string memo = 2;</code>
        */
       public com.google.protobuf.ByteString
           getMemoBytes() {
-        java.lang.Object ref = memo_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          memo_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getMemoBytes();
       }
       /**
-       * <code>optional string memo = 2;</code>
-       *
        * <pre>
        * human-readable message for customer
        * </pre>
+       *
+       * <code>optional string memo = 2;</code>
        */
       public Builder setMemo(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemo(value);
         return this;
       }
       /**
-       * <code>optional string memo = 2;</code>
-       *
        * <pre>
        * human-readable message for customer
        * </pre>
+       *
+       * <code>optional string memo = 2;</code>
        */
       public Builder clearMemo() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        memo_ = getDefaultInstance().getMemo();
-        onChanged();
+        copyOnWrite();
+        instance.clearMemo();
         return this;
       }
       /**
-       * <code>optional string memo = 2;</code>
-       *
        * <pre>
        * human-readable message for customer
        * </pre>
+       *
+       * <code>optional string memo = 2;</code>
        */
       public Builder setMemoBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemoBytes(value);
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:payments.PaymentACK)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.flo.protocols.payments.Protos.PaymentACK();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new PaymentACK(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:payments.PaymentACK)
-  }
-
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_payments_Output_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_payments_Output_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_payments_PaymentDetails_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_payments_PaymentDetails_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_payments_PaymentRequest_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_payments_PaymentRequest_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_payments_X509Certificates_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_payments_X509Certificates_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_payments_Payment_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_payments_Payment_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_payments_PaymentACK_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_payments_PaymentACK_fieldAccessorTable;
-
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
-    return descriptor;
-  }
-  private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
-  static {
-    java.lang.String[] descriptorData = {
-      "\n\024paymentrequest.proto\022\010payments\"+\n\006Outp" +
-      "ut\022\021\n\006amount\030\001 \001(\004:\0010\022\016\n\006script\030\002 \002(\014\"\243\001" +
-      "\n\016PaymentDetails\022\025\n\007network\030\001 \001(\t:\004main\022" +
-      "!\n\007outputs\030\002 \003(\0132\020.payments.Output\022\014\n\004ti" +
-      "me\030\003 \002(\004\022\017\n\007expires\030\004 \001(\004\022\014\n\004memo\030\005 \001(\t\022" +
-      "\023\n\013payment_url\030\006 \001(\t\022\025\n\rmerchant_data\030\007 " +
-      "\001(\014\"\225\001\n\016PaymentRequest\022\"\n\027payment_detail" +
-      "s_version\030\001 \001(\r:\0011\022\026\n\010pki_type\030\002 \001(\t:\004no" +
-      "ne\022\020\n\010pki_data\030\003 \001(\014\022\"\n\032serialized_payme" +
-      "nt_details\030\004 \002(\014\022\021\n\tsignature\030\005 \001(\014\"\'\n\020X",
-      "509Certificates\022\023\n\013certificate\030\001 \003(\014\"i\n\007" +
-      "Payment\022\025\n\rmerchant_data\030\001 \001(\014\022\024\n\014transa" +
-      "ctions\030\002 \003(\014\022#\n\trefund_to\030\003 \003(\0132\020.paymen" +
-      "ts.Output\022\014\n\004memo\030\004 \001(\t\">\n\nPaymentACK\022\"\n" +
-      "\007payment\030\001 \002(\0132\021.payments.Payment\022\014\n\004mem" +
-      "o\030\002 \001(\tB$\n\032org.flo.protocols.paymentsB\006P" +
-      "rotos"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasPayment()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
             return null;
           }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-    internal_static_payments_Output_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_payments_Output_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_payments_Output_descriptor,
-        new java.lang.String[] { "Amount", "Script", });
-    internal_static_payments_PaymentDetails_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_payments_PaymentDetails_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_payments_PaymentDetails_descriptor,
-        new java.lang.String[] { "Network", "Outputs", "Time", "Expires", "Memo", "PaymentUrl", "MerchantData", });
-    internal_static_payments_PaymentRequest_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_payments_PaymentRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_payments_PaymentRequest_descriptor,
-        new java.lang.String[] { "PaymentDetailsVersion", "PkiType", "PkiData", "SerializedPaymentDetails", "Signature", });
-    internal_static_payments_X509Certificates_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_payments_X509Certificates_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_payments_X509Certificates_descriptor,
-        new java.lang.String[] { "Certificate", });
-    internal_static_payments_Payment_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_payments_Payment_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_payments_Payment_descriptor,
-        new java.lang.String[] { "MerchantData", "Transactions", "RefundTo", "Memo", });
-    internal_static_payments_PaymentACK_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_payments_PaymentACK_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_payments_PaymentACK_descriptor,
-        new java.lang.String[] { "Payment", "Memo", });
+          if (!getPayment().isInitialized()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.flo.protocols.payments.Protos.PaymentACK other = (org.flo.protocols.payments.Protos.PaymentACK) arg1;
+          payment_ = visitor.visitMessage(payment_, other.payment_);
+          memo_ = visitor.visitString(
+              hasMemo(), memo_,
+              other.hasMemo(), other.memo_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  org.flo.protocols.payments.Protos.Payment.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                    subBuilder = payment_.toBuilder();
+                  }
+                  payment_ = input.readMessage(org.flo.protocols.payments.Protos.Payment.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(payment_);
+                    payment_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000001;
+                  break;
+                }
+                case 18: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000002;
+                  memo_ = s;
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.flo.protocols.payments.Protos.PaymentACK.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
+    }
+
+
+    // @@protoc_insertion_point(class_scope:payments.PaymentACK)
+    private static final org.flo.protocols.payments.Protos.PaymentACK DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new PaymentACK();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.flo.protocols.payments.Protos.PaymentACK getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<PaymentACK> PARSER;
+
+    public static com.google.protobuf.Parser<PaymentACK> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
+  }
+
+
+  static {
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/floj-core/src/main/java/org/floj/protocols/channels/ClientState.java
+++ b/floj-core/src/main/java/org/floj/protocols/channels/ClientState.java
@@ -6,11 +6,11 @@ package org.floj.protocols.channels;
 public final class ClientState {
   private ClientState() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
   }
   public interface StoredClientPaymentChannelsOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.StoredClientPaymentChannels)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
@@ -25,125 +25,24 @@ public final class ClientState {
      * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
      */
     int getChannelsCount();
-    /**
-     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-     */
-    java.util.List<? extends org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder> 
-        getChannelsOrBuilderList();
-    /**
-     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-     */
-    org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder getChannelsOrBuilder(
-        int index);
   }
   /**
-   * Protobuf type {@code paymentchannels.StoredClientPaymentChannels}
-   *
    * <pre>
    * A set of StoredPaymentChannel's
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.StoredClientPaymentChannels}
    */
-  public static final class StoredClientPaymentChannels extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class StoredClientPaymentChannels extends
+      com.google.protobuf.GeneratedMessageLite<
+          StoredClientPaymentChannels, StoredClientPaymentChannels.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.StoredClientPaymentChannels)
       StoredClientPaymentChannelsOrBuilder {
-    // Use StoredClientPaymentChannels.newBuilder() to construct.
-    private StoredClientPaymentChannels(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private StoredClientPaymentChannels() {
+      channels_ = emptyProtobufList();
     }
-    private StoredClientPaymentChannels(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final StoredClientPaymentChannels defaultInstance;
-    public static StoredClientPaymentChannels getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public StoredClientPaymentChannels getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private StoredClientPaymentChannels(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                channels_ = new java.util.ArrayList<org.floj.protocols.channels.ClientState.StoredClientPaymentChannel>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              channels_.add(input.readMessage(org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.PARSER, extensionRegistry));
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          channels_ = java.util.Collections.unmodifiableList(channels_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannels_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannels_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.class, org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<StoredClientPaymentChannels> PARSER =
-        new com.google.protobuf.AbstractParser<StoredClientPaymentChannels>() {
-      public StoredClientPaymentChannels parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StoredClientPaymentChannels(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<StoredClientPaymentChannels> getParserForType() {
-      return PARSER;
-    }
-
     public static final int CHANNELS_FIELD_NUMBER = 1;
-    private java.util.List<org.floj.protocols.channels.ClientState.StoredClientPaymentChannel> channels_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.protocols.channels.ClientState.StoredClientPaymentChannel> channels_;
     /**
      * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
      */
@@ -176,36 +75,100 @@ public final class ClientState {
         int index) {
       return channels_.get(index);
     }
-
-    private void initFields() {
-      channels_ = java.util.Collections.emptyList();
+    private void ensureChannelsIsMutable() {
+      if (!channels_.isModifiable()) {
+        channels_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(channels_);
+       }
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
 
-      for (int i = 0; i < getChannelsCount(); i++) {
-        if (!getChannels(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void setChannels(
+        int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel value) {
+      if (value == null) {
+        throw new NullPointerException();
       }
-      memoizedIsInitialized = 1;
-      return true;
+      ensureChannelsIsMutable();
+      channels_.set(index, value);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void setChannels(
+        int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder builderForValue) {
+      ensureChannelsIsMutable();
+      channels_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(org.floj.protocols.channels.ClientState.StoredClientPaymentChannel value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureChannelsIsMutable();
+      channels_.add(value);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(
+        int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureChannelsIsMutable();
+      channels_.add(index, value);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(
+        org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder builderForValue) {
+      ensureChannelsIsMutable();
+      channels_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(
+        int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder builderForValue) {
+      ensureChannelsIsMutable();
+      channels_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void addAllChannels(
+        java.lang.Iterable<? extends org.floj.protocols.channels.ClientState.StoredClientPaymentChannel> values) {
+      ensureChannelsIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, channels_);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void clearChannels() {
+      channels_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
+     */
+    private void removeChannels(int index) {
+      ensureChannelsIsMutable();
+      channels_.remove(index);
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       for (int i = 0; i < channels_.size(); i++) {
         output.writeMessage(1, channels_.get(i));
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -215,301 +178,122 @@ public final class ClientState {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, channels_.get(i));
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.protocols.channels.ClientState.StoredClientPaymentChannels prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.StoredClientPaymentChannels}
-     *
      * <pre>
      * A set of StoredPaymentChannel's
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.StoredClientPaymentChannels}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.protocols.channels.ClientState.StoredClientPaymentChannels, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.StoredClientPaymentChannels)
         org.floj.protocols.channels.ClientState.StoredClientPaymentChannelsOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannels_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannels_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.class, org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.Builder.class);
-      }
-
       // Construct using org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getChannelsFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-
-      public Builder clear() {
-        super.clear();
-        if (channelsBuilder_ == null) {
-          channels_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          channelsBuilder_.clear();
-        }
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannels_descriptor;
-      }
-
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannels getDefaultInstanceForType() {
-        return org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.getDefaultInstance();
-      }
-
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannels build() {
-        org.floj.protocols.channels.ClientState.StoredClientPaymentChannels result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannels buildPartial() {
-        org.floj.protocols.channels.ClientState.StoredClientPaymentChannels result = new org.floj.protocols.channels.ClientState.StoredClientPaymentChannels(this);
-        int from_bitField0_ = bitField0_;
-        if (channelsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            channels_ = java.util.Collections.unmodifiableList(channels_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.channels_ = channels_;
-        } else {
-          result.channels_ = channelsBuilder_.build();
-        }
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.protocols.channels.ClientState.StoredClientPaymentChannels) {
-          return mergeFrom((org.floj.protocols.channels.ClientState.StoredClientPaymentChannels)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.protocols.channels.ClientState.StoredClientPaymentChannels other) {
-        if (other == org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.getDefaultInstance()) return this;
-        if (channelsBuilder_ == null) {
-          if (!other.channels_.isEmpty()) {
-            if (channels_.isEmpty()) {
-              channels_ = other.channels_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureChannelsIsMutable();
-              channels_.addAll(other.channels_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.channels_.isEmpty()) {
-            if (channelsBuilder_.isEmpty()) {
-              channelsBuilder_.dispose();
-              channelsBuilder_ = null;
-              channels_ = other.channels_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-              channelsBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getChannelsFieldBuilder() : null;
-            } else {
-              channelsBuilder_.addAllMessages(other.channels_);
-            }
-          }
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        for (int i = 0; i < getChannelsCount(); i++) {
-          if (!getChannels(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.protocols.channels.ClientState.StoredClientPaymentChannels parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.protocols.channels.ClientState.StoredClientPaymentChannels) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.util.List<org.floj.protocols.channels.ClientState.StoredClientPaymentChannel> channels_ =
-        java.util.Collections.emptyList();
-      private void ensureChannelsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          channels_ = new java.util.ArrayList<org.floj.protocols.channels.ClientState.StoredClientPaymentChannel>(channels_);
-          bitField0_ |= 0x00000001;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.protocols.channels.ClientState.StoredClientPaymentChannel, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder, org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder> channelsBuilder_;
 
       /**
        * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
        */
       public java.util.List<org.floj.protocols.channels.ClientState.StoredClientPaymentChannel> getChannelsList() {
-        if (channelsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(channels_);
-        } else {
-          return channelsBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getChannelsList());
       }
       /**
        * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
        */
       public int getChannelsCount() {
-        if (channelsBuilder_ == null) {
-          return channels_.size();
-        } else {
-          return channelsBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getChannelsCount();
+      }/**
        * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
        */
       public org.floj.protocols.channels.ClientState.StoredClientPaymentChannel getChannels(int index) {
-        if (channelsBuilder_ == null) {
-          return channels_.get(index);
-        } else {
-          return channelsBuilder_.getMessage(index);
-        }
+        return instance.getChannels(index);
       }
       /**
        * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
        */
       public Builder setChannels(
           int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel value) {
-        if (channelsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureChannelsIsMutable();
-          channels_.set(index, value);
-          onChanged();
-        } else {
-          channelsBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setChannels(index, value);
         return this;
       }
       /**
@@ -517,29 +301,16 @@ public final class ClientState {
        */
       public Builder setChannels(
           int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder builderForValue) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          channelsBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setChannels(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
        */
       public Builder addChannels(org.floj.protocols.channels.ClientState.StoredClientPaymentChannel value) {
-        if (channelsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureChannelsIsMutable();
-          channels_.add(value);
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addChannels(value);
         return this;
       }
       /**
@@ -547,16 +318,8 @@ public final class ClientState {
        */
       public Builder addChannels(
           int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel value) {
-        if (channelsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureChannelsIsMutable();
-          channels_.add(index, value);
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addChannels(index, value);
         return this;
       }
       /**
@@ -564,13 +327,8 @@ public final class ClientState {
        */
       public Builder addChannels(
           org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder builderForValue) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.add(builderForValue.build());
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addChannels(builderForValue);
         return this;
       }
       /**
@@ -578,13 +336,8 @@ public final class ClientState {
        */
       public Builder addChannels(
           int index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder builderForValue) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addChannels(index, builderForValue);
         return this;
       }
       /**
@@ -592,121 +345,148 @@ public final class ClientState {
        */
       public Builder addAllChannels(
           java.lang.Iterable<? extends org.floj.protocols.channels.ClientState.StoredClientPaymentChannel> values) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, channels_);
-          onChanged();
-        } else {
-          channelsBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllChannels(values);
         return this;
       }
       /**
        * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
        */
       public Builder clearChannels() {
-        if (channelsBuilder_ == null) {
-          channels_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          channelsBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearChannels();
         return this;
       }
       /**
        * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
        */
       public Builder removeChannels(int index) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.remove(index);
-          onChanged();
-        } else {
-          channelsBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeChannels(index);
         return this;
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder getChannelsBuilder(
-          int index) {
-        return getChannelsFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder getChannelsOrBuilder(
-          int index) {
-        if (channelsBuilder_ == null) {
-          return channels_.get(index);  } else {
-          return channelsBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-       */
-      public java.util.List<? extends org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder> 
-           getChannelsOrBuilderList() {
-        if (channelsBuilder_ != null) {
-          return channelsBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(channels_);
-        }
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder addChannelsBuilder() {
-        return getChannelsFieldBuilder().addBuilder(
-            org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder addChannelsBuilder(
-          int index) {
-        return getChannelsFieldBuilder().addBuilder(
-            index, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredClientPaymentChannel channels = 1;</code>
-       */
-      public java.util.List<org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder> 
-           getChannelsBuilderList() {
-        return getChannelsFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.protocols.channels.ClientState.StoredClientPaymentChannel, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder, org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder> 
-          getChannelsFieldBuilder() {
-        if (channelsBuilder_ == null) {
-          channelsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.protocols.channels.ClientState.StoredClientPaymentChannel, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder, org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder>(
-                  channels_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
-                  getParentForChildren(),
-                  isClean());
-          channels_ = null;
-        }
-        return channelsBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.StoredClientPaymentChannels)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.protocols.channels.ClientState.StoredClientPaymentChannels();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new StoredClientPaymentChannels(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          for (int i = 0; i < getChannelsCount(); i++) {
+            if (!getChannels(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          channels_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.protocols.channels.ClientState.StoredClientPaymentChannels other = (org.floj.protocols.channels.ClientState.StoredClientPaymentChannels) arg1;
+          channels_= visitor.visitList(channels_, other.channels_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  if (!channels_.isModifiable()) {
+                    channels_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(channels_);
+                  }
+                  channels_.add(
+                      input.readMessage(org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.parser(), extensionRegistry));
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.protocols.channels.ClientState.StoredClientPaymentChannels.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.StoredClientPaymentChannels)
+    private static final org.floj.protocols.channels.ClientState.StoredClientPaymentChannels DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new StoredClientPaymentChannels();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannels getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<StoredClientPaymentChannels> PARSER;
+
+    public static com.google.protobuf.Parser<StoredClientPaymentChannels> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface StoredClientPaymentChannelOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.StoredClientPaymentChannel)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required bytes id = 1;</code>
@@ -745,19 +525,19 @@ public final class ClientState {
     com.google.protobuf.ByteString getMyPublicKey();
 
     /**
-     * <code>required bytes myKey = 4;</code>
-     *
      * <pre>
      * Deprecated, key is already stored in the wallet, and found using myPublicKey;
      * </pre>
+     *
+     * <code>required bytes myKey = 4;</code>
      */
     boolean hasMyKey();
     /**
-     * <code>required bytes myKey = 4;</code>
-     *
      * <pre>
      * Deprecated, key is already stored in the wallet, and found using myPublicKey;
      * </pre>
+     *
+     * <code>required bytes myKey = 4;</code>
      */
     com.google.protobuf.ByteString getMyKey();
 
@@ -771,40 +551,40 @@ public final class ClientState {
     long getValueToMe();
 
     /**
-     * <code>required uint64 refundFees = 6;</code>
-     *
      * <pre>
      * Fees required to refund the transaction.
      * </pre>
+     *
+     * <code>required uint64 refundFees = 6;</code>
      */
     boolean hasRefundFees();
     /**
-     * <code>required uint64 refundFees = 6;</code>
-     *
      * <pre>
      * Fees required to refund the transaction.
      * </pre>
+     *
+     * <code>required uint64 refundFees = 6;</code>
      */
     long getRefundFees();
 
     /**
-     * <code>optional bytes closeTransactionHash = 7;</code>
-     *
      * <pre>
      * When set, the hash of the transaction that was presented by the server for closure of the channel.
      * It spends the contractTransaction and is expected to be broadcast to the network by the server.
      * It's supposed to be in the wallet already.
      * </pre>
+     *
+     * <code>optional bytes closeTransactionHash = 7;</code>
      */
     boolean hasCloseTransactionHash();
     /**
-     * <code>optional bytes closeTransactionHash = 7;</code>
-     *
      * <pre>
      * When set, the hash of the transaction that was presented by the server for closure of the channel.
      * It spends the contractTransaction and is expected to be broadcast to the network by the server.
      * It's supposed to be in the wallet already.
      * </pre>
+     *
+     * <code>optional bytes closeTransactionHash = 7;</code>
      */
     com.google.protobuf.ByteString getCloseTransactionHash();
 
@@ -818,190 +598,62 @@ public final class ClientState {
     int getMajorVersion();
 
     /**
-     * <code>optional uint64 expiryTime = 10;</code>
-     *
      * <pre>
      * The expiry time of the CLTV lock. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional uint64 expiryTime = 10;</code>
      */
     boolean hasExpiryTime();
     /**
-     * <code>optional uint64 expiryTime = 10;</code>
-     *
      * <pre>
      * The expiry time of the CLTV lock. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional uint64 expiryTime = 10;</code>
      */
     long getExpiryTime();
 
     /**
-     * <code>optional bytes serverKey = 11;</code>
-     *
      * <pre>
      * The server's public key. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional bytes serverKey = 11;</code>
      */
     boolean hasServerKey();
     /**
-     * <code>optional bytes serverKey = 11;</code>
-     *
      * <pre>
      * The server's public key. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional bytes serverKey = 11;</code>
      */
     com.google.protobuf.ByteString getServerKey();
   }
   /**
-   * Protobuf type {@code paymentchannels.StoredClientPaymentChannel}
-   *
    * <pre>
    * A client-side payment channel in serialized form, which can be reloaded later if the client restarts and wants to
    * reopen an existing channel
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.StoredClientPaymentChannel}
    */
-  public static final class StoredClientPaymentChannel extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class StoredClientPaymentChannel extends
+      com.google.protobuf.GeneratedMessageLite<
+          StoredClientPaymentChannel, StoredClientPaymentChannel.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.StoredClientPaymentChannel)
       StoredClientPaymentChannelOrBuilder {
-    // Use StoredClientPaymentChannel.newBuilder() to construct.
-    private StoredClientPaymentChannel(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private StoredClientPaymentChannel() {
+      id_ = com.google.protobuf.ByteString.EMPTY;
+      contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
+      refundTransaction_ = com.google.protobuf.ByteString.EMPTY;
+      myPublicKey_ = com.google.protobuf.ByteString.EMPTY;
+      myKey_ = com.google.protobuf.ByteString.EMPTY;
+      closeTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
+      majorVersion_ = 1;
+      serverKey_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private StoredClientPaymentChannel(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final StoredClientPaymentChannel defaultInstance;
-    public static StoredClientPaymentChannel getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public StoredClientPaymentChannel getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private StoredClientPaymentChannel(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              contractTransaction_ = input.readBytes();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              refundTransaction_ = input.readBytes();
-              break;
-            }
-            case 34: {
-              bitField0_ |= 0x00000010;
-              myKey_ = input.readBytes();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000020;
-              valueToMe_ = input.readUInt64();
-              break;
-            }
-            case 48: {
-              bitField0_ |= 0x00000040;
-              refundFees_ = input.readUInt64();
-              break;
-            }
-            case 58: {
-              bitField0_ |= 0x00000080;
-              closeTransactionHash_ = input.readBytes();
-              break;
-            }
-            case 66: {
-              bitField0_ |= 0x00000008;
-              myPublicKey_ = input.readBytes();
-              break;
-            }
-            case 72: {
-              bitField0_ |= 0x00000100;
-              majorVersion_ = input.readUInt32();
-              break;
-            }
-            case 80: {
-              bitField0_ |= 0x00000200;
-              expiryTime_ = input.readUInt64();
-              break;
-            }
-            case 90: {
-              bitField0_ |= 0x00000400;
-              serverKey_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannel_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannel_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.class, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<StoredClientPaymentChannel> PARSER =
-        new com.google.protobuf.AbstractParser<StoredClientPaymentChannel>() {
-      public StoredClientPaymentChannel parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StoredClientPaymentChannel(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<StoredClientPaymentChannel> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ID_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString id_;
@@ -1016,6 +668,23 @@ public final class ClientState {
      */
     public com.google.protobuf.ByteString getId() {
       return id_;
+    }
+    /**
+     * <code>required bytes id = 1;</code>
+     */
+    private void setId(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      id_ = value;
+    }
+    /**
+     * <code>required bytes id = 1;</code>
+     */
+    private void clearId() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      id_ = getDefaultInstance().getId();
     }
 
     public static final int CONTRACTTRANSACTION_FIELD_NUMBER = 2;
@@ -1032,6 +701,23 @@ public final class ClientState {
     public com.google.protobuf.ByteString getContractTransaction() {
       return contractTransaction_;
     }
+    /**
+     * <code>required bytes contractTransaction = 2;</code>
+     */
+    private void setContractTransaction(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      contractTransaction_ = value;
+    }
+    /**
+     * <code>required bytes contractTransaction = 2;</code>
+     */
+    private void clearContractTransaction() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      contractTransaction_ = getDefaultInstance().getContractTransaction();
+    }
 
     public static final int REFUNDTRANSACTION_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString refundTransaction_;
@@ -1046,6 +732,23 @@ public final class ClientState {
      */
     public com.google.protobuf.ByteString getRefundTransaction() {
       return refundTransaction_;
+    }
+    /**
+     * <code>required bytes refundTransaction = 3;</code>
+     */
+    private void setRefundTransaction(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      refundTransaction_ = value;
+    }
+    /**
+     * <code>required bytes refundTransaction = 3;</code>
+     */
+    private void clearRefundTransaction() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      refundTransaction_ = getDefaultInstance().getRefundTransaction();
     }
 
     public static final int MYPUBLICKEY_FIELD_NUMBER = 8;
@@ -1062,28 +765,70 @@ public final class ClientState {
     public com.google.protobuf.ByteString getMyPublicKey() {
       return myPublicKey_;
     }
+    /**
+     * <code>required bytes myPublicKey = 8;</code>
+     */
+    private void setMyPublicKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+      myPublicKey_ = value;
+    }
+    /**
+     * <code>required bytes myPublicKey = 8;</code>
+     */
+    private void clearMyPublicKey() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      myPublicKey_ = getDefaultInstance().getMyPublicKey();
+    }
 
     public static final int MYKEY_FIELD_NUMBER = 4;
     private com.google.protobuf.ByteString myKey_;
     /**
-     * <code>required bytes myKey = 4;</code>
-     *
      * <pre>
      * Deprecated, key is already stored in the wallet, and found using myPublicKey;
      * </pre>
+     *
+     * <code>required bytes myKey = 4;</code>
      */
     public boolean hasMyKey() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>required bytes myKey = 4;</code>
-     *
      * <pre>
      * Deprecated, key is already stored in the wallet, and found using myPublicKey;
      * </pre>
+     *
+     * <code>required bytes myKey = 4;</code>
      */
     public com.google.protobuf.ByteString getMyKey() {
       return myKey_;
+    }
+    /**
+     * <pre>
+     * Deprecated, key is already stored in the wallet, and found using myPublicKey;
+     * </pre>
+     *
+     * <code>required bytes myKey = 4;</code>
+     */
+    private void setMyKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+      myKey_ = value;
+    }
+    /**
+     * <pre>
+     * Deprecated, key is already stored in the wallet, and found using myPublicKey;
+     * </pre>
+     *
+     * <code>required bytes myKey = 4;</code>
+     */
+    private void clearMyKey() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      myKey_ = getDefaultInstance().getMyKey();
     }
 
     public static final int VALUETOME_FIELD_NUMBER = 5;
@@ -1100,55 +845,120 @@ public final class ClientState {
     public long getValueToMe() {
       return valueToMe_;
     }
+    /**
+     * <code>required uint64 valueToMe = 5;</code>
+     */
+    private void setValueToMe(long value) {
+      bitField0_ |= 0x00000020;
+      valueToMe_ = value;
+    }
+    /**
+     * <code>required uint64 valueToMe = 5;</code>
+     */
+    private void clearValueToMe() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      valueToMe_ = 0L;
+    }
 
     public static final int REFUNDFEES_FIELD_NUMBER = 6;
     private long refundFees_;
     /**
-     * <code>required uint64 refundFees = 6;</code>
-     *
      * <pre>
      * Fees required to refund the transaction.
      * </pre>
+     *
+     * <code>required uint64 refundFees = 6;</code>
      */
     public boolean hasRefundFees() {
       return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
-     * <code>required uint64 refundFees = 6;</code>
-     *
      * <pre>
      * Fees required to refund the transaction.
      * </pre>
+     *
+     * <code>required uint64 refundFees = 6;</code>
      */
     public long getRefundFees() {
       return refundFees_;
+    }
+    /**
+     * <pre>
+     * Fees required to refund the transaction.
+     * </pre>
+     *
+     * <code>required uint64 refundFees = 6;</code>
+     */
+    private void setRefundFees(long value) {
+      bitField0_ |= 0x00000040;
+      refundFees_ = value;
+    }
+    /**
+     * <pre>
+     * Fees required to refund the transaction.
+     * </pre>
+     *
+     * <code>required uint64 refundFees = 6;</code>
+     */
+    private void clearRefundFees() {
+      bitField0_ = (bitField0_ & ~0x00000040);
+      refundFees_ = 0L;
     }
 
     public static final int CLOSETRANSACTIONHASH_FIELD_NUMBER = 7;
     private com.google.protobuf.ByteString closeTransactionHash_;
     /**
-     * <code>optional bytes closeTransactionHash = 7;</code>
-     *
      * <pre>
      * When set, the hash of the transaction that was presented by the server for closure of the channel.
      * It spends the contractTransaction and is expected to be broadcast to the network by the server.
      * It's supposed to be in the wallet already.
      * </pre>
+     *
+     * <code>optional bytes closeTransactionHash = 7;</code>
      */
     public boolean hasCloseTransactionHash() {
       return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
-     * <code>optional bytes closeTransactionHash = 7;</code>
-     *
      * <pre>
      * When set, the hash of the transaction that was presented by the server for closure of the channel.
      * It spends the contractTransaction and is expected to be broadcast to the network by the server.
      * It's supposed to be in the wallet already.
      * </pre>
+     *
+     * <code>optional bytes closeTransactionHash = 7;</code>
      */
     public com.google.protobuf.ByteString getCloseTransactionHash() {
       return closeTransactionHash_;
+    }
+    /**
+     * <pre>
+     * When set, the hash of the transaction that was presented by the server for closure of the channel.
+     * It spends the contractTransaction and is expected to be broadcast to the network by the server.
+     * It's supposed to be in the wallet already.
+     * </pre>
+     *
+     * <code>optional bytes closeTransactionHash = 7;</code>
+     */
+    private void setCloseTransactionHash(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+      closeTransactionHash_ = value;
+    }
+    /**
+     * <pre>
+     * When set, the hash of the transaction that was presented by the server for closure of the channel.
+     * It spends the contractTransaction and is expected to be broadcast to the network by the server.
+     * It's supposed to be in the wallet already.
+     * </pre>
+     *
+     * <code>optional bytes closeTransactionHash = 7;</code>
+     */
+    private void clearCloseTransactionHash() {
+      bitField0_ = (bitField0_ & ~0x00000080);
+      closeTransactionHash_ = getDefaultInstance().getCloseTransactionHash();
     }
 
     public static final int MAJORVERSION_FIELD_NUMBER = 9;
@@ -1165,107 +975,116 @@ public final class ClientState {
     public int getMajorVersion() {
       return majorVersion_;
     }
+    /**
+     * <code>optional uint32 majorVersion = 9 [default = 1];</code>
+     */
+    private void setMajorVersion(int value) {
+      bitField0_ |= 0x00000100;
+      majorVersion_ = value;
+    }
+    /**
+     * <code>optional uint32 majorVersion = 9 [default = 1];</code>
+     */
+    private void clearMajorVersion() {
+      bitField0_ = (bitField0_ & ~0x00000100);
+      majorVersion_ = 1;
+    }
 
     public static final int EXPIRYTIME_FIELD_NUMBER = 10;
     private long expiryTime_;
     /**
-     * <code>optional uint64 expiryTime = 10;</code>
-     *
      * <pre>
      * The expiry time of the CLTV lock. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional uint64 expiryTime = 10;</code>
      */
     public boolean hasExpiryTime() {
       return ((bitField0_ & 0x00000200) == 0x00000200);
     }
     /**
-     * <code>optional uint64 expiryTime = 10;</code>
-     *
      * <pre>
      * The expiry time of the CLTV lock. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional uint64 expiryTime = 10;</code>
      */
     public long getExpiryTime() {
       return expiryTime_;
+    }
+    /**
+     * <pre>
+     * The expiry time of the CLTV lock. Only used in protocol v2.
+     * </pre>
+     *
+     * <code>optional uint64 expiryTime = 10;</code>
+     */
+    private void setExpiryTime(long value) {
+      bitField0_ |= 0x00000200;
+      expiryTime_ = value;
+    }
+    /**
+     * <pre>
+     * The expiry time of the CLTV lock. Only used in protocol v2.
+     * </pre>
+     *
+     * <code>optional uint64 expiryTime = 10;</code>
+     */
+    private void clearExpiryTime() {
+      bitField0_ = (bitField0_ & ~0x00000200);
+      expiryTime_ = 0L;
     }
 
     public static final int SERVERKEY_FIELD_NUMBER = 11;
     private com.google.protobuf.ByteString serverKey_;
     /**
-     * <code>optional bytes serverKey = 11;</code>
-     *
      * <pre>
      * The server's public key. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional bytes serverKey = 11;</code>
      */
     public boolean hasServerKey() {
       return ((bitField0_ & 0x00000400) == 0x00000400);
     }
     /**
-     * <code>optional bytes serverKey = 11;</code>
-     *
      * <pre>
      * The server's public key. Only used in protocol v2.
      * </pre>
+     *
+     * <code>optional bytes serverKey = 11;</code>
      */
     public com.google.protobuf.ByteString getServerKey() {
       return serverKey_;
     }
-
-    private void initFields() {
-      id_ = com.google.protobuf.ByteString.EMPTY;
-      contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
-      refundTransaction_ = com.google.protobuf.ByteString.EMPTY;
-      myPublicKey_ = com.google.protobuf.ByteString.EMPTY;
-      myKey_ = com.google.protobuf.ByteString.EMPTY;
-      valueToMe_ = 0L;
-      refundFees_ = 0L;
-      closeTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
-      majorVersion_ = 1;
-      expiryTime_ = 0L;
-      serverKey_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * The server's public key. Only used in protocol v2.
+     * </pre>
+     *
+     * <code>optional bytes serverKey = 11;</code>
+     */
+    private void setServerKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000400;
+      serverKey_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasContractTransaction()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasRefundTransaction()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasMyPublicKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasMyKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasValueToMe()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasRefundFees()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * The server's public key. Only used in protocol v2.
+     * </pre>
+     *
+     * <code>optional bytes serverKey = 11;</code>
+     */
+    private void clearServerKey() {
+      bitField0_ = (bitField0_ & ~0x00000400);
+      serverKey_ = getDefaultInstance().getServerKey();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, id_);
       }
@@ -1299,10 +1118,9 @@ public final class ClientState {
       if (((bitField0_ & 0x00000400) == 0x00000400)) {
         output.writeBytes(11, serverKey_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -1352,854 +1170,737 @@ public final class ClientState {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(11, serverKey_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.protocols.channels.ClientState.StoredClientPaymentChannel prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.StoredClientPaymentChannel}
-     *
      * <pre>
      * A client-side payment channel in serialized form, which can be reloaded later if the client restarts and wants to
      * reopen an existing channel
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.StoredClientPaymentChannel}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.protocols.channels.ClientState.StoredClientPaymentChannel, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.StoredClientPaymentChannel)
         org.floj.protocols.channels.ClientState.StoredClientPaymentChannelOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannel_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannel_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.class, org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.Builder.class);
-      }
-
       // Construct using org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        id_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        refundTransaction_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        myPublicKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        myKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
-        valueToMe_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
-        refundFees_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000040);
-        closeTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000080);
-        majorVersion_ = 1;
-        bitField0_ = (bitField0_ & ~0x00000100);
-        expiryTime_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000200);
-        serverKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000400);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.protocols.channels.ClientState.internal_static_paymentchannels_StoredClientPaymentChannel_descriptor;
-      }
-
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannel getDefaultInstanceForType() {
-        return org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.getDefaultInstance();
-      }
-
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannel build() {
-        org.floj.protocols.channels.ClientState.StoredClientPaymentChannel result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.protocols.channels.ClientState.StoredClientPaymentChannel buildPartial() {
-        org.floj.protocols.channels.ClientState.StoredClientPaymentChannel result = new org.floj.protocols.channels.ClientState.StoredClientPaymentChannel(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.id_ = id_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.contractTransaction_ = contractTransaction_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.refundTransaction_ = refundTransaction_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.myPublicKey_ = myPublicKey_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.myKey_ = myKey_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        result.valueToMe_ = valueToMe_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000040;
-        }
-        result.refundFees_ = refundFees_;
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-          to_bitField0_ |= 0x00000080;
-        }
-        result.closeTransactionHash_ = closeTransactionHash_;
-        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
-          to_bitField0_ |= 0x00000100;
-        }
-        result.majorVersion_ = majorVersion_;
-        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
-          to_bitField0_ |= 0x00000200;
-        }
-        result.expiryTime_ = expiryTime_;
-        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
-          to_bitField0_ |= 0x00000400;
-        }
-        result.serverKey_ = serverKey_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.protocols.channels.ClientState.StoredClientPaymentChannel) {
-          return mergeFrom((org.floj.protocols.channels.ClientState.StoredClientPaymentChannel)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.protocols.channels.ClientState.StoredClientPaymentChannel other) {
-        if (other == org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.getDefaultInstance()) return this;
-        if (other.hasId()) {
-          setId(other.getId());
-        }
-        if (other.hasContractTransaction()) {
-          setContractTransaction(other.getContractTransaction());
-        }
-        if (other.hasRefundTransaction()) {
-          setRefundTransaction(other.getRefundTransaction());
-        }
-        if (other.hasMyPublicKey()) {
-          setMyPublicKey(other.getMyPublicKey());
-        }
-        if (other.hasMyKey()) {
-          setMyKey(other.getMyKey());
-        }
-        if (other.hasValueToMe()) {
-          setValueToMe(other.getValueToMe());
-        }
-        if (other.hasRefundFees()) {
-          setRefundFees(other.getRefundFees());
-        }
-        if (other.hasCloseTransactionHash()) {
-          setCloseTransactionHash(other.getCloseTransactionHash());
-        }
-        if (other.hasMajorVersion()) {
-          setMajorVersion(other.getMajorVersion());
-        }
-        if (other.hasExpiryTime()) {
-          setExpiryTime(other.getExpiryTime());
-        }
-        if (other.hasServerKey()) {
-          setServerKey(other.getServerKey());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasId()) {
-          
-          return false;
-        }
-        if (!hasContractTransaction()) {
-          
-          return false;
-        }
-        if (!hasRefundTransaction()) {
-          
-          return false;
-        }
-        if (!hasMyPublicKey()) {
-          
-          return false;
-        }
-        if (!hasMyKey()) {
-          
-          return false;
-        }
-        if (!hasValueToMe()) {
-          
-          return false;
-        }
-        if (!hasRefundFees()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.protocols.channels.ClientState.StoredClientPaymentChannel parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.protocols.channels.ClientState.StoredClientPaymentChannel) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString id_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes id = 1;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasId();
       }
       /**
        * <code>required bytes id = 1;</code>
        */
       public com.google.protobuf.ByteString getId() {
-        return id_;
+        return instance.getId();
       }
       /**
        * <code>required bytes id = 1;</code>
        */
       public Builder setId(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        id_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setId(value);
         return this;
       }
       /**
        * <code>required bytes id = 1;</code>
        */
       public Builder clearId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        id_ = getDefaultInstance().getId();
-        onChanged();
+        copyOnWrite();
+        instance.clearId();
         return this;
       }
 
-      private com.google.protobuf.ByteString contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes contractTransaction = 2;</code>
        */
       public boolean hasContractTransaction() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasContractTransaction();
       }
       /**
        * <code>required bytes contractTransaction = 2;</code>
        */
       public com.google.protobuf.ByteString getContractTransaction() {
-        return contractTransaction_;
+        return instance.getContractTransaction();
       }
       /**
        * <code>required bytes contractTransaction = 2;</code>
        */
       public Builder setContractTransaction(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        contractTransaction_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setContractTransaction(value);
         return this;
       }
       /**
        * <code>required bytes contractTransaction = 2;</code>
        */
       public Builder clearContractTransaction() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        contractTransaction_ = getDefaultInstance().getContractTransaction();
-        onChanged();
+        copyOnWrite();
+        instance.clearContractTransaction();
         return this;
       }
 
-      private com.google.protobuf.ByteString refundTransaction_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes refundTransaction = 3;</code>
        */
       public boolean hasRefundTransaction() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasRefundTransaction();
       }
       /**
        * <code>required bytes refundTransaction = 3;</code>
        */
       public com.google.protobuf.ByteString getRefundTransaction() {
-        return refundTransaction_;
+        return instance.getRefundTransaction();
       }
       /**
        * <code>required bytes refundTransaction = 3;</code>
        */
       public Builder setRefundTransaction(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        refundTransaction_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setRefundTransaction(value);
         return this;
       }
       /**
        * <code>required bytes refundTransaction = 3;</code>
        */
       public Builder clearRefundTransaction() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        refundTransaction_ = getDefaultInstance().getRefundTransaction();
-        onChanged();
+        copyOnWrite();
+        instance.clearRefundTransaction();
         return this;
       }
 
-      private com.google.protobuf.ByteString myPublicKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes myPublicKey = 8;</code>
        */
       public boolean hasMyPublicKey() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasMyPublicKey();
       }
       /**
        * <code>required bytes myPublicKey = 8;</code>
        */
       public com.google.protobuf.ByteString getMyPublicKey() {
-        return myPublicKey_;
+        return instance.getMyPublicKey();
       }
       /**
        * <code>required bytes myPublicKey = 8;</code>
        */
       public Builder setMyPublicKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        myPublicKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMyPublicKey(value);
         return this;
       }
       /**
        * <code>required bytes myPublicKey = 8;</code>
        */
       public Builder clearMyPublicKey() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        myPublicKey_ = getDefaultInstance().getMyPublicKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearMyPublicKey();
         return this;
       }
 
-      private com.google.protobuf.ByteString myKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes myKey = 4;</code>
-       *
        * <pre>
        * Deprecated, key is already stored in the wallet, and found using myPublicKey;
        * </pre>
+       *
+       * <code>required bytes myKey = 4;</code>
        */
       public boolean hasMyKey() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasMyKey();
       }
       /**
-       * <code>required bytes myKey = 4;</code>
-       *
        * <pre>
        * Deprecated, key is already stored in the wallet, and found using myPublicKey;
        * </pre>
+       *
+       * <code>required bytes myKey = 4;</code>
        */
       public com.google.protobuf.ByteString getMyKey() {
-        return myKey_;
+        return instance.getMyKey();
       }
       /**
-       * <code>required bytes myKey = 4;</code>
-       *
        * <pre>
        * Deprecated, key is already stored in the wallet, and found using myPublicKey;
        * </pre>
+       *
+       * <code>required bytes myKey = 4;</code>
        */
       public Builder setMyKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-        myKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMyKey(value);
         return this;
       }
       /**
-       * <code>required bytes myKey = 4;</code>
-       *
        * <pre>
        * Deprecated, key is already stored in the wallet, and found using myPublicKey;
        * </pre>
+       *
+       * <code>required bytes myKey = 4;</code>
        */
       public Builder clearMyKey() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        myKey_ = getDefaultInstance().getMyKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearMyKey();
         return this;
       }
 
-      private long valueToMe_ ;
       /**
        * <code>required uint64 valueToMe = 5;</code>
        */
       public boolean hasValueToMe() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return instance.hasValueToMe();
       }
       /**
        * <code>required uint64 valueToMe = 5;</code>
        */
       public long getValueToMe() {
-        return valueToMe_;
+        return instance.getValueToMe();
       }
       /**
        * <code>required uint64 valueToMe = 5;</code>
        */
       public Builder setValueToMe(long value) {
-        bitField0_ |= 0x00000020;
-        valueToMe_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setValueToMe(value);
         return this;
       }
       /**
        * <code>required uint64 valueToMe = 5;</code>
        */
       public Builder clearValueToMe() {
-        bitField0_ = (bitField0_ & ~0x00000020);
-        valueToMe_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearValueToMe();
         return this;
       }
 
-      private long refundFees_ ;
       /**
-       * <code>required uint64 refundFees = 6;</code>
-       *
        * <pre>
        * Fees required to refund the transaction.
        * </pre>
+       *
+       * <code>required uint64 refundFees = 6;</code>
        */
       public boolean hasRefundFees() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return instance.hasRefundFees();
       }
       /**
-       * <code>required uint64 refundFees = 6;</code>
-       *
        * <pre>
        * Fees required to refund the transaction.
        * </pre>
+       *
+       * <code>required uint64 refundFees = 6;</code>
        */
       public long getRefundFees() {
-        return refundFees_;
+        return instance.getRefundFees();
       }
       /**
-       * <code>required uint64 refundFees = 6;</code>
-       *
        * <pre>
        * Fees required to refund the transaction.
        * </pre>
+       *
+       * <code>required uint64 refundFees = 6;</code>
        */
       public Builder setRefundFees(long value) {
-        bitField0_ |= 0x00000040;
-        refundFees_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setRefundFees(value);
         return this;
       }
       /**
-       * <code>required uint64 refundFees = 6;</code>
-       *
        * <pre>
        * Fees required to refund the transaction.
        * </pre>
+       *
+       * <code>required uint64 refundFees = 6;</code>
        */
       public Builder clearRefundFees() {
-        bitField0_ = (bitField0_ & ~0x00000040);
-        refundFees_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearRefundFees();
         return this;
       }
 
-      private com.google.protobuf.ByteString closeTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes closeTransactionHash = 7;</code>
-       *
        * <pre>
        * When set, the hash of the transaction that was presented by the server for closure of the channel.
        * It spends the contractTransaction and is expected to be broadcast to the network by the server.
        * It's supposed to be in the wallet already.
        * </pre>
+       *
+       * <code>optional bytes closeTransactionHash = 7;</code>
        */
       public boolean hasCloseTransactionHash() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return instance.hasCloseTransactionHash();
       }
       /**
-       * <code>optional bytes closeTransactionHash = 7;</code>
-       *
        * <pre>
        * When set, the hash of the transaction that was presented by the server for closure of the channel.
        * It spends the contractTransaction and is expected to be broadcast to the network by the server.
        * It's supposed to be in the wallet already.
        * </pre>
+       *
+       * <code>optional bytes closeTransactionHash = 7;</code>
        */
       public com.google.protobuf.ByteString getCloseTransactionHash() {
-        return closeTransactionHash_;
+        return instance.getCloseTransactionHash();
       }
       /**
-       * <code>optional bytes closeTransactionHash = 7;</code>
-       *
        * <pre>
        * When set, the hash of the transaction that was presented by the server for closure of the channel.
        * It spends the contractTransaction and is expected to be broadcast to the network by the server.
        * It's supposed to be in the wallet already.
        * </pre>
+       *
+       * <code>optional bytes closeTransactionHash = 7;</code>
        */
       public Builder setCloseTransactionHash(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000080;
-        closeTransactionHash_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setCloseTransactionHash(value);
         return this;
       }
       /**
-       * <code>optional bytes closeTransactionHash = 7;</code>
-       *
        * <pre>
        * When set, the hash of the transaction that was presented by the server for closure of the channel.
        * It spends the contractTransaction and is expected to be broadcast to the network by the server.
        * It's supposed to be in the wallet already.
        * </pre>
+       *
+       * <code>optional bytes closeTransactionHash = 7;</code>
        */
       public Builder clearCloseTransactionHash() {
-        bitField0_ = (bitField0_ & ~0x00000080);
-        closeTransactionHash_ = getDefaultInstance().getCloseTransactionHash();
-        onChanged();
+        copyOnWrite();
+        instance.clearCloseTransactionHash();
         return this;
       }
 
-      private int majorVersion_ = 1;
       /**
        * <code>optional uint32 majorVersion = 9 [default = 1];</code>
        */
       public boolean hasMajorVersion() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
+        return instance.hasMajorVersion();
       }
       /**
        * <code>optional uint32 majorVersion = 9 [default = 1];</code>
        */
       public int getMajorVersion() {
-        return majorVersion_;
+        return instance.getMajorVersion();
       }
       /**
        * <code>optional uint32 majorVersion = 9 [default = 1];</code>
        */
       public Builder setMajorVersion(int value) {
-        bitField0_ |= 0x00000100;
-        majorVersion_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMajorVersion(value);
         return this;
       }
       /**
        * <code>optional uint32 majorVersion = 9 [default = 1];</code>
        */
       public Builder clearMajorVersion() {
-        bitField0_ = (bitField0_ & ~0x00000100);
-        majorVersion_ = 1;
-        onChanged();
+        copyOnWrite();
+        instance.clearMajorVersion();
         return this;
       }
 
-      private long expiryTime_ ;
       /**
-       * <code>optional uint64 expiryTime = 10;</code>
-       *
        * <pre>
        * The expiry time of the CLTV lock. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional uint64 expiryTime = 10;</code>
        */
       public boolean hasExpiryTime() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
+        return instance.hasExpiryTime();
       }
       /**
-       * <code>optional uint64 expiryTime = 10;</code>
-       *
        * <pre>
        * The expiry time of the CLTV lock. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional uint64 expiryTime = 10;</code>
        */
       public long getExpiryTime() {
-        return expiryTime_;
+        return instance.getExpiryTime();
       }
       /**
-       * <code>optional uint64 expiryTime = 10;</code>
-       *
        * <pre>
        * The expiry time of the CLTV lock. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional uint64 expiryTime = 10;</code>
        */
       public Builder setExpiryTime(long value) {
-        bitField0_ |= 0x00000200;
-        expiryTime_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setExpiryTime(value);
         return this;
       }
       /**
-       * <code>optional uint64 expiryTime = 10;</code>
-       *
        * <pre>
        * The expiry time of the CLTV lock. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional uint64 expiryTime = 10;</code>
        */
       public Builder clearExpiryTime() {
-        bitField0_ = (bitField0_ & ~0x00000200);
-        expiryTime_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearExpiryTime();
         return this;
       }
 
-      private com.google.protobuf.ByteString serverKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes serverKey = 11;</code>
-       *
        * <pre>
        * The server's public key. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional bytes serverKey = 11;</code>
        */
       public boolean hasServerKey() {
-        return ((bitField0_ & 0x00000400) == 0x00000400);
+        return instance.hasServerKey();
       }
       /**
-       * <code>optional bytes serverKey = 11;</code>
-       *
        * <pre>
        * The server's public key. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional bytes serverKey = 11;</code>
        */
       public com.google.protobuf.ByteString getServerKey() {
-        return serverKey_;
+        return instance.getServerKey();
       }
       /**
-       * <code>optional bytes serverKey = 11;</code>
-       *
        * <pre>
        * The server's public key. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional bytes serverKey = 11;</code>
        */
       public Builder setServerKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000400;
-        serverKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setServerKey(value);
         return this;
       }
       /**
-       * <code>optional bytes serverKey = 11;</code>
-       *
        * <pre>
        * The server's public key. Only used in protocol v2.
        * </pre>
+       *
+       * <code>optional bytes serverKey = 11;</code>
        */
       public Builder clearServerKey() {
-        bitField0_ = (bitField0_ & ~0x00000400);
-        serverKey_ = getDefaultInstance().getServerKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearServerKey();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.StoredClientPaymentChannel)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.protocols.channels.ClientState.StoredClientPaymentChannel();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new StoredClientPaymentChannel(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:paymentchannels.StoredClientPaymentChannel)
-  }
-
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_StoredClientPaymentChannels_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_StoredClientPaymentChannels_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_StoredClientPaymentChannel_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_StoredClientPaymentChannel_fieldAccessorTable;
-
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
-    return descriptor;
-  }
-  private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
-  static {
-    java.lang.String[] descriptorData = {
-      "\n storedclientpaymentchannel.proto\022\017paym" +
-      "entchannels\"\\\n\033StoredClientPaymentChanne" +
-      "ls\022=\n\010channels\030\001 \003(\0132+.paymentchannels.S" +
-      "toredClientPaymentChannel\"\211\002\n\032StoredClie" +
-      "ntPaymentChannel\022\n\n\002id\030\001 \002(\014\022\033\n\023contract" +
-      "Transaction\030\002 \002(\014\022\031\n\021refundTransaction\030\003" +
-      " \002(\014\022\023\n\013myPublicKey\030\010 \002(\014\022\r\n\005myKey\030\004 \002(\014" +
-      "\022\021\n\tvalueToMe\030\005 \002(\004\022\022\n\nrefundFees\030\006 \002(\004\022" +
-      "\034\n\024closeTransactionHash\030\007 \001(\014\022\027\n\014majorVe" +
-      "rsion\030\t \001(\r:\0011\022\022\n\nexpiryTime\030\n \001(\004\022\021\n\tse",
-      "rverKey\030\013 \001(\014B*\n\033org.floj.protocols.chan" +
-      "nelsB\013ClientState"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasId()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
             return null;
           }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-    internal_static_paymentchannels_StoredClientPaymentChannels_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_paymentchannels_StoredClientPaymentChannels_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_StoredClientPaymentChannels_descriptor,
-        new java.lang.String[] { "Channels", });
-    internal_static_paymentchannels_StoredClientPaymentChannel_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_paymentchannels_StoredClientPaymentChannel_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_StoredClientPaymentChannel_descriptor,
-        new java.lang.String[] { "Id", "ContractTransaction", "RefundTransaction", "MyPublicKey", "MyKey", "ValueToMe", "RefundFees", "CloseTransactionHash", "MajorVersion", "ExpiryTime", "ServerKey", });
+          if (!hasContractTransaction()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasRefundTransaction()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasMyPublicKey()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasMyKey()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasValueToMe()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasRefundFees()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.protocols.channels.ClientState.StoredClientPaymentChannel other = (org.floj.protocols.channels.ClientState.StoredClientPaymentChannel) arg1;
+          id_ = visitor.visitByteString(
+              hasId(), id_,
+              other.hasId(), other.id_);
+          contractTransaction_ = visitor.visitByteString(
+              hasContractTransaction(), contractTransaction_,
+              other.hasContractTransaction(), other.contractTransaction_);
+          refundTransaction_ = visitor.visitByteString(
+              hasRefundTransaction(), refundTransaction_,
+              other.hasRefundTransaction(), other.refundTransaction_);
+          myPublicKey_ = visitor.visitByteString(
+              hasMyPublicKey(), myPublicKey_,
+              other.hasMyPublicKey(), other.myPublicKey_);
+          myKey_ = visitor.visitByteString(
+              hasMyKey(), myKey_,
+              other.hasMyKey(), other.myKey_);
+          valueToMe_ = visitor.visitLong(
+              hasValueToMe(), valueToMe_,
+              other.hasValueToMe(), other.valueToMe_);
+          refundFees_ = visitor.visitLong(
+              hasRefundFees(), refundFees_,
+              other.hasRefundFees(), other.refundFees_);
+          closeTransactionHash_ = visitor.visitByteString(
+              hasCloseTransactionHash(), closeTransactionHash_,
+              other.hasCloseTransactionHash(), other.closeTransactionHash_);
+          majorVersion_ = visitor.visitInt(
+              hasMajorVersion(), majorVersion_,
+              other.hasMajorVersion(), other.majorVersion_);
+          expiryTime_ = visitor.visitLong(
+              hasExpiryTime(), expiryTime_,
+              other.hasExpiryTime(), other.expiryTime_);
+          serverKey_ = visitor.visitByteString(
+              hasServerKey(), serverKey_,
+              other.hasServerKey(), other.serverKey_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  id_ = input.readBytes();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  contractTransaction_ = input.readBytes();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  refundTransaction_ = input.readBytes();
+                  break;
+                }
+                case 34: {
+                  bitField0_ |= 0x00000010;
+                  myKey_ = input.readBytes();
+                  break;
+                }
+                case 40: {
+                  bitField0_ |= 0x00000020;
+                  valueToMe_ = input.readUInt64();
+                  break;
+                }
+                case 48: {
+                  bitField0_ |= 0x00000040;
+                  refundFees_ = input.readUInt64();
+                  break;
+                }
+                case 58: {
+                  bitField0_ |= 0x00000080;
+                  closeTransactionHash_ = input.readBytes();
+                  break;
+                }
+                case 66: {
+                  bitField0_ |= 0x00000008;
+                  myPublicKey_ = input.readBytes();
+                  break;
+                }
+                case 72: {
+                  bitField0_ |= 0x00000100;
+                  majorVersion_ = input.readUInt32();
+                  break;
+                }
+                case 80: {
+                  bitField0_ |= 0x00000200;
+                  expiryTime_ = input.readUInt64();
+                  break;
+                }
+                case 90: {
+                  bitField0_ |= 0x00000400;
+                  serverKey_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.protocols.channels.ClientState.StoredClientPaymentChannel.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
+    }
+
+
+    // @@protoc_insertion_point(class_scope:paymentchannels.StoredClientPaymentChannel)
+    private static final org.floj.protocols.channels.ClientState.StoredClientPaymentChannel DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new StoredClientPaymentChannel();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.protocols.channels.ClientState.StoredClientPaymentChannel getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<StoredClientPaymentChannel> PARSER;
+
+    public static com.google.protobuf.Parser<StoredClientPaymentChannel> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
+  }
+
+
+  static {
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/floj-core/src/main/java/org/floj/protocols/channels/PaymentChannelClient.java
+++ b/floj-core/src/main/java/org/floj/protocols/channels/PaymentChannelClient.java
@@ -358,9 +358,10 @@ public class PaymentChannelClient implements IPaymentChannelClient {
                     // Make an initial payment of the dust limit, and put it into the message as well. The size of the
                     // server-requested dust limit was already sanity checked by this point.
                     PaymentChannelClientState.IncrementedPayment payment = state().incrementPaymentBy(Coin.valueOf(minPayment), userKeySetup);
-                    Protos.UpdatePayment.Builder initialMsg = provideContractBuilder.getInitialPaymentBuilder();
+                    Protos.UpdatePayment.Builder initialMsg = Protos.UpdatePayment.newBuilder();
                     initialMsg.setSignature(ByteString.copyFrom(payment.signature.encodeToFLO()));
                     initialMsg.setClientChangeValue(state.getValueRefunded().value);
+                    provideContractBuilder.setInitialPayment(initialMsg);
                 } catch (ValueOutOfRangeException e) {
                     throw new IllegalStateException(e);  // This cannot happen.
                 }
@@ -399,9 +400,10 @@ public class PaymentChannelClient implements IPaymentChannelClient {
             // Make an initial payment of the dust limit, and put it into the message as well. The size of the
             // server-requested dust limit was already sanity checked by this point.
             PaymentChannelClientState.IncrementedPayment payment = state().incrementPaymentBy(Coin.valueOf(minPayment), userKey);
-            Protos.UpdatePayment.Builder initialMsg = contractMsg.getInitialPaymentBuilder();
+            Protos.UpdatePayment.Builder initialMsg = Protos.UpdatePayment.newBuilder();
             initialMsg.setSignature(ByteString.copyFrom(payment.signature.encodeToFLO()));
             initialMsg.setClientChangeValue(state.getValueRefunded().value);
+            contractMsg.setInitialPayment(initialMsg);
         } catch (ValueOutOfRangeException e) {
             throw new IllegalStateException(e);  // This cannot happen.
         }
@@ -722,7 +724,7 @@ public class PaymentChannelClient implements IPaymentChannelClient {
                     increasePaymentFuture = null;
                     lock.unlock();
                 }
-            }, MoreExecutors.sameThreadExecutor());
+            }, MoreExecutors.directExecutor());
 
             conn.sendToServer(Protos.TwoWayChannelMessage.newBuilder()
                     .setUpdatePayment(updatePaymentBuilder)

--- a/floj-core/src/main/java/org/floj/protocols/channels/PaymentChannelServer.java
+++ b/floj-core/src/main/java/org/floj/protocols/channels/PaymentChannelServer.java
@@ -418,7 +418,7 @@ public class PaymentChannelServer {
                 Futures.addCallback(ackInfoFuture, new FutureCallback<ByteString>() {
                     @Override
                     public void onSuccess(@Nullable ByteString result) {
-                        if (result != null) ack.setPaymentAck(ack.getPaymentAckBuilder().setInfo(result));
+                        if (result != null) ack.setPaymentAck(Protos.PaymentAck.newBuilder().setInfo(result));
                         conn.sendToClient(ack.build());
                     }
 
@@ -531,7 +531,7 @@ public class PaymentChannelServer {
                 if (result != null) {
                     // Result can be null on various error paths, like if we never actually opened
                     // properly and so on.
-                    msg.getSettlementBuilder().setTx(ByteString.copyFrom(result.unsafeFLOSerialize()));
+                    msg.setSettlement(Protos.Settlement.newBuilder().setTx(ByteString.copyFrom(result.unsafeFLOSerialize())));
                     log.info("Sending CLOSE back with broadcast settlement tx.");
                 } else {
                     log.info("Sending CLOSE back without broadcast settlement tx.");

--- a/floj-core/src/main/java/org/floj/protocols/channels/ServerState.java
+++ b/floj-core/src/main/java/org/floj/protocols/channels/ServerState.java
@@ -6,11 +6,11 @@ package org.floj.protocols.channels;
 public final class ServerState {
   private ServerState() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
   }
   public interface StoredServerPaymentChannelsOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.StoredServerPaymentChannels)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
@@ -25,125 +25,24 @@ public final class ServerState {
      * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
      */
     int getChannelsCount();
-    /**
-     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-     */
-    java.util.List<? extends org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder> 
-        getChannelsOrBuilderList();
-    /**
-     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-     */
-    org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder getChannelsOrBuilder(
-        int index);
   }
   /**
-   * Protobuf type {@code paymentchannels.StoredServerPaymentChannels}
-   *
    * <pre>
    * A set of StoredPaymentChannel's
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.StoredServerPaymentChannels}
    */
-  public static final class StoredServerPaymentChannels extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class StoredServerPaymentChannels extends
+      com.google.protobuf.GeneratedMessageLite<
+          StoredServerPaymentChannels, StoredServerPaymentChannels.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.StoredServerPaymentChannels)
       StoredServerPaymentChannelsOrBuilder {
-    // Use StoredServerPaymentChannels.newBuilder() to construct.
-    private StoredServerPaymentChannels(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private StoredServerPaymentChannels() {
+      channels_ = emptyProtobufList();
     }
-    private StoredServerPaymentChannels(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final StoredServerPaymentChannels defaultInstance;
-    public static StoredServerPaymentChannels getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public StoredServerPaymentChannels getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private StoredServerPaymentChannels(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                channels_ = new java.util.ArrayList<org.floj.protocols.channels.ServerState.StoredServerPaymentChannel>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              channels_.add(input.readMessage(org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.PARSER, extensionRegistry));
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          channels_ = java.util.Collections.unmodifiableList(channels_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannels_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannels_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.class, org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<StoredServerPaymentChannels> PARSER =
-        new com.google.protobuf.AbstractParser<StoredServerPaymentChannels>() {
-      public StoredServerPaymentChannels parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StoredServerPaymentChannels(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<StoredServerPaymentChannels> getParserForType() {
-      return PARSER;
-    }
-
     public static final int CHANNELS_FIELD_NUMBER = 1;
-    private java.util.List<org.floj.protocols.channels.ServerState.StoredServerPaymentChannel> channels_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.protocols.channels.ServerState.StoredServerPaymentChannel> channels_;
     /**
      * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
      */
@@ -176,36 +75,100 @@ public final class ServerState {
         int index) {
       return channels_.get(index);
     }
-
-    private void initFields() {
-      channels_ = java.util.Collections.emptyList();
+    private void ensureChannelsIsMutable() {
+      if (!channels_.isModifiable()) {
+        channels_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(channels_);
+       }
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
 
-      for (int i = 0; i < getChannelsCount(); i++) {
-        if (!getChannels(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void setChannels(
+        int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel value) {
+      if (value == null) {
+        throw new NullPointerException();
       }
-      memoizedIsInitialized = 1;
-      return true;
+      ensureChannelsIsMutable();
+      channels_.set(index, value);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void setChannels(
+        int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder builderForValue) {
+      ensureChannelsIsMutable();
+      channels_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(org.floj.protocols.channels.ServerState.StoredServerPaymentChannel value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureChannelsIsMutable();
+      channels_.add(value);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(
+        int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureChannelsIsMutable();
+      channels_.add(index, value);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(
+        org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder builderForValue) {
+      ensureChannelsIsMutable();
+      channels_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void addChannels(
+        int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder builderForValue) {
+      ensureChannelsIsMutable();
+      channels_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void addAllChannels(
+        java.lang.Iterable<? extends org.floj.protocols.channels.ServerState.StoredServerPaymentChannel> values) {
+      ensureChannelsIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, channels_);
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void clearChannels() {
+      channels_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
+     */
+    private void removeChannels(int index) {
+      ensureChannelsIsMutable();
+      channels_.remove(index);
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       for (int i = 0; i < channels_.size(); i++) {
         output.writeMessage(1, channels_.get(i));
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -215,301 +178,122 @@ public final class ServerState {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, channels_.get(i));
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.protocols.channels.ServerState.StoredServerPaymentChannels prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.StoredServerPaymentChannels}
-     *
      * <pre>
      * A set of StoredPaymentChannel's
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.StoredServerPaymentChannels}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.protocols.channels.ServerState.StoredServerPaymentChannels, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.StoredServerPaymentChannels)
         org.floj.protocols.channels.ServerState.StoredServerPaymentChannelsOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannels_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannels_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.class, org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.Builder.class);
-      }
-
       // Construct using org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getChannelsFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-
-      public Builder clear() {
-        super.clear();
-        if (channelsBuilder_ == null) {
-          channels_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          channelsBuilder_.clear();
-        }
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannels_descriptor;
-      }
-
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannels getDefaultInstanceForType() {
-        return org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.getDefaultInstance();
-      }
-
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannels build() {
-        org.floj.protocols.channels.ServerState.StoredServerPaymentChannels result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannels buildPartial() {
-        org.floj.protocols.channels.ServerState.StoredServerPaymentChannels result = new org.floj.protocols.channels.ServerState.StoredServerPaymentChannels(this);
-        int from_bitField0_ = bitField0_;
-        if (channelsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            channels_ = java.util.Collections.unmodifiableList(channels_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.channels_ = channels_;
-        } else {
-          result.channels_ = channelsBuilder_.build();
-        }
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.protocols.channels.ServerState.StoredServerPaymentChannels) {
-          return mergeFrom((org.floj.protocols.channels.ServerState.StoredServerPaymentChannels)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.protocols.channels.ServerState.StoredServerPaymentChannels other) {
-        if (other == org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.getDefaultInstance()) return this;
-        if (channelsBuilder_ == null) {
-          if (!other.channels_.isEmpty()) {
-            if (channels_.isEmpty()) {
-              channels_ = other.channels_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureChannelsIsMutable();
-              channels_.addAll(other.channels_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.channels_.isEmpty()) {
-            if (channelsBuilder_.isEmpty()) {
-              channelsBuilder_.dispose();
-              channelsBuilder_ = null;
-              channels_ = other.channels_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-              channelsBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getChannelsFieldBuilder() : null;
-            } else {
-              channelsBuilder_.addAllMessages(other.channels_);
-            }
-          }
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        for (int i = 0; i < getChannelsCount(); i++) {
-          if (!getChannels(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.protocols.channels.ServerState.StoredServerPaymentChannels parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.protocols.channels.ServerState.StoredServerPaymentChannels) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.util.List<org.floj.protocols.channels.ServerState.StoredServerPaymentChannel> channels_ =
-        java.util.Collections.emptyList();
-      private void ensureChannelsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          channels_ = new java.util.ArrayList<org.floj.protocols.channels.ServerState.StoredServerPaymentChannel>(channels_);
-          bitField0_ |= 0x00000001;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.protocols.channels.ServerState.StoredServerPaymentChannel, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder, org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder> channelsBuilder_;
 
       /**
        * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
        */
       public java.util.List<org.floj.protocols.channels.ServerState.StoredServerPaymentChannel> getChannelsList() {
-        if (channelsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(channels_);
-        } else {
-          return channelsBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getChannelsList());
       }
       /**
        * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
        */
       public int getChannelsCount() {
-        if (channelsBuilder_ == null) {
-          return channels_.size();
-        } else {
-          return channelsBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getChannelsCount();
+      }/**
        * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
        */
       public org.floj.protocols.channels.ServerState.StoredServerPaymentChannel getChannels(int index) {
-        if (channelsBuilder_ == null) {
-          return channels_.get(index);
-        } else {
-          return channelsBuilder_.getMessage(index);
-        }
+        return instance.getChannels(index);
       }
       /**
        * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
        */
       public Builder setChannels(
           int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel value) {
-        if (channelsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureChannelsIsMutable();
-          channels_.set(index, value);
-          onChanged();
-        } else {
-          channelsBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setChannels(index, value);
         return this;
       }
       /**
@@ -517,29 +301,16 @@ public final class ServerState {
        */
       public Builder setChannels(
           int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder builderForValue) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          channelsBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setChannels(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
        */
       public Builder addChannels(org.floj.protocols.channels.ServerState.StoredServerPaymentChannel value) {
-        if (channelsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureChannelsIsMutable();
-          channels_.add(value);
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addChannels(value);
         return this;
       }
       /**
@@ -547,16 +318,8 @@ public final class ServerState {
        */
       public Builder addChannels(
           int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel value) {
-        if (channelsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureChannelsIsMutable();
-          channels_.add(index, value);
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addChannels(index, value);
         return this;
       }
       /**
@@ -564,13 +327,8 @@ public final class ServerState {
        */
       public Builder addChannels(
           org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder builderForValue) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.add(builderForValue.build());
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addChannels(builderForValue);
         return this;
       }
       /**
@@ -578,13 +336,8 @@ public final class ServerState {
        */
       public Builder addChannels(
           int index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder builderForValue) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          channelsBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addChannels(index, builderForValue);
         return this;
       }
       /**
@@ -592,121 +345,148 @@ public final class ServerState {
        */
       public Builder addAllChannels(
           java.lang.Iterable<? extends org.floj.protocols.channels.ServerState.StoredServerPaymentChannel> values) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, channels_);
-          onChanged();
-        } else {
-          channelsBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllChannels(values);
         return this;
       }
       /**
        * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
        */
       public Builder clearChannels() {
-        if (channelsBuilder_ == null) {
-          channels_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          channelsBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearChannels();
         return this;
       }
       /**
        * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
        */
       public Builder removeChannels(int index) {
-        if (channelsBuilder_ == null) {
-          ensureChannelsIsMutable();
-          channels_.remove(index);
-          onChanged();
-        } else {
-          channelsBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeChannels(index);
         return this;
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder getChannelsBuilder(
-          int index) {
-        return getChannelsFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder getChannelsOrBuilder(
-          int index) {
-        if (channelsBuilder_ == null) {
-          return channels_.get(index);  } else {
-          return channelsBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-       */
-      public java.util.List<? extends org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder> 
-           getChannelsOrBuilderList() {
-        if (channelsBuilder_ != null) {
-          return channelsBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(channels_);
-        }
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder addChannelsBuilder() {
-        return getChannelsFieldBuilder().addBuilder(
-            org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-       */
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder addChannelsBuilder(
-          int index) {
-        return getChannelsFieldBuilder().addBuilder(
-            index, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .paymentchannels.StoredServerPaymentChannel channels = 1;</code>
-       */
-      public java.util.List<org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder> 
-           getChannelsBuilderList() {
-        return getChannelsFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.protocols.channels.ServerState.StoredServerPaymentChannel, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder, org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder> 
-          getChannelsFieldBuilder() {
-        if (channelsBuilder_ == null) {
-          channelsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.protocols.channels.ServerState.StoredServerPaymentChannel, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder, org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder>(
-                  channels_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
-                  getParentForChildren(),
-                  isClean());
-          channels_ = null;
-        }
-        return channelsBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.StoredServerPaymentChannels)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.protocols.channels.ServerState.StoredServerPaymentChannels();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new StoredServerPaymentChannels(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          for (int i = 0; i < getChannelsCount(); i++) {
+            if (!getChannels(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          channels_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.protocols.channels.ServerState.StoredServerPaymentChannels other = (org.floj.protocols.channels.ServerState.StoredServerPaymentChannels) arg1;
+          channels_= visitor.visitList(channels_, other.channels_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  if (!channels_.isModifiable()) {
+                    channels_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(channels_);
+                  }
+                  channels_.add(
+                      input.readMessage(org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.parser(), extensionRegistry));
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.protocols.channels.ServerState.StoredServerPaymentChannels.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:paymentchannels.StoredServerPaymentChannels)
+    private static final org.floj.protocols.channels.ServerState.StoredServerPaymentChannels DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new StoredServerPaymentChannels();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannels getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<StoredServerPaymentChannels> PARSER;
+
+    public static com.google.protobuf.Parser<StoredServerPaymentChannels> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface StoredServerPaymentChannelOrBuilder extends
       // @@protoc_insertion_point(interface_extends:paymentchannels.StoredServerPaymentChannel)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required uint64 bestValueToMe = 1;</code>
@@ -772,157 +552,42 @@ public final class ServerState {
     int getMajorVersion();
 
     /**
-     * <code>optional bytes clientKey = 8;</code>
-     *
      * <pre>
      * Protocol version 2 only - the P2SH hash doesn't contain the required key
      * </pre>
+     *
+     * <code>optional bytes clientKey = 8;</code>
      */
     boolean hasClientKey();
     /**
-     * <code>optional bytes clientKey = 8;</code>
-     *
      * <pre>
      * Protocol version 2 only - the P2SH hash doesn't contain the required key
      * </pre>
+     *
+     * <code>optional bytes clientKey = 8;</code>
      */
     com.google.protobuf.ByteString getClientKey();
   }
   /**
-   * Protobuf type {@code paymentchannels.StoredServerPaymentChannel}
-   *
    * <pre>
    * A server-side payment channel in serialized form, which can be reloaded later if the server restarts
    * </pre>
+   *
+   * Protobuf type {@code paymentchannels.StoredServerPaymentChannel}
    */
-  public static final class StoredServerPaymentChannel extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class StoredServerPaymentChannel extends
+      com.google.protobuf.GeneratedMessageLite<
+          StoredServerPaymentChannel, StoredServerPaymentChannel.Builder> implements
       // @@protoc_insertion_point(message_implements:paymentchannels.StoredServerPaymentChannel)
       StoredServerPaymentChannelOrBuilder {
-    // Use StoredServerPaymentChannel.newBuilder() to construct.
-    private StoredServerPaymentChannel(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private StoredServerPaymentChannel() {
+      bestValueSignature_ = com.google.protobuf.ByteString.EMPTY;
+      contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
+      clientOutput_ = com.google.protobuf.ByteString.EMPTY;
+      myKey_ = com.google.protobuf.ByteString.EMPTY;
+      majorVersion_ = 1;
+      clientKey_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private StoredServerPaymentChannel(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final StoredServerPaymentChannel defaultInstance;
-    public static StoredServerPaymentChannel getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public StoredServerPaymentChannel getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private StoredServerPaymentChannel(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              bestValueToMe_ = input.readUInt64();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              bestValueSignature_ = input.readBytes();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              refundTransactionUnlockTimeSecs_ = input.readUInt64();
-              break;
-            }
-            case 34: {
-              bitField0_ |= 0x00000008;
-              contractTransaction_ = input.readBytes();
-              break;
-            }
-            case 42: {
-              bitField0_ |= 0x00000010;
-              clientOutput_ = input.readBytes();
-              break;
-            }
-            case 50: {
-              bitField0_ |= 0x00000020;
-              myKey_ = input.readBytes();
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              majorVersion_ = input.readUInt32();
-              break;
-            }
-            case 66: {
-              bitField0_ |= 0x00000080;
-              clientKey_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannel_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannel_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.class, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<StoredServerPaymentChannel> PARSER =
-        new com.google.protobuf.AbstractParser<StoredServerPaymentChannel>() {
-      public StoredServerPaymentChannel parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StoredServerPaymentChannel(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<StoredServerPaymentChannel> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int BESTVALUETOME_FIELD_NUMBER = 1;
     private long bestValueToMe_;
@@ -937,6 +602,20 @@ public final class ServerState {
      */
     public long getBestValueToMe() {
       return bestValueToMe_;
+    }
+    /**
+     * <code>required uint64 bestValueToMe = 1;</code>
+     */
+    private void setBestValueToMe(long value) {
+      bitField0_ |= 0x00000001;
+      bestValueToMe_ = value;
+    }
+    /**
+     * <code>required uint64 bestValueToMe = 1;</code>
+     */
+    private void clearBestValueToMe() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      bestValueToMe_ = 0L;
     }
 
     public static final int BESTVALUESIGNATURE_FIELD_NUMBER = 2;
@@ -953,6 +632,23 @@ public final class ServerState {
     public com.google.protobuf.ByteString getBestValueSignature() {
       return bestValueSignature_;
     }
+    /**
+     * <code>optional bytes bestValueSignature = 2;</code>
+     */
+    private void setBestValueSignature(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      bestValueSignature_ = value;
+    }
+    /**
+     * <code>optional bytes bestValueSignature = 2;</code>
+     */
+    private void clearBestValueSignature() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      bestValueSignature_ = getDefaultInstance().getBestValueSignature();
+    }
 
     public static final int REFUNDTRANSACTIONUNLOCKTIMESECS_FIELD_NUMBER = 3;
     private long refundTransactionUnlockTimeSecs_;
@@ -967,6 +663,20 @@ public final class ServerState {
      */
     public long getRefundTransactionUnlockTimeSecs() {
       return refundTransactionUnlockTimeSecs_;
+    }
+    /**
+     * <code>required uint64 refundTransactionUnlockTimeSecs = 3;</code>
+     */
+    private void setRefundTransactionUnlockTimeSecs(long value) {
+      bitField0_ |= 0x00000004;
+      refundTransactionUnlockTimeSecs_ = value;
+    }
+    /**
+     * <code>required uint64 refundTransactionUnlockTimeSecs = 3;</code>
+     */
+    private void clearRefundTransactionUnlockTimeSecs() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      refundTransactionUnlockTimeSecs_ = 0L;
     }
 
     public static final int CONTRACTTRANSACTION_FIELD_NUMBER = 4;
@@ -983,6 +693,23 @@ public final class ServerState {
     public com.google.protobuf.ByteString getContractTransaction() {
       return contractTransaction_;
     }
+    /**
+     * <code>required bytes contractTransaction = 4;</code>
+     */
+    private void setContractTransaction(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+      contractTransaction_ = value;
+    }
+    /**
+     * <code>required bytes contractTransaction = 4;</code>
+     */
+    private void clearContractTransaction() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      contractTransaction_ = getDefaultInstance().getContractTransaction();
+    }
 
     public static final int CLIENTOUTPUT_FIELD_NUMBER = 5;
     private com.google.protobuf.ByteString clientOutput_;
@@ -997,6 +724,23 @@ public final class ServerState {
      */
     public com.google.protobuf.ByteString getClientOutput() {
       return clientOutput_;
+    }
+    /**
+     * <code>optional bytes clientOutput = 5;</code>
+     */
+    private void setClientOutput(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+      clientOutput_ = value;
+    }
+    /**
+     * <code>optional bytes clientOutput = 5;</code>
+     */
+    private void clearClientOutput() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      clientOutput_ = getDefaultInstance().getClientOutput();
     }
 
     public static final int MYKEY_FIELD_NUMBER = 6;
@@ -1013,6 +757,23 @@ public final class ServerState {
     public com.google.protobuf.ByteString getMyKey() {
       return myKey_;
     }
+    /**
+     * <code>required bytes myKey = 6;</code>
+     */
+    private void setMyKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+      myKey_ = value;
+    }
+    /**
+     * <code>required bytes myKey = 6;</code>
+     */
+    private void clearMyKey() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      myKey_ = getDefaultInstance().getMyKey();
+    }
 
     public static final int MAJORVERSION_FIELD_NUMBER = 7;
     private int majorVersion_;
@@ -1028,69 +789,71 @@ public final class ServerState {
     public int getMajorVersion() {
       return majorVersion_;
     }
+    /**
+     * <code>optional uint32 majorVersion = 7 [default = 1];</code>
+     */
+    private void setMajorVersion(int value) {
+      bitField0_ |= 0x00000040;
+      majorVersion_ = value;
+    }
+    /**
+     * <code>optional uint32 majorVersion = 7 [default = 1];</code>
+     */
+    private void clearMajorVersion() {
+      bitField0_ = (bitField0_ & ~0x00000040);
+      majorVersion_ = 1;
+    }
 
     public static final int CLIENTKEY_FIELD_NUMBER = 8;
     private com.google.protobuf.ByteString clientKey_;
     /**
-     * <code>optional bytes clientKey = 8;</code>
-     *
      * <pre>
      * Protocol version 2 only - the P2SH hash doesn't contain the required key
      * </pre>
+     *
+     * <code>optional bytes clientKey = 8;</code>
      */
     public boolean hasClientKey() {
       return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
-     * <code>optional bytes clientKey = 8;</code>
-     *
      * <pre>
      * Protocol version 2 only - the P2SH hash doesn't contain the required key
      * </pre>
+     *
+     * <code>optional bytes clientKey = 8;</code>
      */
     public com.google.protobuf.ByteString getClientKey() {
       return clientKey_;
     }
-
-    private void initFields() {
-      bestValueToMe_ = 0L;
-      bestValueSignature_ = com.google.protobuf.ByteString.EMPTY;
-      refundTransactionUnlockTimeSecs_ = 0L;
-      contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
-      clientOutput_ = com.google.protobuf.ByteString.EMPTY;
-      myKey_ = com.google.protobuf.ByteString.EMPTY;
-      majorVersion_ = 1;
-      clientKey_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * Protocol version 2 only - the P2SH hash doesn't contain the required key
+     * </pre>
+     *
+     * <code>optional bytes clientKey = 8;</code>
+     */
+    private void setClientKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+      clientKey_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasBestValueToMe()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasRefundTransactionUnlockTimeSecs()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasContractTransaction()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasMyKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Protocol version 2 only - the P2SH hash doesn't contain the required key
+     * </pre>
+     *
+     * <code>optional bytes clientKey = 8;</code>
+     */
+    private void clearClientKey() {
+      bitField0_ = (bitField0_ & ~0x00000080);
+      clientKey_ = getDefaultInstance().getClientKey();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeUInt64(1, bestValueToMe_);
       }
@@ -1115,10 +878,9 @@ public final class ServerState {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeBytes(8, clientKey_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -1156,639 +918,535 @@ public final class ServerState {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(8, clientKey_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.protocols.channels.ServerState.StoredServerPaymentChannel prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code paymentchannels.StoredServerPaymentChannel}
-     *
      * <pre>
      * A server-side payment channel in serialized form, which can be reloaded later if the server restarts
      * </pre>
+     *
+     * Protobuf type {@code paymentchannels.StoredServerPaymentChannel}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.protocols.channels.ServerState.StoredServerPaymentChannel, Builder> implements
         // @@protoc_insertion_point(builder_implements:paymentchannels.StoredServerPaymentChannel)
         org.floj.protocols.channels.ServerState.StoredServerPaymentChannelOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannel_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannel_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.class, org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.Builder.class);
-      }
-
       // Construct using org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        bestValueToMe_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        bestValueSignature_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        refundTransactionUnlockTimeSecs_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        clientOutput_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
-        myKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000020);
-        majorVersion_ = 1;
-        bitField0_ = (bitField0_ & ~0x00000040);
-        clientKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000080);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.protocols.channels.ServerState.internal_static_paymentchannels_StoredServerPaymentChannel_descriptor;
-      }
-
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannel getDefaultInstanceForType() {
-        return org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.getDefaultInstance();
-      }
-
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannel build() {
-        org.floj.protocols.channels.ServerState.StoredServerPaymentChannel result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.protocols.channels.ServerState.StoredServerPaymentChannel buildPartial() {
-        org.floj.protocols.channels.ServerState.StoredServerPaymentChannel result = new org.floj.protocols.channels.ServerState.StoredServerPaymentChannel(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.bestValueToMe_ = bestValueToMe_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.bestValueSignature_ = bestValueSignature_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.refundTransactionUnlockTimeSecs_ = refundTransactionUnlockTimeSecs_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.contractTransaction_ = contractTransaction_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.clientOutput_ = clientOutput_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        result.myKey_ = myKey_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000040;
-        }
-        result.majorVersion_ = majorVersion_;
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-          to_bitField0_ |= 0x00000080;
-        }
-        result.clientKey_ = clientKey_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.protocols.channels.ServerState.StoredServerPaymentChannel) {
-          return mergeFrom((org.floj.protocols.channels.ServerState.StoredServerPaymentChannel)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.protocols.channels.ServerState.StoredServerPaymentChannel other) {
-        if (other == org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.getDefaultInstance()) return this;
-        if (other.hasBestValueToMe()) {
-          setBestValueToMe(other.getBestValueToMe());
-        }
-        if (other.hasBestValueSignature()) {
-          setBestValueSignature(other.getBestValueSignature());
-        }
-        if (other.hasRefundTransactionUnlockTimeSecs()) {
-          setRefundTransactionUnlockTimeSecs(other.getRefundTransactionUnlockTimeSecs());
-        }
-        if (other.hasContractTransaction()) {
-          setContractTransaction(other.getContractTransaction());
-        }
-        if (other.hasClientOutput()) {
-          setClientOutput(other.getClientOutput());
-        }
-        if (other.hasMyKey()) {
-          setMyKey(other.getMyKey());
-        }
-        if (other.hasMajorVersion()) {
-          setMajorVersion(other.getMajorVersion());
-        }
-        if (other.hasClientKey()) {
-          setClientKey(other.getClientKey());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasBestValueToMe()) {
-          
-          return false;
-        }
-        if (!hasRefundTransactionUnlockTimeSecs()) {
-          
-          return false;
-        }
-        if (!hasContractTransaction()) {
-          
-          return false;
-        }
-        if (!hasMyKey()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.protocols.channels.ServerState.StoredServerPaymentChannel parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.protocols.channels.ServerState.StoredServerPaymentChannel) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private long bestValueToMe_ ;
       /**
        * <code>required uint64 bestValueToMe = 1;</code>
        */
       public boolean hasBestValueToMe() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasBestValueToMe();
       }
       /**
        * <code>required uint64 bestValueToMe = 1;</code>
        */
       public long getBestValueToMe() {
-        return bestValueToMe_;
+        return instance.getBestValueToMe();
       }
       /**
        * <code>required uint64 bestValueToMe = 1;</code>
        */
       public Builder setBestValueToMe(long value) {
-        bitField0_ |= 0x00000001;
-        bestValueToMe_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setBestValueToMe(value);
         return this;
       }
       /**
        * <code>required uint64 bestValueToMe = 1;</code>
        */
       public Builder clearBestValueToMe() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        bestValueToMe_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearBestValueToMe();
         return this;
       }
 
-      private com.google.protobuf.ByteString bestValueSignature_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes bestValueSignature = 2;</code>
        */
       public boolean hasBestValueSignature() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasBestValueSignature();
       }
       /**
        * <code>optional bytes bestValueSignature = 2;</code>
        */
       public com.google.protobuf.ByteString getBestValueSignature() {
-        return bestValueSignature_;
+        return instance.getBestValueSignature();
       }
       /**
        * <code>optional bytes bestValueSignature = 2;</code>
        */
       public Builder setBestValueSignature(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        bestValueSignature_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setBestValueSignature(value);
         return this;
       }
       /**
        * <code>optional bytes bestValueSignature = 2;</code>
        */
       public Builder clearBestValueSignature() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        bestValueSignature_ = getDefaultInstance().getBestValueSignature();
-        onChanged();
+        copyOnWrite();
+        instance.clearBestValueSignature();
         return this;
       }
 
-      private long refundTransactionUnlockTimeSecs_ ;
       /**
        * <code>required uint64 refundTransactionUnlockTimeSecs = 3;</code>
        */
       public boolean hasRefundTransactionUnlockTimeSecs() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasRefundTransactionUnlockTimeSecs();
       }
       /**
        * <code>required uint64 refundTransactionUnlockTimeSecs = 3;</code>
        */
       public long getRefundTransactionUnlockTimeSecs() {
-        return refundTransactionUnlockTimeSecs_;
+        return instance.getRefundTransactionUnlockTimeSecs();
       }
       /**
        * <code>required uint64 refundTransactionUnlockTimeSecs = 3;</code>
        */
       public Builder setRefundTransactionUnlockTimeSecs(long value) {
-        bitField0_ |= 0x00000004;
-        refundTransactionUnlockTimeSecs_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setRefundTransactionUnlockTimeSecs(value);
         return this;
       }
       /**
        * <code>required uint64 refundTransactionUnlockTimeSecs = 3;</code>
        */
       public Builder clearRefundTransactionUnlockTimeSecs() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        refundTransactionUnlockTimeSecs_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearRefundTransactionUnlockTimeSecs();
         return this;
       }
 
-      private com.google.protobuf.ByteString contractTransaction_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes contractTransaction = 4;</code>
        */
       public boolean hasContractTransaction() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasContractTransaction();
       }
       /**
        * <code>required bytes contractTransaction = 4;</code>
        */
       public com.google.protobuf.ByteString getContractTransaction() {
-        return contractTransaction_;
+        return instance.getContractTransaction();
       }
       /**
        * <code>required bytes contractTransaction = 4;</code>
        */
       public Builder setContractTransaction(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        contractTransaction_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setContractTransaction(value);
         return this;
       }
       /**
        * <code>required bytes contractTransaction = 4;</code>
        */
       public Builder clearContractTransaction() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        contractTransaction_ = getDefaultInstance().getContractTransaction();
-        onChanged();
+        copyOnWrite();
+        instance.clearContractTransaction();
         return this;
       }
 
-      private com.google.protobuf.ByteString clientOutput_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes clientOutput = 5;</code>
        */
       public boolean hasClientOutput() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasClientOutput();
       }
       /**
        * <code>optional bytes clientOutput = 5;</code>
        */
       public com.google.protobuf.ByteString getClientOutput() {
-        return clientOutput_;
+        return instance.getClientOutput();
       }
       /**
        * <code>optional bytes clientOutput = 5;</code>
        */
       public Builder setClientOutput(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-        clientOutput_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setClientOutput(value);
         return this;
       }
       /**
        * <code>optional bytes clientOutput = 5;</code>
        */
       public Builder clearClientOutput() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        clientOutput_ = getDefaultInstance().getClientOutput();
-        onChanged();
+        copyOnWrite();
+        instance.clearClientOutput();
         return this;
       }
 
-      private com.google.protobuf.ByteString myKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes myKey = 6;</code>
        */
       public boolean hasMyKey() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return instance.hasMyKey();
       }
       /**
        * <code>required bytes myKey = 6;</code>
        */
       public com.google.protobuf.ByteString getMyKey() {
-        return myKey_;
+        return instance.getMyKey();
       }
       /**
        * <code>required bytes myKey = 6;</code>
        */
       public Builder setMyKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000020;
-        myKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMyKey(value);
         return this;
       }
       /**
        * <code>required bytes myKey = 6;</code>
        */
       public Builder clearMyKey() {
-        bitField0_ = (bitField0_ & ~0x00000020);
-        myKey_ = getDefaultInstance().getMyKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearMyKey();
         return this;
       }
 
-      private int majorVersion_ = 1;
       /**
        * <code>optional uint32 majorVersion = 7 [default = 1];</code>
        */
       public boolean hasMajorVersion() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return instance.hasMajorVersion();
       }
       /**
        * <code>optional uint32 majorVersion = 7 [default = 1];</code>
        */
       public int getMajorVersion() {
-        return majorVersion_;
+        return instance.getMajorVersion();
       }
       /**
        * <code>optional uint32 majorVersion = 7 [default = 1];</code>
        */
       public Builder setMajorVersion(int value) {
-        bitField0_ |= 0x00000040;
-        majorVersion_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMajorVersion(value);
         return this;
       }
       /**
        * <code>optional uint32 majorVersion = 7 [default = 1];</code>
        */
       public Builder clearMajorVersion() {
-        bitField0_ = (bitField0_ & ~0x00000040);
-        majorVersion_ = 1;
-        onChanged();
+        copyOnWrite();
+        instance.clearMajorVersion();
         return this;
       }
 
-      private com.google.protobuf.ByteString clientKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes clientKey = 8;</code>
-       *
        * <pre>
        * Protocol version 2 only - the P2SH hash doesn't contain the required key
        * </pre>
+       *
+       * <code>optional bytes clientKey = 8;</code>
        */
       public boolean hasClientKey() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return instance.hasClientKey();
       }
       /**
-       * <code>optional bytes clientKey = 8;</code>
-       *
        * <pre>
        * Protocol version 2 only - the P2SH hash doesn't contain the required key
        * </pre>
+       *
+       * <code>optional bytes clientKey = 8;</code>
        */
       public com.google.protobuf.ByteString getClientKey() {
-        return clientKey_;
+        return instance.getClientKey();
       }
       /**
-       * <code>optional bytes clientKey = 8;</code>
-       *
        * <pre>
        * Protocol version 2 only - the P2SH hash doesn't contain the required key
        * </pre>
+       *
+       * <code>optional bytes clientKey = 8;</code>
        */
       public Builder setClientKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000080;
-        clientKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setClientKey(value);
         return this;
       }
       /**
-       * <code>optional bytes clientKey = 8;</code>
-       *
        * <pre>
        * Protocol version 2 only - the P2SH hash doesn't contain the required key
        * </pre>
+       *
+       * <code>optional bytes clientKey = 8;</code>
        */
       public Builder clearClientKey() {
-        bitField0_ = (bitField0_ & ~0x00000080);
-        clientKey_ = getDefaultInstance().getClientKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearClientKey();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:paymentchannels.StoredServerPaymentChannel)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.protocols.channels.ServerState.StoredServerPaymentChannel();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new StoredServerPaymentChannel(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:paymentchannels.StoredServerPaymentChannel)
-  }
-
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_StoredServerPaymentChannels_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_StoredServerPaymentChannels_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_paymentchannels_StoredServerPaymentChannel_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_paymentchannels_StoredServerPaymentChannel_fieldAccessorTable;
-
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
-    return descriptor;
-  }
-  private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
-  static {
-    java.lang.String[] descriptorData = {
-      "\n storedserverpaymentchannel.proto\022\017paym" +
-      "entchannels\"\\\n\033StoredServerPaymentChanne" +
-      "ls\022=\n\010channels\030\001 \003(\0132+.paymentchannels.S" +
-      "toredServerPaymentChannel\"\346\001\n\032StoredServ" +
-      "erPaymentChannel\022\025\n\rbestValueToMe\030\001 \002(\004\022" +
-      "\032\n\022bestValueSignature\030\002 \001(\014\022\'\n\037refundTra" +
-      "nsactionUnlockTimeSecs\030\003 \002(\004\022\033\n\023contract" +
-      "Transaction\030\004 \002(\014\022\024\n\014clientOutput\030\005 \001(\014\022" +
-      "\r\n\005myKey\030\006 \002(\014\022\027\n\014majorVersion\030\007 \001(\r:\0011\022" +
-      "\021\n\tclientKey\030\010 \001(\014B*\n\033org.floj.protocols",
-      ".channelsB\013ServerState"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasBestValueToMe()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
             return null;
           }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-    internal_static_paymentchannels_StoredServerPaymentChannels_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_paymentchannels_StoredServerPaymentChannels_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_StoredServerPaymentChannels_descriptor,
-        new java.lang.String[] { "Channels", });
-    internal_static_paymentchannels_StoredServerPaymentChannel_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_paymentchannels_StoredServerPaymentChannel_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_paymentchannels_StoredServerPaymentChannel_descriptor,
-        new java.lang.String[] { "BestValueToMe", "BestValueSignature", "RefundTransactionUnlockTimeSecs", "ContractTransaction", "ClientOutput", "MyKey", "MajorVersion", "ClientKey", });
+          if (!hasRefundTransactionUnlockTimeSecs()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasContractTransaction()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasMyKey()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.protocols.channels.ServerState.StoredServerPaymentChannel other = (org.floj.protocols.channels.ServerState.StoredServerPaymentChannel) arg1;
+          bestValueToMe_ = visitor.visitLong(
+              hasBestValueToMe(), bestValueToMe_,
+              other.hasBestValueToMe(), other.bestValueToMe_);
+          bestValueSignature_ = visitor.visitByteString(
+              hasBestValueSignature(), bestValueSignature_,
+              other.hasBestValueSignature(), other.bestValueSignature_);
+          refundTransactionUnlockTimeSecs_ = visitor.visitLong(
+              hasRefundTransactionUnlockTimeSecs(), refundTransactionUnlockTimeSecs_,
+              other.hasRefundTransactionUnlockTimeSecs(), other.refundTransactionUnlockTimeSecs_);
+          contractTransaction_ = visitor.visitByteString(
+              hasContractTransaction(), contractTransaction_,
+              other.hasContractTransaction(), other.contractTransaction_);
+          clientOutput_ = visitor.visitByteString(
+              hasClientOutput(), clientOutput_,
+              other.hasClientOutput(), other.clientOutput_);
+          myKey_ = visitor.visitByteString(
+              hasMyKey(), myKey_,
+              other.hasMyKey(), other.myKey_);
+          majorVersion_ = visitor.visitInt(
+              hasMajorVersion(), majorVersion_,
+              other.hasMajorVersion(), other.majorVersion_);
+          clientKey_ = visitor.visitByteString(
+              hasClientKey(), clientKey_,
+              other.hasClientKey(), other.clientKey_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  bestValueToMe_ = input.readUInt64();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  bestValueSignature_ = input.readBytes();
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000004;
+                  refundTransactionUnlockTimeSecs_ = input.readUInt64();
+                  break;
+                }
+                case 34: {
+                  bitField0_ |= 0x00000008;
+                  contractTransaction_ = input.readBytes();
+                  break;
+                }
+                case 42: {
+                  bitField0_ |= 0x00000010;
+                  clientOutput_ = input.readBytes();
+                  break;
+                }
+                case 50: {
+                  bitField0_ |= 0x00000020;
+                  myKey_ = input.readBytes();
+                  break;
+                }
+                case 56: {
+                  bitField0_ |= 0x00000040;
+                  majorVersion_ = input.readUInt32();
+                  break;
+                }
+                case 66: {
+                  bitField0_ |= 0x00000080;
+                  clientKey_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.protocols.channels.ServerState.StoredServerPaymentChannel.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
+    }
+
+
+    // @@protoc_insertion_point(class_scope:paymentchannels.StoredServerPaymentChannel)
+    private static final org.floj.protocols.channels.ServerState.StoredServerPaymentChannel DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new StoredServerPaymentChannel();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.protocols.channels.ServerState.StoredServerPaymentChannel getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<StoredServerPaymentChannel> PARSER;
+
+    public static com.google.protobuf.Parser<StoredServerPaymentChannel> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
+  }
+
+
+  static {
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/floj-core/src/main/java/org/floj/wallet/BasicKeyChain.java
+++ b/floj-core/src/main/java/org/floj/wallet/BasicKeyChain.java
@@ -319,9 +319,9 @@ public class BasicKeyChain implements EncryptableKeyChain {
             // which the leaf keys chain to an encrypted parent and rederive their private keys on the fly. In that
             // case the caller in DeterministicKeyChain will take care of setting the type.
             EncryptedData data = item.getEncryptedData();
-            proto.getEncryptedDataBuilder()
+            proto.setEncryptedData(Protos.EncryptedData.newBuilder()
                     .setEncryptedPrivateKey(ByteString.copyFrom(data.encryptedBytes))
-                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector));
+                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector)));
             // We don't allow mixing of encryption types at the moment.
             checkState(item.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
             proto.setType(Protos.Key.Type.ENCRYPTED_SCRYPT_AES);

--- a/floj-core/src/main/java/org/floj/wallet/DeterministicKeyChain.java
+++ b/floj-core/src/main/java/org/floj/wallet/DeterministicKeyChain.java
@@ -739,7 +739,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             DeterministicKey key = (DeterministicKey) entry.getKey();
             Protos.Key.Builder proto = entry.getValue();
             proto.setType(Protos.Key.Type.DETERMINISTIC_KEY);
-            final Protos.DeterministicKey.Builder detKey = proto.getDeterministicKeyBuilder();
+            final Protos.DeterministicKey.Builder detKey = Protos.DeterministicKey.newBuilder();
             detKey.setChainCode(ByteString.copyFrom(key.getChainCode()));
             for (ChildNumber num : key.getPath())
                 detKey.addPath(num.i());
@@ -756,6 +756,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             if (entries.isEmpty() && isFollowing()) {
                 detKey.setIsFollowing(true);
             }
+            proto.setDeterministicKey(detKey);
             if (key.getParent() != null) {
                 // HD keys inherit the timestamp of their parent if they have one, so no need to serialize it.
                 proto.clearCreationTimestamp();
@@ -1270,9 +1271,9 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         // the seed.
         if (seed.isEncrypted() && seed.getEncryptedSeedData() != null) {
             EncryptedData data = seed.getEncryptedSeedData();
-            proto.getEncryptedDeterministicSeedBuilder()
+            proto.setEncryptedData(Protos.EncryptedData.newBuilder()
                     .setEncryptedPrivateKey(ByteString.copyFrom(data.encryptedBytes))
-                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector));
+                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector)));
             // We don't allow mixing of encryption types at the moment.
             checkState(seed.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
         } else {

--- a/floj-core/src/main/java/org/floj/wallet/Protos.java
+++ b/floj-core/src/main/java/org/floj/wallet/Protos.java
@@ -6,11 +6,11 @@ package org.floj.wallet;
 public final class Protos {
   private Protos() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
   }
   public interface PeerAddressOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.PeerAddress)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required bytes ip_address = 1;</code>
@@ -42,109 +42,14 @@ public final class Protos {
   /**
    * Protobuf type {@code wallet.PeerAddress}
    */
-  public static final class PeerAddress extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class PeerAddress extends
+      com.google.protobuf.GeneratedMessageLite<
+          PeerAddress, PeerAddress.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.PeerAddress)
       PeerAddressOrBuilder {
-    // Use PeerAddress.newBuilder() to construct.
-    private PeerAddress(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private PeerAddress() {
+      ipAddress_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private PeerAddress(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final PeerAddress defaultInstance;
-    public static PeerAddress getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public PeerAddress getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PeerAddress(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              ipAddress_ = input.readBytes();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              port_ = input.readUInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              services_ = input.readUInt64();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_PeerAddress_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_PeerAddress_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.PeerAddress.class, org.floj.wallet.Protos.PeerAddress.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<PeerAddress> PARSER =
-        new com.google.protobuf.AbstractParser<PeerAddress>() {
-      public PeerAddress parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PeerAddress(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<PeerAddress> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int IP_ADDRESS_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString ipAddress_;
@@ -159,6 +64,23 @@ public final class Protos {
      */
     public com.google.protobuf.ByteString getIpAddress() {
       return ipAddress_;
+    }
+    /**
+     * <code>required bytes ip_address = 1;</code>
+     */
+    private void setIpAddress(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      ipAddress_ = value;
+    }
+    /**
+     * <code>required bytes ip_address = 1;</code>
+     */
+    private void clearIpAddress() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      ipAddress_ = getDefaultInstance().getIpAddress();
     }
 
     public static final int PORT_FIELD_NUMBER = 2;
@@ -175,6 +97,20 @@ public final class Protos {
     public int getPort() {
       return port_;
     }
+    /**
+     * <code>required uint32 port = 2;</code>
+     */
+    private void setPort(int value) {
+      bitField0_ |= 0x00000002;
+      port_ = value;
+    }
+    /**
+     * <code>required uint32 port = 2;</code>
+     */
+    private void clearPort() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      port_ = 0;
+    }
 
     public static final int SERVICES_FIELD_NUMBER = 3;
     private long services_;
@@ -190,37 +126,23 @@ public final class Protos {
     public long getServices() {
       return services_;
     }
-
-    private void initFields() {
-      ipAddress_ = com.google.protobuf.ByteString.EMPTY;
-      port_ = 0;
-      services_ = 0L;
+    /**
+     * <code>required uint64 services = 3;</code>
+     */
+    private void setServices(long value) {
+      bitField0_ |= 0x00000004;
+      services_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasIpAddress()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasPort()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasServices()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>required uint64 services = 3;</code>
+     */
+    private void clearServices() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      services_ = 0L;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, ipAddress_);
       }
@@ -230,10 +152,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeUInt64(3, services_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -251,564 +172,480 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(3, services_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.PeerAddress parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.PeerAddress parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.PeerAddress parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.PeerAddress parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.PeerAddress parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.PeerAddress parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.PeerAddress parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.PeerAddress parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.PeerAddress parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.PeerAddress parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.PeerAddress prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code wallet.PeerAddress}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.PeerAddress, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.PeerAddress)
         org.floj.wallet.Protos.PeerAddressOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_PeerAddress_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_PeerAddress_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.PeerAddress.class, org.floj.wallet.Protos.PeerAddress.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.PeerAddress.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        ipAddress_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        port_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        services_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_PeerAddress_descriptor;
-      }
-
-      public org.floj.wallet.Protos.PeerAddress getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.PeerAddress.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.PeerAddress build() {
-        org.floj.wallet.Protos.PeerAddress result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.PeerAddress buildPartial() {
-        org.floj.wallet.Protos.PeerAddress result = new org.floj.wallet.Protos.PeerAddress(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.ipAddress_ = ipAddress_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.port_ = port_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.services_ = services_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.PeerAddress) {
-          return mergeFrom((org.floj.wallet.Protos.PeerAddress)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.PeerAddress other) {
-        if (other == org.floj.wallet.Protos.PeerAddress.getDefaultInstance()) return this;
-        if (other.hasIpAddress()) {
-          setIpAddress(other.getIpAddress());
-        }
-        if (other.hasPort()) {
-          setPort(other.getPort());
-        }
-        if (other.hasServices()) {
-          setServices(other.getServices());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasIpAddress()) {
-          
-          return false;
-        }
-        if (!hasPort()) {
-          
-          return false;
-        }
-        if (!hasServices()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.PeerAddress parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.PeerAddress) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString ipAddress_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes ip_address = 1;</code>
        */
       public boolean hasIpAddress() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasIpAddress();
       }
       /**
        * <code>required bytes ip_address = 1;</code>
        */
       public com.google.protobuf.ByteString getIpAddress() {
-        return ipAddress_;
+        return instance.getIpAddress();
       }
       /**
        * <code>required bytes ip_address = 1;</code>
        */
       public Builder setIpAddress(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        ipAddress_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setIpAddress(value);
         return this;
       }
       /**
        * <code>required bytes ip_address = 1;</code>
        */
       public Builder clearIpAddress() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        ipAddress_ = getDefaultInstance().getIpAddress();
-        onChanged();
+        copyOnWrite();
+        instance.clearIpAddress();
         return this;
       }
 
-      private int port_ ;
       /**
        * <code>required uint32 port = 2;</code>
        */
       public boolean hasPort() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasPort();
       }
       /**
        * <code>required uint32 port = 2;</code>
        */
       public int getPort() {
-        return port_;
+        return instance.getPort();
       }
       /**
        * <code>required uint32 port = 2;</code>
        */
       public Builder setPort(int value) {
-        bitField0_ |= 0x00000002;
-        port_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPort(value);
         return this;
       }
       /**
        * <code>required uint32 port = 2;</code>
        */
       public Builder clearPort() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        port_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearPort();
         return this;
       }
 
-      private long services_ ;
       /**
        * <code>required uint64 services = 3;</code>
        */
       public boolean hasServices() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasServices();
       }
       /**
        * <code>required uint64 services = 3;</code>
        */
       public long getServices() {
-        return services_;
+        return instance.getServices();
       }
       /**
        * <code>required uint64 services = 3;</code>
        */
       public Builder setServices(long value) {
-        bitField0_ |= 0x00000004;
-        services_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setServices(value);
         return this;
       }
       /**
        * <code>required uint64 services = 3;</code>
        */
       public Builder clearServices() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        services_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearServices();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.PeerAddress)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.PeerAddress();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new PeerAddress(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasIpAddress()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasPort()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasServices()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.PeerAddress other = (org.floj.wallet.Protos.PeerAddress) arg1;
+          ipAddress_ = visitor.visitByteString(
+              hasIpAddress(), ipAddress_,
+              other.hasIpAddress(), other.ipAddress_);
+          port_ = visitor.visitInt(
+              hasPort(), port_,
+              other.hasPort(), other.port_);
+          services_ = visitor.visitLong(
+              hasServices(), services_,
+              other.hasServices(), other.services_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  ipAddress_ = input.readBytes();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  port_ = input.readUInt32();
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000004;
+                  services_ = input.readUInt64();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.PeerAddress.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.PeerAddress)
+    private static final org.floj.wallet.Protos.PeerAddress DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new PeerAddress();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.PeerAddress getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<PeerAddress> PARSER;
+
+    public static com.google.protobuf.Parser<PeerAddress> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface EncryptedDataOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.EncryptedData)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes initialisation_vector = 1;</code>
-     *
      * <pre>
      * The initialisation vector for the AES encryption (16 bytes)
      * </pre>
+     *
+     * <code>required bytes initialisation_vector = 1;</code>
      */
     boolean hasInitialisationVector();
     /**
-     * <code>required bytes initialisation_vector = 1;</code>
-     *
      * <pre>
      * The initialisation vector for the AES encryption (16 bytes)
      * </pre>
+     *
+     * <code>required bytes initialisation_vector = 1;</code>
      */
     com.google.protobuf.ByteString getInitialisationVector();
 
     /**
-     * <code>required bytes encrypted_private_key = 2;</code>
-     *
      * <pre>
      * The encrypted private key
      * </pre>
+     *
+     * <code>required bytes encrypted_private_key = 2;</code>
      */
     boolean hasEncryptedPrivateKey();
     /**
-     * <code>required bytes encrypted_private_key = 2;</code>
-     *
      * <pre>
      * The encrypted private key
      * </pre>
+     *
+     * <code>required bytes encrypted_private_key = 2;</code>
      */
     com.google.protobuf.ByteString getEncryptedPrivateKey();
   }
   /**
    * Protobuf type {@code wallet.EncryptedData}
    */
-  public static final class EncryptedData extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class EncryptedData extends
+      com.google.protobuf.GeneratedMessageLite<
+          EncryptedData, EncryptedData.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.EncryptedData)
       EncryptedDataOrBuilder {
-    // Use EncryptedData.newBuilder() to construct.
-    private EncryptedData(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private EncryptedData() {
+      initialisationVector_ = com.google.protobuf.ByteString.EMPTY;
+      encryptedPrivateKey_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private EncryptedData(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final EncryptedData defaultInstance;
-    public static EncryptedData getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public EncryptedData getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private EncryptedData(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              initialisationVector_ = input.readBytes();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              encryptedPrivateKey_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_EncryptedData_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_EncryptedData_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.EncryptedData.class, org.floj.wallet.Protos.EncryptedData.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<EncryptedData> PARSER =
-        new com.google.protobuf.AbstractParser<EncryptedData>() {
-      public EncryptedData parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new EncryptedData(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<EncryptedData> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int INITIALISATION_VECTOR_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString initialisationVector_;
     /**
-     * <code>required bytes initialisation_vector = 1;</code>
-     *
      * <pre>
      * The initialisation vector for the AES encryption (16 bytes)
      * </pre>
+     *
+     * <code>required bytes initialisation_vector = 1;</code>
      */
     public boolean hasInitialisationVector() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bytes initialisation_vector = 1;</code>
-     *
      * <pre>
      * The initialisation vector for the AES encryption (16 bytes)
      * </pre>
+     *
+     * <code>required bytes initialisation_vector = 1;</code>
      */
     public com.google.protobuf.ByteString getInitialisationVector() {
       return initialisationVector_;
+    }
+    /**
+     * <pre>
+     * The initialisation vector for the AES encryption (16 bytes)
+     * </pre>
+     *
+     * <code>required bytes initialisation_vector = 1;</code>
+     */
+    private void setInitialisationVector(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      initialisationVector_ = value;
+    }
+    /**
+     * <pre>
+     * The initialisation vector for the AES encryption (16 bytes)
+     * </pre>
+     *
+     * <code>required bytes initialisation_vector = 1;</code>
+     */
+    private void clearInitialisationVector() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      initialisationVector_ = getDefaultInstance().getInitialisationVector();
     }
 
     public static final int ENCRYPTED_PRIVATE_KEY_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString encryptedPrivateKey_;
     /**
-     * <code>required bytes encrypted_private_key = 2;</code>
-     *
      * <pre>
      * The encrypted private key
      * </pre>
+     *
+     * <code>required bytes encrypted_private_key = 2;</code>
      */
     public boolean hasEncryptedPrivateKey() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required bytes encrypted_private_key = 2;</code>
-     *
      * <pre>
      * The encrypted private key
      * </pre>
+     *
+     * <code>required bytes encrypted_private_key = 2;</code>
      */
     public com.google.protobuf.ByteString getEncryptedPrivateKey() {
       return encryptedPrivateKey_;
     }
-
-    private void initFields() {
-      initialisationVector_ = com.google.protobuf.ByteString.EMPTY;
-      encryptedPrivateKey_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * The encrypted private key
+     * </pre>
+     *
+     * <code>required bytes encrypted_private_key = 2;</code>
+     */
+    private void setEncryptedPrivateKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      encryptedPrivateKey_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasInitialisationVector()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasEncryptedPrivateKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * The encrypted private key
+     * </pre>
+     *
+     * <code>required bytes encrypted_private_key = 2;</code>
+     */
+    private void clearEncryptedPrivateKey() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      encryptedPrivateKey_ = getDefaultInstance().getEncryptedPrivateKey();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, initialisationVector_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, encryptedPrivateKey_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -822,387 +659,363 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, encryptedPrivateKey_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.EncryptedData parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.EncryptedData parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.EncryptedData parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.EncryptedData parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.EncryptedData parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.EncryptedData parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.EncryptedData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.EncryptedData parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.EncryptedData parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.EncryptedData parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.EncryptedData prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code wallet.EncryptedData}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.EncryptedData, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.EncryptedData)
         org.floj.wallet.Protos.EncryptedDataOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_EncryptedData_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_EncryptedData_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.EncryptedData.class, org.floj.wallet.Protos.EncryptedData.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.EncryptedData.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        initialisationVector_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        encryptedPrivateKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_EncryptedData_descriptor;
-      }
-
-      public org.floj.wallet.Protos.EncryptedData getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.EncryptedData build() {
-        org.floj.wallet.Protos.EncryptedData result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.EncryptedData buildPartial() {
-        org.floj.wallet.Protos.EncryptedData result = new org.floj.wallet.Protos.EncryptedData(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.initialisationVector_ = initialisationVector_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.encryptedPrivateKey_ = encryptedPrivateKey_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.EncryptedData) {
-          return mergeFrom((org.floj.wallet.Protos.EncryptedData)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.EncryptedData other) {
-        if (other == org.floj.wallet.Protos.EncryptedData.getDefaultInstance()) return this;
-        if (other.hasInitialisationVector()) {
-          setInitialisationVector(other.getInitialisationVector());
-        }
-        if (other.hasEncryptedPrivateKey()) {
-          setEncryptedPrivateKey(other.getEncryptedPrivateKey());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasInitialisationVector()) {
-          
-          return false;
-        }
-        if (!hasEncryptedPrivateKey()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.EncryptedData parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.EncryptedData) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString initialisationVector_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes initialisation_vector = 1;</code>
-       *
        * <pre>
        * The initialisation vector for the AES encryption (16 bytes)
        * </pre>
+       *
+       * <code>required bytes initialisation_vector = 1;</code>
        */
       public boolean hasInitialisationVector() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasInitialisationVector();
       }
       /**
-       * <code>required bytes initialisation_vector = 1;</code>
-       *
        * <pre>
        * The initialisation vector for the AES encryption (16 bytes)
        * </pre>
+       *
+       * <code>required bytes initialisation_vector = 1;</code>
        */
       public com.google.protobuf.ByteString getInitialisationVector() {
-        return initialisationVector_;
+        return instance.getInitialisationVector();
       }
       /**
-       * <code>required bytes initialisation_vector = 1;</code>
-       *
        * <pre>
        * The initialisation vector for the AES encryption (16 bytes)
        * </pre>
+       *
+       * <code>required bytes initialisation_vector = 1;</code>
        */
       public Builder setInitialisationVector(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        initialisationVector_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setInitialisationVector(value);
         return this;
       }
       /**
-       * <code>required bytes initialisation_vector = 1;</code>
-       *
        * <pre>
        * The initialisation vector for the AES encryption (16 bytes)
        * </pre>
+       *
+       * <code>required bytes initialisation_vector = 1;</code>
        */
       public Builder clearInitialisationVector() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        initialisationVector_ = getDefaultInstance().getInitialisationVector();
-        onChanged();
+        copyOnWrite();
+        instance.clearInitialisationVector();
         return this;
       }
 
-      private com.google.protobuf.ByteString encryptedPrivateKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes encrypted_private_key = 2;</code>
-       *
        * <pre>
        * The encrypted private key
        * </pre>
+       *
+       * <code>required bytes encrypted_private_key = 2;</code>
        */
       public boolean hasEncryptedPrivateKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasEncryptedPrivateKey();
       }
       /**
-       * <code>required bytes encrypted_private_key = 2;</code>
-       *
        * <pre>
        * The encrypted private key
        * </pre>
+       *
+       * <code>required bytes encrypted_private_key = 2;</code>
        */
       public com.google.protobuf.ByteString getEncryptedPrivateKey() {
-        return encryptedPrivateKey_;
+        return instance.getEncryptedPrivateKey();
       }
       /**
-       * <code>required bytes encrypted_private_key = 2;</code>
-       *
        * <pre>
        * The encrypted private key
        * </pre>
+       *
+       * <code>required bytes encrypted_private_key = 2;</code>
        */
       public Builder setEncryptedPrivateKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        encryptedPrivateKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setEncryptedPrivateKey(value);
         return this;
       }
       /**
-       * <code>required bytes encrypted_private_key = 2;</code>
-       *
        * <pre>
        * The encrypted private key
        * </pre>
+       *
+       * <code>required bytes encrypted_private_key = 2;</code>
        */
       public Builder clearEncryptedPrivateKey() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        encryptedPrivateKey_ = getDefaultInstance().getEncryptedPrivateKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearEncryptedPrivateKey();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.EncryptedData)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.EncryptedData();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new EncryptedData(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasInitialisationVector()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasEncryptedPrivateKey()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.EncryptedData other = (org.floj.wallet.Protos.EncryptedData) arg1;
+          initialisationVector_ = visitor.visitByteString(
+              hasInitialisationVector(), initialisationVector_,
+              other.hasInitialisationVector(), other.initialisationVector_);
+          encryptedPrivateKey_ = visitor.visitByteString(
+              hasEncryptedPrivateKey(), encryptedPrivateKey_,
+              other.hasEncryptedPrivateKey(), other.encryptedPrivateKey_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  initialisationVector_ = input.readBytes();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  encryptedPrivateKey_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.EncryptedData.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.EncryptedData)
+    private static final org.floj.wallet.Protos.EncryptedData DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new EncryptedData();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.EncryptedData getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<EncryptedData> PARSER;
+
+    public static com.google.protobuf.Parser<EncryptedData> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface DeterministicKeyOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.DeterministicKey)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes chain_code = 1;</code>
-     *
      * <pre>
      * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
      * should just treat it as a regular ORIGINAL type key.
      * </pre>
+     *
+     * <code>required bytes chain_code = 1;</code>
      */
     boolean hasChainCode();
     /**
-     * <code>required bytes chain_code = 1;</code>
-     *
      * <pre>
      * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
      * should just treat it as a regular ORIGINAL type key.
      * </pre>
+     *
+     * <code>required bytes chain_code = 1;</code>
      */
     com.google.protobuf.ByteString getChainCode();
 
     /**
-     * <code>repeated uint32 path = 2;</code>
-     *
      * <pre>
      * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
      * and high bit unset for public derivation.
      * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
      */
     java.util.List<java.lang.Integer> getPathList();
     /**
-     * <code>repeated uint32 path = 2;</code>
-     *
      * <pre>
      * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
      * and high bit unset for public derivation.
      * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
      */
     int getPathCount();
     /**
-     * <code>repeated uint32 path = 2;</code>
-     *
      * <pre>
      * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
      * and high bit unset for public derivation.
      * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
      */
     int getPath(int index);
 
     /**
-     * <code>optional uint32 issued_subkeys = 3;</code>
-     *
      * <pre>
      * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
      * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -1210,11 +1023,11 @@ public final class Protos {
      * this wallet - for instance when restoring from backup or if the seed was shared between devices.
      * If this field is missing it means we're not issuing subkeys of this key to users.
      * </pre>
+     *
+     * <code>optional uint32 issued_subkeys = 3;</code>
      */
     boolean hasIssuedSubkeys();
     /**
-     * <code>optional uint32 issued_subkeys = 3;</code>
-     *
      * <pre>
      * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
      * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -1222,6 +1035,8 @@ public final class Protos {
      * this wallet - for instance when restoring from backup or if the seed was shared between devices.
      * If this field is missing it means we're not issuing subkeys of this key to users.
      * </pre>
+     *
+     * <code>optional uint32 issued_subkeys = 3;</code>
      */
     int getIssuedSubkeys();
 
@@ -1235,260 +1050,214 @@ public final class Protos {
     int getLookaheadSize();
 
     /**
-     * <code>optional bool isFollowing = 5;</code>
-     *
      * <pre>
      **
      * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
      * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
      * a single P2SH multisignature address
      * </pre>
+     *
+     * <code>optional bool isFollowing = 5;</code>
      */
     boolean hasIsFollowing();
     /**
-     * <code>optional bool isFollowing = 5;</code>
-     *
      * <pre>
      **
      * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
      * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
      * a single P2SH multisignature address
      * </pre>
+     *
+     * <code>optional bool isFollowing = 5;</code>
      */
     boolean getIsFollowing();
 
     /**
-     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-     *
      * <pre>
      * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
      * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
      * </pre>
+     *
+     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
      */
     boolean hasSigsRequiredToSpend();
     /**
-     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-     *
      * <pre>
      * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
      * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
      * </pre>
+     *
+     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
      */
     int getSigsRequiredToSpend();
   }
   /**
-   * Protobuf type {@code wallet.DeterministicKey}
-   *
    * <pre>
    **
    * Data attached to a Key message that defines the data needed by the BIP32 deterministic key hierarchy algorithm.
    * </pre>
+   *
+   * Protobuf type {@code wallet.DeterministicKey}
    */
-  public static final class DeterministicKey extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class DeterministicKey extends
+      com.google.protobuf.GeneratedMessageLite<
+          DeterministicKey, DeterministicKey.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.DeterministicKey)
       DeterministicKeyOrBuilder {
-    // Use DeterministicKey.newBuilder() to construct.
-    private DeterministicKey(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private DeterministicKey() {
+      chainCode_ = com.google.protobuf.ByteString.EMPTY;
+      path_ = emptyIntList();
+      sigsRequiredToSpend_ = 1;
     }
-    private DeterministicKey(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final DeterministicKey defaultInstance;
-    public static DeterministicKey getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public DeterministicKey getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private DeterministicKey(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              chainCode_ = input.readBytes();
-              break;
-            }
-            case 16: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                path_ = new java.util.ArrayList<java.lang.Integer>();
-                mutable_bitField0_ |= 0x00000002;
-              }
-              path_.add(input.readUInt32());
-              break;
-            }
-            case 18: {
-              int length = input.readRawVarint32();
-              int limit = input.pushLimit(length);
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002) && input.getBytesUntilLimit() > 0) {
-                path_ = new java.util.ArrayList<java.lang.Integer>();
-                mutable_bitField0_ |= 0x00000002;
-              }
-              while (input.getBytesUntilLimit() > 0) {
-                path_.add(input.readUInt32());
-              }
-              input.popLimit(limit);
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000002;
-              issuedSubkeys_ = input.readUInt32();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000004;
-              lookaheadSize_ = input.readUInt32();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000008;
-              isFollowing_ = input.readBool();
-              break;
-            }
-            case 48: {
-              bitField0_ |= 0x00000010;
-              sigsRequiredToSpend_ = input.readUInt32();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-          path_ = java.util.Collections.unmodifiableList(path_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_DeterministicKey_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_DeterministicKey_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.DeterministicKey.class, org.floj.wallet.Protos.DeterministicKey.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<DeterministicKey> PARSER =
-        new com.google.protobuf.AbstractParser<DeterministicKey>() {
-      public DeterministicKey parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DeterministicKey(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<DeterministicKey> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int CHAIN_CODE_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString chainCode_;
     /**
-     * <code>required bytes chain_code = 1;</code>
-     *
      * <pre>
      * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
      * should just treat it as a regular ORIGINAL type key.
      * </pre>
+     *
+     * <code>required bytes chain_code = 1;</code>
      */
     public boolean hasChainCode() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bytes chain_code = 1;</code>
-     *
      * <pre>
      * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
      * should just treat it as a regular ORIGINAL type key.
      * </pre>
+     *
+     * <code>required bytes chain_code = 1;</code>
      */
     public com.google.protobuf.ByteString getChainCode() {
       return chainCode_;
     }
+    /**
+     * <pre>
+     * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
+     * should just treat it as a regular ORIGINAL type key.
+     * </pre>
+     *
+     * <code>required bytes chain_code = 1;</code>
+     */
+    private void setChainCode(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      chainCode_ = value;
+    }
+    /**
+     * <pre>
+     * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
+     * should just treat it as a regular ORIGINAL type key.
+     * </pre>
+     *
+     * <code>required bytes chain_code = 1;</code>
+     */
+    private void clearChainCode() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      chainCode_ = getDefaultInstance().getChainCode();
+    }
 
     public static final int PATH_FIELD_NUMBER = 2;
-    private java.util.List<java.lang.Integer> path_;
+    private com.google.protobuf.Internal.IntList path_;
     /**
-     * <code>repeated uint32 path = 2;</code>
-     *
      * <pre>
      * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
      * and high bit unset for public derivation.
      * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
      */
     public java.util.List<java.lang.Integer>
         getPathList() {
       return path_;
     }
     /**
-     * <code>repeated uint32 path = 2;</code>
-     *
      * <pre>
      * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
      * and high bit unset for public derivation.
      * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
      */
     public int getPathCount() {
       return path_.size();
     }
     /**
-     * <code>repeated uint32 path = 2;</code>
-     *
      * <pre>
      * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
      * and high bit unset for public derivation.
      * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
      */
     public int getPath(int index) {
-      return path_.get(index);
+      return path_.getInt(index);
+    }
+    private void ensurePathIsMutable() {
+      if (!path_.isModifiable()) {
+        path_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(path_);
+       }
+    }
+    /**
+     * <pre>
+     * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
+     * and high bit unset for public derivation.
+     * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
+     */
+    private void setPath(
+        int index, int value) {
+      ensurePathIsMutable();
+      path_.setInt(index, value);
+    }
+    /**
+     * <pre>
+     * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
+     * and high bit unset for public derivation.
+     * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
+     */
+    private void addPath(int value) {
+      ensurePathIsMutable();
+      path_.addInt(value);
+    }
+    /**
+     * <pre>
+     * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
+     * and high bit unset for public derivation.
+     * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
+     */
+    private void addAllPath(
+        java.lang.Iterable<? extends java.lang.Integer> values) {
+      ensurePathIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, path_);
+    }
+    /**
+     * <pre>
+     * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
+     * and high bit unset for public derivation.
+     * </pre>
+     *
+     * <code>repeated uint32 path = 2;</code>
+     */
+    private void clearPath() {
+      path_ = emptyIntList();
     }
 
     public static final int ISSUED_SUBKEYS_FIELD_NUMBER = 3;
     private int issuedSubkeys_;
     /**
-     * <code>optional uint32 issued_subkeys = 3;</code>
-     *
      * <pre>
      * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
      * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -1496,13 +1265,13 @@ public final class Protos {
      * this wallet - for instance when restoring from backup or if the seed was shared between devices.
      * If this field is missing it means we're not issuing subkeys of this key to users.
      * </pre>
+     *
+     * <code>optional uint32 issued_subkeys = 3;</code>
      */
     public boolean hasIssuedSubkeys() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional uint32 issued_subkeys = 3;</code>
-     *
      * <pre>
      * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
      * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -1510,9 +1279,41 @@ public final class Protos {
      * this wallet - for instance when restoring from backup or if the seed was shared between devices.
      * If this field is missing it means we're not issuing subkeys of this key to users.
      * </pre>
+     *
+     * <code>optional uint32 issued_subkeys = 3;</code>
      */
     public int getIssuedSubkeys() {
       return issuedSubkeys_;
+    }
+    /**
+     * <pre>
+     * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
+     * For the parents of keys being handed out, this is always less than the true number of children: the difference is
+     * called the lookahead zone. These keys are put into Bloom filters so we can spot transactions made by clones of
+     * this wallet - for instance when restoring from backup or if the seed was shared between devices.
+     * If this field is missing it means we're not issuing subkeys of this key to users.
+     * </pre>
+     *
+     * <code>optional uint32 issued_subkeys = 3;</code>
+     */
+    private void setIssuedSubkeys(int value) {
+      bitField0_ |= 0x00000002;
+      issuedSubkeys_ = value;
+    }
+    /**
+     * <pre>
+     * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
+     * For the parents of keys being handed out, this is always less than the true number of children: the difference is
+     * called the lookahead zone. These keys are put into Bloom filters so we can spot transactions made by clones of
+     * this wallet - for instance when restoring from backup or if the seed was shared between devices.
+     * If this field is missing it means we're not issuing subkeys of this key to users.
+     * </pre>
+     *
+     * <code>optional uint32 issued_subkeys = 3;</code>
+     */
+    private void clearIssuedSubkeys() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      issuedSubkeys_ = 0;
     }
 
     public static final int LOOKAHEAD_SIZE_FIELD_NUMBER = 4;
@@ -1529,91 +1330,134 @@ public final class Protos {
     public int getLookaheadSize() {
       return lookaheadSize_;
     }
+    /**
+     * <code>optional uint32 lookahead_size = 4;</code>
+     */
+    private void setLookaheadSize(int value) {
+      bitField0_ |= 0x00000004;
+      lookaheadSize_ = value;
+    }
+    /**
+     * <code>optional uint32 lookahead_size = 4;</code>
+     */
+    private void clearLookaheadSize() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      lookaheadSize_ = 0;
+    }
 
     public static final int ISFOLLOWING_FIELD_NUMBER = 5;
     private boolean isFollowing_;
     /**
-     * <code>optional bool isFollowing = 5;</code>
-     *
      * <pre>
      **
      * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
      * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
      * a single P2SH multisignature address
      * </pre>
+     *
+     * <code>optional bool isFollowing = 5;</code>
      */
     public boolean hasIsFollowing() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional bool isFollowing = 5;</code>
-     *
      * <pre>
      **
      * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
      * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
      * a single P2SH multisignature address
      * </pre>
+     *
+     * <code>optional bool isFollowing = 5;</code>
      */
     public boolean getIsFollowing() {
       return isFollowing_;
+    }
+    /**
+     * <pre>
+     **
+     * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
+     * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
+     * a single P2SH multisignature address
+     * </pre>
+     *
+     * <code>optional bool isFollowing = 5;</code>
+     */
+    private void setIsFollowing(boolean value) {
+      bitField0_ |= 0x00000008;
+      isFollowing_ = value;
+    }
+    /**
+     * <pre>
+     **
+     * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
+     * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
+     * a single P2SH multisignature address
+     * </pre>
+     *
+     * <code>optional bool isFollowing = 5;</code>
+     */
+    private void clearIsFollowing() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      isFollowing_ = false;
     }
 
     public static final int SIGSREQUIREDTOSPEND_FIELD_NUMBER = 6;
     private int sigsRequiredToSpend_;
     /**
-     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-     *
      * <pre>
      * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
      * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
      * </pre>
+     *
+     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
      */
     public boolean hasSigsRequiredToSpend() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-     *
      * <pre>
      * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
      * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
      * </pre>
+     *
+     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
      */
     public int getSigsRequiredToSpend() {
       return sigsRequiredToSpend_;
     }
-
-    private void initFields() {
-      chainCode_ = com.google.protobuf.ByteString.EMPTY;
-      path_ = java.util.Collections.emptyList();
-      issuedSubkeys_ = 0;
-      lookaheadSize_ = 0;
-      isFollowing_ = false;
-      sigsRequiredToSpend_ = 1;
+    /**
+     * <pre>
+     * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
+     * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
+     * </pre>
+     *
+     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
+     */
+    private void setSigsRequiredToSpend(int value) {
+      bitField0_ |= 0x00000010;
+      sigsRequiredToSpend_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasChainCode()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
+     * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
+     * </pre>
+     *
+     * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
+     */
+    private void clearSigsRequiredToSpend() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      sigsRequiredToSpend_ = 1;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, chainCode_);
       }
       for (int i = 0; i < path_.size(); i++) {
-        output.writeUInt32(2, path_.get(i));
+        output.writeUInt32(2, path_.getInt(i));
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeUInt32(3, issuedSubkeys_);
@@ -1627,10 +1471,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeUInt32(6, sigsRequiredToSpend_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -1644,7 +1487,7 @@ public final class Protos {
         int dataSize = 0;
         for (int i = 0; i < path_.size(); i++) {
           dataSize += com.google.protobuf.CodedOutputStream
-            .computeUInt32SizeNoTag(path_.get(i));
+            .computeUInt32SizeNoTag(path_.getInt(i));
         }
         size += dataSize;
         size += 1 * getPathList().size();
@@ -1665,425 +1508,238 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(6, sigsRequiredToSpend_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.DeterministicKey parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.DeterministicKey prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.DeterministicKey}
-     *
      * <pre>
      **
      * Data attached to a Key message that defines the data needed by the BIP32 deterministic key hierarchy algorithm.
      * </pre>
+     *
+     * Protobuf type {@code wallet.DeterministicKey}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.DeterministicKey, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.DeterministicKey)
         org.floj.wallet.Protos.DeterministicKeyOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_DeterministicKey_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_DeterministicKey_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.DeterministicKey.class, org.floj.wallet.Protos.DeterministicKey.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.DeterministicKey.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        chainCode_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        path_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
-        issuedSubkeys_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        lookaheadSize_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        isFollowing_ = false;
-        bitField0_ = (bitField0_ & ~0x00000010);
-        sigsRequiredToSpend_ = 1;
-        bitField0_ = (bitField0_ & ~0x00000020);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_DeterministicKey_descriptor;
-      }
-
-      public org.floj.wallet.Protos.DeterministicKey getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.DeterministicKey.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.DeterministicKey build() {
-        org.floj.wallet.Protos.DeterministicKey result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.DeterministicKey buildPartial() {
-        org.floj.wallet.Protos.DeterministicKey result = new org.floj.wallet.Protos.DeterministicKey(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.chainCode_ = chainCode_;
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          path_ = java.util.Collections.unmodifiableList(path_);
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.path_ = path_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.issuedSubkeys_ = issuedSubkeys_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.lookaheadSize_ = lookaheadSize_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.isFollowing_ = isFollowing_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.sigsRequiredToSpend_ = sigsRequiredToSpend_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.DeterministicKey) {
-          return mergeFrom((org.floj.wallet.Protos.DeterministicKey)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.DeterministicKey other) {
-        if (other == org.floj.wallet.Protos.DeterministicKey.getDefaultInstance()) return this;
-        if (other.hasChainCode()) {
-          setChainCode(other.getChainCode());
-        }
-        if (!other.path_.isEmpty()) {
-          if (path_.isEmpty()) {
-            path_ = other.path_;
-            bitField0_ = (bitField0_ & ~0x00000002);
-          } else {
-            ensurePathIsMutable();
-            path_.addAll(other.path_);
-          }
-          onChanged();
-        }
-        if (other.hasIssuedSubkeys()) {
-          setIssuedSubkeys(other.getIssuedSubkeys());
-        }
-        if (other.hasLookaheadSize()) {
-          setLookaheadSize(other.getLookaheadSize());
-        }
-        if (other.hasIsFollowing()) {
-          setIsFollowing(other.getIsFollowing());
-        }
-        if (other.hasSigsRequiredToSpend()) {
-          setSigsRequiredToSpend(other.getSigsRequiredToSpend());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasChainCode()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.DeterministicKey parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.DeterministicKey) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString chainCode_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes chain_code = 1;</code>
-       *
        * <pre>
        * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
        * should just treat it as a regular ORIGINAL type key.
        * </pre>
+       *
+       * <code>required bytes chain_code = 1;</code>
        */
       public boolean hasChainCode() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasChainCode();
       }
       /**
-       * <code>required bytes chain_code = 1;</code>
-       *
        * <pre>
        * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
        * should just treat it as a regular ORIGINAL type key.
        * </pre>
+       *
+       * <code>required bytes chain_code = 1;</code>
        */
       public com.google.protobuf.ByteString getChainCode() {
-        return chainCode_;
+        return instance.getChainCode();
       }
       /**
-       * <code>required bytes chain_code = 1;</code>
-       *
        * <pre>
        * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
        * should just treat it as a regular ORIGINAL type key.
        * </pre>
+       *
+       * <code>required bytes chain_code = 1;</code>
        */
       public Builder setChainCode(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        chainCode_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setChainCode(value);
         return this;
       }
       /**
-       * <code>required bytes chain_code = 1;</code>
-       *
        * <pre>
        * Random data that allows us to extend a key. Without this, we can't figure out the next key in the chain and
        * should just treat it as a regular ORIGINAL type key.
        * </pre>
+       *
+       * <code>required bytes chain_code = 1;</code>
        */
       public Builder clearChainCode() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        chainCode_ = getDefaultInstance().getChainCode();
-        onChanged();
+        copyOnWrite();
+        instance.clearChainCode();
         return this;
       }
 
-      private java.util.List<java.lang.Integer> path_ = java.util.Collections.emptyList();
-      private void ensurePathIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          path_ = new java.util.ArrayList<java.lang.Integer>(path_);
-          bitField0_ |= 0x00000002;
-         }
-      }
       /**
-       * <code>repeated uint32 path = 2;</code>
-       *
        * <pre>
        * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
        * and high bit unset for public derivation.
        * </pre>
+       *
+       * <code>repeated uint32 path = 2;</code>
        */
       public java.util.List<java.lang.Integer>
           getPathList() {
-        return java.util.Collections.unmodifiableList(path_);
+        return java.util.Collections.unmodifiableList(
+            instance.getPathList());
       }
       /**
-       * <code>repeated uint32 path = 2;</code>
-       *
        * <pre>
        * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
        * and high bit unset for public derivation.
        * </pre>
+       *
+       * <code>repeated uint32 path = 2;</code>
        */
       public int getPathCount() {
-        return path_.size();
+        return instance.getPathCount();
       }
       /**
-       * <code>repeated uint32 path = 2;</code>
-       *
        * <pre>
        * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
        * and high bit unset for public derivation.
        * </pre>
+       *
+       * <code>repeated uint32 path = 2;</code>
        */
       public int getPath(int index) {
-        return path_.get(index);
+        return instance.getPath(index);
       }
       /**
-       * <code>repeated uint32 path = 2;</code>
-       *
        * <pre>
        * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
        * and high bit unset for public derivation.
        * </pre>
+       *
+       * <code>repeated uint32 path = 2;</code>
        */
       public Builder setPath(
           int index, int value) {
-        ensurePathIsMutable();
-        path_.set(index, value);
-        onChanged();
+        copyOnWrite();
+        instance.setPath(index, value);
         return this;
       }
       /**
-       * <code>repeated uint32 path = 2;</code>
-       *
        * <pre>
        * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
        * and high bit unset for public derivation.
        * </pre>
+       *
+       * <code>repeated uint32 path = 2;</code>
        */
       public Builder addPath(int value) {
-        ensurePathIsMutable();
-        path_.add(value);
-        onChanged();
+        copyOnWrite();
+        instance.addPath(value);
         return this;
       }
       /**
-       * <code>repeated uint32 path = 2;</code>
-       *
        * <pre>
        * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
        * and high bit unset for public derivation.
        * </pre>
+       *
+       * <code>repeated uint32 path = 2;</code>
        */
       public Builder addAllPath(
           java.lang.Iterable<? extends java.lang.Integer> values) {
-        ensurePathIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, path_);
-        onChanged();
+        copyOnWrite();
+        instance.addAllPath(values);
         return this;
       }
       /**
-       * <code>repeated uint32 path = 2;</code>
-       *
        * <pre>
        * The path through the key tree. Each number is encoded in the standard form: high bit set for private derivation
        * and high bit unset for public derivation.
        * </pre>
+       *
+       * <code>repeated uint32 path = 2;</code>
        */
       public Builder clearPath() {
-        path_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
-        onChanged();
+        copyOnWrite();
+        instance.clearPath();
         return this;
       }
 
-      private int issuedSubkeys_ ;
       /**
-       * <code>optional uint32 issued_subkeys = 3;</code>
-       *
        * <pre>
        * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
        * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -2091,13 +1747,13 @@ public final class Protos {
        * this wallet - for instance when restoring from backup or if the seed was shared between devices.
        * If this field is missing it means we're not issuing subkeys of this key to users.
        * </pre>
+       *
+       * <code>optional uint32 issued_subkeys = 3;</code>
        */
       public boolean hasIssuedSubkeys() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasIssuedSubkeys();
       }
       /**
-       * <code>optional uint32 issued_subkeys = 3;</code>
-       *
        * <pre>
        * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
        * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -2105,13 +1761,13 @@ public final class Protos {
        * this wallet - for instance when restoring from backup or if the seed was shared between devices.
        * If this field is missing it means we're not issuing subkeys of this key to users.
        * </pre>
+       *
+       * <code>optional uint32 issued_subkeys = 3;</code>
        */
       public int getIssuedSubkeys() {
-        return issuedSubkeys_;
+        return instance.getIssuedSubkeys();
       }
       /**
-       * <code>optional uint32 issued_subkeys = 3;</code>
-       *
        * <pre>
        * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
        * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -2119,16 +1775,15 @@ public final class Protos {
        * this wallet - for instance when restoring from backup or if the seed was shared between devices.
        * If this field is missing it means we're not issuing subkeys of this key to users.
        * </pre>
+       *
+       * <code>optional uint32 issued_subkeys = 3;</code>
        */
       public Builder setIssuedSubkeys(int value) {
-        bitField0_ |= 0x00000004;
-        issuedSubkeys_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setIssuedSubkeys(value);
         return this;
       }
       /**
-       * <code>optional uint32 issued_subkeys = 3;</code>
-       *
        * <pre>
        * How many children of this key have been issued, that is, given to the user when they requested a fresh key?
        * For the parents of keys being handed out, this is always less than the true number of children: the difference is
@@ -2136,172 +1791,322 @@ public final class Protos {
        * this wallet - for instance when restoring from backup or if the seed was shared between devices.
        * If this field is missing it means we're not issuing subkeys of this key to users.
        * </pre>
+       *
+       * <code>optional uint32 issued_subkeys = 3;</code>
        */
       public Builder clearIssuedSubkeys() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        issuedSubkeys_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearIssuedSubkeys();
         return this;
       }
 
-      private int lookaheadSize_ ;
       /**
        * <code>optional uint32 lookahead_size = 4;</code>
        */
       public boolean hasLookaheadSize() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasLookaheadSize();
       }
       /**
        * <code>optional uint32 lookahead_size = 4;</code>
        */
       public int getLookaheadSize() {
-        return lookaheadSize_;
+        return instance.getLookaheadSize();
       }
       /**
        * <code>optional uint32 lookahead_size = 4;</code>
        */
       public Builder setLookaheadSize(int value) {
-        bitField0_ |= 0x00000008;
-        lookaheadSize_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLookaheadSize(value);
         return this;
       }
       /**
        * <code>optional uint32 lookahead_size = 4;</code>
        */
       public Builder clearLookaheadSize() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        lookaheadSize_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearLookaheadSize();
         return this;
       }
 
-      private boolean isFollowing_ ;
       /**
-       * <code>optional bool isFollowing = 5;</code>
-       *
        * <pre>
        **
        * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
        * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
        * a single P2SH multisignature address
        * </pre>
+       *
+       * <code>optional bool isFollowing = 5;</code>
        */
       public boolean hasIsFollowing() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasIsFollowing();
       }
       /**
-       * <code>optional bool isFollowing = 5;</code>
-       *
        * <pre>
        **
        * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
        * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
        * a single P2SH multisignature address
        * </pre>
+       *
+       * <code>optional bool isFollowing = 5;</code>
        */
       public boolean getIsFollowing() {
-        return isFollowing_;
+        return instance.getIsFollowing();
       }
       /**
-       * <code>optional bool isFollowing = 5;</code>
-       *
        * <pre>
        **
        * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
        * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
        * a single P2SH multisignature address
        * </pre>
+       *
+       * <code>optional bool isFollowing = 5;</code>
        */
       public Builder setIsFollowing(boolean value) {
-        bitField0_ |= 0x00000010;
-        isFollowing_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setIsFollowing(value);
         return this;
       }
       /**
-       * <code>optional bool isFollowing = 5;</code>
-       *
        * <pre>
        **
        * Flag indicating that this key is a root of a following chain. This chain is following the next non-following chain.
        * Following/followed chains concept is used for married keychains, where the set of keys combined together to produce
        * a single P2SH multisignature address
        * </pre>
+       *
+       * <code>optional bool isFollowing = 5;</code>
        */
       public Builder clearIsFollowing() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        isFollowing_ = false;
-        onChanged();
+        copyOnWrite();
+        instance.clearIsFollowing();
         return this;
       }
 
-      private int sigsRequiredToSpend_ = 1;
       /**
-       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-       *
        * <pre>
        * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
        * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
        * </pre>
+       *
+       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
        */
       public boolean hasSigsRequiredToSpend() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return instance.hasSigsRequiredToSpend();
       }
       /**
-       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-       *
        * <pre>
        * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
        * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
        * </pre>
+       *
+       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
        */
       public int getSigsRequiredToSpend() {
-        return sigsRequiredToSpend_;
+        return instance.getSigsRequiredToSpend();
       }
       /**
-       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-       *
        * <pre>
        * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
        * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
        * </pre>
+       *
+       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
        */
       public Builder setSigsRequiredToSpend(int value) {
-        bitField0_ |= 0x00000020;
-        sigsRequiredToSpend_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSigsRequiredToSpend(value);
         return this;
       }
       /**
-       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
-       *
        * <pre>
        * Number of signatures required to spend. This field is needed only for married keychains to reconstruct KeyChain
        * and represents the N value from N-of-M CHECKMULTISIG script. For regular single keychains it will always be 1.
        * </pre>
+       *
+       * <code>optional uint32 sigsRequiredToSpend = 6 [default = 1];</code>
        */
       public Builder clearSigsRequiredToSpend() {
-        bitField0_ = (bitField0_ & ~0x00000020);
-        sigsRequiredToSpend_ = 1;
-        onChanged();
+        copyOnWrite();
+        instance.clearSigsRequiredToSpend();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.DeterministicKey)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.DeterministicKey();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new DeterministicKey(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasChainCode()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          path_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.DeterministicKey other = (org.floj.wallet.Protos.DeterministicKey) arg1;
+          chainCode_ = visitor.visitByteString(
+              hasChainCode(), chainCode_,
+              other.hasChainCode(), other.chainCode_);
+          path_= visitor.visitIntList(path_, other.path_);
+          issuedSubkeys_ = visitor.visitInt(
+              hasIssuedSubkeys(), issuedSubkeys_,
+              other.hasIssuedSubkeys(), other.issuedSubkeys_);
+          lookaheadSize_ = visitor.visitInt(
+              hasLookaheadSize(), lookaheadSize_,
+              other.hasLookaheadSize(), other.lookaheadSize_);
+          isFollowing_ = visitor.visitBoolean(
+              hasIsFollowing(), isFollowing_,
+              other.hasIsFollowing(), other.isFollowing_);
+          sigsRequiredToSpend_ = visitor.visitInt(
+              hasSigsRequiredToSpend(), sigsRequiredToSpend_,
+              other.hasSigsRequiredToSpend(), other.sigsRequiredToSpend_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  chainCode_ = input.readBytes();
+                  break;
+                }
+                case 16: {
+                  if (!path_.isModifiable()) {
+                    path_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(path_);
+                  }
+                  path_.addInt(input.readUInt32());
+                  break;
+                }
+                case 18: {
+                  int length = input.readRawVarint32();
+                  int limit = input.pushLimit(length);
+                  if (!path_.isModifiable() && input.getBytesUntilLimit() > 0) {
+                    path_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(path_);
+                  }
+                  while (input.getBytesUntilLimit() > 0) {
+                    path_.addInt(input.readUInt32());
+                  }
+                  input.popLimit(limit);
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000002;
+                  issuedSubkeys_ = input.readUInt32();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000004;
+                  lookaheadSize_ = input.readUInt32();
+                  break;
+                }
+                case 40: {
+                  bitField0_ |= 0x00000008;
+                  isFollowing_ = input.readBool();
+                  break;
+                }
+                case 48: {
+                  bitField0_ |= 0x00000010;
+                  sigsRequiredToSpend_ = input.readUInt32();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.DeterministicKey.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.DeterministicKey)
+    private static final org.floj.wallet.Protos.DeterministicKey DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new DeterministicKey();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.DeterministicKey getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<DeterministicKey> PARSER;
+
+    public static com.google.protobuf.Parser<DeterministicKey> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface KeyOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.Key)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required .wallet.Key.Type type = 1;</code>
@@ -2313,110 +2118,102 @@ public final class Protos {
     org.floj.wallet.Protos.Key.Type getType();
 
     /**
-     * <code>optional bytes secret_bytes = 2;</code>
-     *
      * <pre>
      * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
      * If the secret is encrypted, or this is a "watching entry" then this is missing.
      * </pre>
+     *
+     * <code>optional bytes secret_bytes = 2;</code>
      */
     boolean hasSecretBytes();
     /**
-     * <code>optional bytes secret_bytes = 2;</code>
-     *
      * <pre>
      * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
      * If the secret is encrypted, or this is a "watching entry" then this is missing.
      * </pre>
+     *
+     * <code>optional bytes secret_bytes = 2;</code>
      */
     com.google.protobuf.ByteString getSecretBytes();
 
     /**
-     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-     *
      * <pre>
      * If the secret data is encrypted, then secret_bytes is missing and this field is set.
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
      */
     boolean hasEncryptedData();
     /**
-     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-     *
      * <pre>
      * If the secret data is encrypted, then secret_bytes is missing and this field is set.
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
      */
     org.floj.wallet.Protos.EncryptedData getEncryptedData();
-    /**
-     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-     *
-     * <pre>
-     * If the secret data is encrypted, then secret_bytes is missing and this field is set.
-     * </pre>
-     */
-    org.floj.wallet.Protos.EncryptedDataOrBuilder getEncryptedDataOrBuilder();
 
     /**
-     * <code>optional bytes public_key = 3;</code>
-     *
      * <pre>
      * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
      * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
      * </pre>
+     *
+     * <code>optional bytes public_key = 3;</code>
      */
     boolean hasPublicKey();
     /**
-     * <code>optional bytes public_key = 3;</code>
-     *
      * <pre>
      * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
      * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
      * </pre>
+     *
+     * <code>optional bytes public_key = 3;</code>
      */
     com.google.protobuf.ByteString getPublicKey();
 
     /**
-     * <code>optional string label = 4;</code>
-     *
      * <pre>
      * User-provided label associated with the key.
      * </pre>
+     *
+     * <code>optional string label = 4;</code>
      */
     boolean hasLabel();
     /**
-     * <code>optional string label = 4;</code>
-     *
      * <pre>
      * User-provided label associated with the key.
      * </pre>
+     *
+     * <code>optional string label = 4;</code>
      */
     java.lang.String getLabel();
     /**
-     * <code>optional string label = 4;</code>
-     *
      * <pre>
      * User-provided label associated with the key.
      * </pre>
+     *
+     * <code>optional string label = 4;</code>
      */
     com.google.protobuf.ByteString
         getLabelBytes();
 
     /**
-     * <code>optional int64 creation_timestamp = 5;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
      * optional is that keys derived from a parent don't have this data.
      * </pre>
+     *
+     * <code>optional int64 creation_timestamp = 5;</code>
      */
     boolean hasCreationTimestamp();
     /**
-     * <code>optional int64 creation_timestamp = 5;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
      * optional is that keys derived from a parent don't have this data.
      * </pre>
+     *
+     * <code>optional int64 creation_timestamp = 5;</code>
      */
     long getCreationTimestamp();
 
@@ -2428,58 +2225,44 @@ public final class Protos {
      * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
      */
     org.floj.wallet.Protos.DeterministicKey getDeterministicKey();
-    /**
-     * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
-     */
-    org.floj.wallet.Protos.DeterministicKeyOrBuilder getDeterministicKeyOrBuilder();
 
     /**
-     * <code>optional bytes deterministic_seed = 8;</code>
-     *
      * <pre>
      * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
      * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
      * </pre>
+     *
+     * <code>optional bytes deterministic_seed = 8;</code>
      */
     boolean hasDeterministicSeed();
     /**
-     * <code>optional bytes deterministic_seed = 8;</code>
-     *
      * <pre>
      * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
      * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
      * </pre>
+     *
+     * <code>optional bytes deterministic_seed = 8;</code>
      */
     com.google.protobuf.ByteString getDeterministicSeed();
 
     /**
-     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-     *
      * <pre>
      * Encrypted version of the seed
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
      */
     boolean hasEncryptedDeterministicSeed();
     /**
-     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-     *
      * <pre>
      * Encrypted version of the seed
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
      */
     org.floj.wallet.Protos.EncryptedData getEncryptedDeterministicSeed();
-    /**
-     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-     *
-     * <pre>
-     * Encrypted version of the seed
-     * </pre>
-     */
-    org.floj.wallet.Protos.EncryptedDataOrBuilder getEncryptedDeterministicSeedOrBuilder();
   }
   /**
-   * Protobuf type {@code wallet.Key}
-   *
    * <pre>
    **
    * A key used to control FLO spending.
@@ -2488,205 +2271,53 @@ public final class Protos {
    * If only the public key is provided, the key can only be used to watch the blockchain and verify
    * transactions, and not for spending.
    * </pre>
+   *
+   * Protobuf type {@code wallet.Key}
    */
-  public static final class Key extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Key extends
+      com.google.protobuf.GeneratedMessageLite<
+          Key, Key.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.Key)
       KeyOrBuilder {
-    // Use Key.newBuilder() to construct.
-    private Key(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Key() {
+      type_ = 1;
+      secretBytes_ = com.google.protobuf.ByteString.EMPTY;
+      publicKey_ = com.google.protobuf.ByteString.EMPTY;
+      label_ = "";
+      deterministicSeed_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Key(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Key defaultInstance;
-    public static Key getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Key getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Key(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              int rawValue = input.readEnum();
-              org.floj.wallet.Protos.Key.Type value = org.floj.wallet.Protos.Key.Type.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(1, rawValue);
-              } else {
-                bitField0_ |= 0x00000001;
-                type_ = value;
-              }
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              secretBytes_ = input.readBytes();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000008;
-              publicKey_ = input.readBytes();
-              break;
-            }
-            case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000010;
-              label_ = bs;
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000020;
-              creationTimestamp_ = input.readInt64();
-              break;
-            }
-            case 50: {
-              org.floj.wallet.Protos.EncryptedData.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                subBuilder = encryptedData_.toBuilder();
-              }
-              encryptedData_ = input.readMessage(org.floj.wallet.Protos.EncryptedData.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(encryptedData_);
-                encryptedData_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000004;
-              break;
-            }
-            case 58: {
-              org.floj.wallet.Protos.DeterministicKey.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000040) == 0x00000040)) {
-                subBuilder = deterministicKey_.toBuilder();
-              }
-              deterministicKey_ = input.readMessage(org.floj.wallet.Protos.DeterministicKey.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(deterministicKey_);
-                deterministicKey_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000040;
-              break;
-            }
-            case 66: {
-              bitField0_ |= 0x00000080;
-              deterministicSeed_ = input.readBytes();
-              break;
-            }
-            case 74: {
-              org.floj.wallet.Protos.EncryptedData.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000100) == 0x00000100)) {
-                subBuilder = encryptedDeterministicSeed_.toBuilder();
-              }
-              encryptedDeterministicSeed_ = input.readMessage(org.floj.wallet.Protos.EncryptedData.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(encryptedDeterministicSeed_);
-                encryptedDeterministicSeed_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000100;
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_Key_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_Key_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.Key.class, org.floj.wallet.Protos.Key.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Key> PARSER =
-        new com.google.protobuf.AbstractParser<Key>() {
-      public Key parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Key(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Key> getParserForType() {
-      return PARSER;
-    }
-
     /**
      * Protobuf enum {@code wallet.Key.Type}
      */
     public enum Type
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
-       * <code>ORIGINAL = 1;</code>
-       *
        * <pre>
        ** Unencrypted - Original flo secp256k1 curve 
        * </pre>
-       */
-      ORIGINAL(0, 1),
-      /**
-       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
        *
+       * <code>ORIGINAL = 1;</code>
+       */
+      ORIGINAL(1),
+      /**
        * <pre>
        ** Encrypted with Scrypt and AES - Original flo secp256k1 curve 
        * </pre>
-       */
-      ENCRYPTED_SCRYPT_AES(1, 2),
-      /**
-       * <code>DETERMINISTIC_MNEMONIC = 3;</code>
        *
+       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
+       */
+      ENCRYPTED_SCRYPT_AES(2),
+      /**
        * <pre>
        **
        * Not really a key, but rather contains the mnemonic phrase for a deterministic key hierarchy in the private_key field.
        * The label and public_key fields are missing. Creation timestamp will exist.
        * </pre>
-       */
-      DETERMINISTIC_MNEMONIC(2, 3),
-      /**
-       * <code>DETERMINISTIC_KEY = 4;</code>
        *
+       * <code>DETERMINISTIC_MNEMONIC = 3;</code>
+       */
+      DETERMINISTIC_MNEMONIC(3),
+      /**
        * <pre>
        **
        * A key that was derived deterministically. Note that the root seed that created it may NOT be present in the
@@ -2695,39 +2326,39 @@ public final class Protos {
        * is a path from this key up to a key that has (possibly encrypted) private bytes, it's expected that the private
        * key can be rederived on the fly.
        * </pre>
+       *
+       * <code>DETERMINISTIC_KEY = 4;</code>
        */
-      DETERMINISTIC_KEY(3, 4),
+      DETERMINISTIC_KEY(4),
       ;
 
       /**
-       * <code>ORIGINAL = 1;</code>
-       *
        * <pre>
        ** Unencrypted - Original flo secp256k1 curve 
        * </pre>
+       *
+       * <code>ORIGINAL = 1;</code>
        */
       public static final int ORIGINAL_VALUE = 1;
       /**
-       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
-       *
        * <pre>
        ** Encrypted with Scrypt and AES - Original flo secp256k1 curve 
        * </pre>
+       *
+       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
        */
       public static final int ENCRYPTED_SCRYPT_AES_VALUE = 2;
       /**
-       * <code>DETERMINISTIC_MNEMONIC = 3;</code>
-       *
        * <pre>
        **
        * Not really a key, but rather contains the mnemonic phrase for a deterministic key hierarchy in the private_key field.
        * The label and public_key fields are missing. Creation timestamp will exist.
        * </pre>
+       *
+       * <code>DETERMINISTIC_MNEMONIC = 3;</code>
        */
       public static final int DETERMINISTIC_MNEMONIC_VALUE = 3;
       /**
-       * <code>DETERMINISTIC_KEY = 4;</code>
-       *
        * <pre>
        **
        * A key that was derived deterministically. Note that the root seed that created it may NOT be present in the
@@ -2736,13 +2367,25 @@ public final class Protos {
        * is a path from this key up to a key that has (possibly encrypted) private bytes, it's expected that the private
        * key can be rederived on the fly.
        * </pre>
+       *
+       * <code>DETERMINISTIC_KEY = 4;</code>
        */
       public static final int DETERMINISTIC_KEY_VALUE = 4;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static Type valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static Type forNumber(int value) {
         switch (value) {
           case 1: return ORIGINAL;
           case 2: return ENCRYPTED_SCRYPT_AES;
@@ -2756,43 +2399,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<Type>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          Type> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Type>() {
               public Type findValueByNumber(int number) {
-                return Type.valueOf(number);
+                return Type.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.Key.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final Type[] VALUES = values();
-
-      public static Type valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private Type(int index, int value) {
-        this.index = index;
+      private Type(int value) {
         this.value = value;
       }
 
@@ -2801,7 +2418,7 @@ public final class Protos {
 
     private int bitField0_;
     public static final int TYPE_FIELD_NUMBER = 1;
-    private org.floj.wallet.Protos.Key.Type type_;
+    private int type_;
     /**
      * <code>required .wallet.Key.Type type = 1;</code>
      */
@@ -2812,169 +2429,329 @@ public final class Protos {
      * <code>required .wallet.Key.Type type = 1;</code>
      */
     public org.floj.wallet.Protos.Key.Type getType() {
-      return type_;
+      org.floj.wallet.Protos.Key.Type result = org.floj.wallet.Protos.Key.Type.forNumber(type_);
+      return result == null ? org.floj.wallet.Protos.Key.Type.ORIGINAL : result;
+    }
+    /**
+     * <code>required .wallet.Key.Type type = 1;</code>
+     */
+    private void setType(org.floj.wallet.Protos.Key.Type value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      bitField0_ |= 0x00000001;
+      type_ = value.getNumber();
+    }
+    /**
+     * <code>required .wallet.Key.Type type = 1;</code>
+     */
+    private void clearType() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      type_ = 1;
     }
 
     public static final int SECRET_BYTES_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString secretBytes_;
     /**
-     * <code>optional bytes secret_bytes = 2;</code>
-     *
      * <pre>
      * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
      * If the secret is encrypted, or this is a "watching entry" then this is missing.
      * </pre>
+     *
+     * <code>optional bytes secret_bytes = 2;</code>
      */
     public boolean hasSecretBytes() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional bytes secret_bytes = 2;</code>
-     *
      * <pre>
      * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
      * If the secret is encrypted, or this is a "watching entry" then this is missing.
      * </pre>
+     *
+     * <code>optional bytes secret_bytes = 2;</code>
      */
     public com.google.protobuf.ByteString getSecretBytes() {
       return secretBytes_;
+    }
+    /**
+     * <pre>
+     * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
+     * If the secret is encrypted, or this is a "watching entry" then this is missing.
+     * </pre>
+     *
+     * <code>optional bytes secret_bytes = 2;</code>
+     */
+    private void setSecretBytes(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      secretBytes_ = value;
+    }
+    /**
+     * <pre>
+     * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
+     * If the secret is encrypted, or this is a "watching entry" then this is missing.
+     * </pre>
+     *
+     * <code>optional bytes secret_bytes = 2;</code>
+     */
+    private void clearSecretBytes() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      secretBytes_ = getDefaultInstance().getSecretBytes();
     }
 
     public static final int ENCRYPTED_DATA_FIELD_NUMBER = 6;
     private org.floj.wallet.Protos.EncryptedData encryptedData_;
     /**
-     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-     *
      * <pre>
      * If the secret data is encrypted, then secret_bytes is missing and this field is set.
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
      */
     public boolean hasEncryptedData() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-     *
      * <pre>
      * If the secret data is encrypted, then secret_bytes is missing and this field is set.
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
      */
     public org.floj.wallet.Protos.EncryptedData getEncryptedData() {
-      return encryptedData_;
+      return encryptedData_ == null ? org.floj.wallet.Protos.EncryptedData.getDefaultInstance() : encryptedData_;
     }
     /**
-     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-     *
      * <pre>
      * If the secret data is encrypted, then secret_bytes is missing and this field is set.
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
      */
-    public org.floj.wallet.Protos.EncryptedDataOrBuilder getEncryptedDataOrBuilder() {
-      return encryptedData_;
+    private void setEncryptedData(org.floj.wallet.Protos.EncryptedData value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      encryptedData_ = value;
+      bitField0_ |= 0x00000004;
+      }
+    /**
+     * <pre>
+     * If the secret data is encrypted, then secret_bytes is missing and this field is set.
+     * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
+     */
+    private void setEncryptedData(
+        org.floj.wallet.Protos.EncryptedData.Builder builderForValue) {
+      encryptedData_ = builderForValue.build();
+      bitField0_ |= 0x00000004;
+    }
+    /**
+     * <pre>
+     * If the secret data is encrypted, then secret_bytes is missing and this field is set.
+     * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
+     */
+    private void mergeEncryptedData(org.floj.wallet.Protos.EncryptedData value) {
+      if (encryptedData_ != null &&
+          encryptedData_ != org.floj.wallet.Protos.EncryptedData.getDefaultInstance()) {
+        encryptedData_ =
+          org.floj.wallet.Protos.EncryptedData.newBuilder(encryptedData_).mergeFrom(value).buildPartial();
+      } else {
+        encryptedData_ = value;
+      }
+      bitField0_ |= 0x00000004;
+    }
+    /**
+     * <pre>
+     * If the secret data is encrypted, then secret_bytes is missing and this field is set.
+     * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
+     */
+    private void clearEncryptedData() {  encryptedData_ = null;
+      bitField0_ = (bitField0_ & ~0x00000004);
     }
 
     public static final int PUBLIC_KEY_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString publicKey_;
     /**
-     * <code>optional bytes public_key = 3;</code>
-     *
      * <pre>
      * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
      * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
      * </pre>
+     *
+     * <code>optional bytes public_key = 3;</code>
      */
     public boolean hasPublicKey() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional bytes public_key = 3;</code>
-     *
      * <pre>
      * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
      * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
      * </pre>
+     *
+     * <code>optional bytes public_key = 3;</code>
      */
     public com.google.protobuf.ByteString getPublicKey() {
       return publicKey_;
     }
+    /**
+     * <pre>
+     * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
+     * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
+     * </pre>
+     *
+     * <code>optional bytes public_key = 3;</code>
+     */
+    private void setPublicKey(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+      publicKey_ = value;
+    }
+    /**
+     * <pre>
+     * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
+     * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
+     * </pre>
+     *
+     * <code>optional bytes public_key = 3;</code>
+     */
+    private void clearPublicKey() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      publicKey_ = getDefaultInstance().getPublicKey();
+    }
 
     public static final int LABEL_FIELD_NUMBER = 4;
-    private java.lang.Object label_;
+    private java.lang.String label_;
     /**
-     * <code>optional string label = 4;</code>
-     *
      * <pre>
      * User-provided label associated with the key.
      * </pre>
+     *
+     * <code>optional string label = 4;</code>
      */
     public boolean hasLabel() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional string label = 4;</code>
-     *
      * <pre>
      * User-provided label associated with the key.
      * </pre>
+     *
+     * <code>optional string label = 4;</code>
      */
     public java.lang.String getLabel() {
-      java.lang.Object ref = label_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          label_ = s;
-        }
-        return s;
-      }
+      return label_;
     }
     /**
-     * <code>optional string label = 4;</code>
-     *
      * <pre>
      * User-provided label associated with the key.
      * </pre>
+     *
+     * <code>optional string label = 4;</code>
      */
     public com.google.protobuf.ByteString
         getLabelBytes() {
-      java.lang.Object ref = label_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        label_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(label_);
+    }
+    /**
+     * <pre>
+     * User-provided label associated with the key.
+     * </pre>
+     *
+     * <code>optional string label = 4;</code>
+     */
+    private void setLabel(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+      label_ = value;
+    }
+    /**
+     * <pre>
+     * User-provided label associated with the key.
+     * </pre>
+     *
+     * <code>optional string label = 4;</code>
+     */
+    private void clearLabel() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      label_ = getDefaultInstance().getLabel();
+    }
+    /**
+     * <pre>
+     * User-provided label associated with the key.
+     * </pre>
+     *
+     * <code>optional string label = 4;</code>
+     */
+    private void setLabelBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+      label_ = value.toStringUtf8();
     }
 
     public static final int CREATION_TIMESTAMP_FIELD_NUMBER = 5;
     private long creationTimestamp_;
     /**
-     * <code>optional int64 creation_timestamp = 5;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
      * optional is that keys derived from a parent don't have this data.
      * </pre>
+     *
+     * <code>optional int64 creation_timestamp = 5;</code>
      */
     public boolean hasCreationTimestamp() {
       return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
-     * <code>optional int64 creation_timestamp = 5;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
      * optional is that keys derived from a parent don't have this data.
      * </pre>
+     *
+     * <code>optional int64 creation_timestamp = 5;</code>
      */
     public long getCreationTimestamp() {
       return creationTimestamp_;
+    }
+    /**
+     * <pre>
+     * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
+     * optional is that keys derived from a parent don't have this data.
+     * </pre>
+     *
+     * <code>optional int64 creation_timestamp = 5;</code>
+     */
+    private void setCreationTimestamp(long value) {
+      bitField0_ |= 0x00000020;
+      creationTimestamp_ = value;
+    }
+    /**
+     * <pre>
+     * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
+     * optional is that keys derived from a parent don't have this data.
+     * </pre>
+     *
+     * <code>optional int64 creation_timestamp = 5;</code>
+     */
+    private void clearCreationTimestamp() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      creationTimestamp_ = 0L;
     }
 
     public static final int DETERMINISTIC_KEY_FIELD_NUMBER = 7;
@@ -2989,121 +2766,178 @@ public final class Protos {
      * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
      */
     public org.floj.wallet.Protos.DeterministicKey getDeterministicKey() {
-      return deterministicKey_;
+      return deterministicKey_ == null ? org.floj.wallet.Protos.DeterministicKey.getDefaultInstance() : deterministicKey_;
     }
     /**
      * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
      */
-    public org.floj.wallet.Protos.DeterministicKeyOrBuilder getDeterministicKeyOrBuilder() {
-      return deterministicKey_;
+    private void setDeterministicKey(org.floj.wallet.Protos.DeterministicKey value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      deterministicKey_ = value;
+      bitField0_ |= 0x00000040;
+      }
+    /**
+     * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
+     */
+    private void setDeterministicKey(
+        org.floj.wallet.Protos.DeterministicKey.Builder builderForValue) {
+      deterministicKey_ = builderForValue.build();
+      bitField0_ |= 0x00000040;
+    }
+    /**
+     * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
+     */
+    private void mergeDeterministicKey(org.floj.wallet.Protos.DeterministicKey value) {
+      if (deterministicKey_ != null &&
+          deterministicKey_ != org.floj.wallet.Protos.DeterministicKey.getDefaultInstance()) {
+        deterministicKey_ =
+          org.floj.wallet.Protos.DeterministicKey.newBuilder(deterministicKey_).mergeFrom(value).buildPartial();
+      } else {
+        deterministicKey_ = value;
+      }
+      bitField0_ |= 0x00000040;
+    }
+    /**
+     * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
+     */
+    private void clearDeterministicKey() {  deterministicKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000040);
     }
 
     public static final int DETERMINISTIC_SEED_FIELD_NUMBER = 8;
     private com.google.protobuf.ByteString deterministicSeed_;
     /**
-     * <code>optional bytes deterministic_seed = 8;</code>
-     *
      * <pre>
      * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
      * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
      * </pre>
+     *
+     * <code>optional bytes deterministic_seed = 8;</code>
      */
     public boolean hasDeterministicSeed() {
       return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
-     * <code>optional bytes deterministic_seed = 8;</code>
-     *
      * <pre>
      * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
      * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
      * </pre>
+     *
+     * <code>optional bytes deterministic_seed = 8;</code>
      */
     public com.google.protobuf.ByteString getDeterministicSeed() {
       return deterministicSeed_;
+    }
+    /**
+     * <pre>
+     * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
+     * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
+     * </pre>
+     *
+     * <code>optional bytes deterministic_seed = 8;</code>
+     */
+    private void setDeterministicSeed(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+      deterministicSeed_ = value;
+    }
+    /**
+     * <pre>
+     * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
+     * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
+     * </pre>
+     *
+     * <code>optional bytes deterministic_seed = 8;</code>
+     */
+    private void clearDeterministicSeed() {
+      bitField0_ = (bitField0_ & ~0x00000080);
+      deterministicSeed_ = getDefaultInstance().getDeterministicSeed();
     }
 
     public static final int ENCRYPTED_DETERMINISTIC_SEED_FIELD_NUMBER = 9;
     private org.floj.wallet.Protos.EncryptedData encryptedDeterministicSeed_;
     /**
-     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-     *
      * <pre>
      * Encrypted version of the seed
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
      */
     public boolean hasEncryptedDeterministicSeed() {
       return ((bitField0_ & 0x00000100) == 0x00000100);
     }
     /**
-     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-     *
      * <pre>
      * Encrypted version of the seed
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
      */
     public org.floj.wallet.Protos.EncryptedData getEncryptedDeterministicSeed() {
-      return encryptedDeterministicSeed_;
+      return encryptedDeterministicSeed_ == null ? org.floj.wallet.Protos.EncryptedData.getDefaultInstance() : encryptedDeterministicSeed_;
     }
     /**
-     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-     *
      * <pre>
      * Encrypted version of the seed
      * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
      */
-    public org.floj.wallet.Protos.EncryptedDataOrBuilder getEncryptedDeterministicSeedOrBuilder() {
-      return encryptedDeterministicSeed_;
+    private void setEncryptedDeterministicSeed(org.floj.wallet.Protos.EncryptedData value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      encryptedDeterministicSeed_ = value;
+      bitField0_ |= 0x00000100;
+      }
+    /**
+     * <pre>
+     * Encrypted version of the seed
+     * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
+     */
+    private void setEncryptedDeterministicSeed(
+        org.floj.wallet.Protos.EncryptedData.Builder builderForValue) {
+      encryptedDeterministicSeed_ = builderForValue.build();
+      bitField0_ |= 0x00000100;
     }
-
-    private void initFields() {
-      type_ = org.floj.wallet.Protos.Key.Type.ORIGINAL;
-      secretBytes_ = com.google.protobuf.ByteString.EMPTY;
-      encryptedData_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-      publicKey_ = com.google.protobuf.ByteString.EMPTY;
-      label_ = "";
-      creationTimestamp_ = 0L;
-      deterministicKey_ = org.floj.wallet.Protos.DeterministicKey.getDefaultInstance();
-      deterministicSeed_ = com.google.protobuf.ByteString.EMPTY;
-      encryptedDeterministicSeed_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
+    /**
+     * <pre>
+     * Encrypted version of the seed
+     * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
+     */
+    private void mergeEncryptedDeterministicSeed(org.floj.wallet.Protos.EncryptedData value) {
+      if (encryptedDeterministicSeed_ != null &&
+          encryptedDeterministicSeed_ != org.floj.wallet.Protos.EncryptedData.getDefaultInstance()) {
+        encryptedDeterministicSeed_ =
+          org.floj.wallet.Protos.EncryptedData.newBuilder(encryptedDeterministicSeed_).mergeFrom(value).buildPartial();
+      } else {
+        encryptedDeterministicSeed_ = value;
+      }
+      bitField0_ |= 0x00000100;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasType()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (hasEncryptedData()) {
-        if (!getEncryptedData().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasDeterministicKey()) {
-        if (!getDeterministicKey().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasEncryptedDeterministicSeed()) {
-        if (!getEncryptedDeterministicSeed().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Encrypted version of the seed
+     * </pre>
+     *
+     * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
+     */
+    private void clearEncryptedDeterministicSeed() {  encryptedDeterministicSeed_ = null;
+      bitField0_ = (bitField0_ & ~0x00000100);
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, type_.getNumber());
+        output.writeEnum(1, type_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, secretBytes_);
@@ -3112,27 +2946,26 @@ public final class Protos {
         output.writeBytes(3, publicKey_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeBytes(4, getLabelBytes());
+        output.writeString(4, getLabel());
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeInt64(5, creationTimestamp_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeMessage(6, encryptedData_);
+        output.writeMessage(6, getEncryptedData());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
-        output.writeMessage(7, deterministicKey_);
+        output.writeMessage(7, getDeterministicKey());
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeBytes(8, deterministicSeed_);
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        output.writeMessage(9, encryptedDeterministicSeed_);
+        output.writeMessage(9, getEncryptedDeterministicSeed());
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -3140,7 +2973,7 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, type_.getNumber());
+          .computeEnumSize(1, type_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -3152,7 +2985,7 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(4, getLabelBytes());
+          .computeStringSize(4, getLabel());
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
@@ -3160,11 +2993,11 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(6, encryptedData_);
+          .computeMessageSize(6, getEncryptedData());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(7, deterministicKey_);
+          .computeMessageSize(7, getDeterministicKey());
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
@@ -3172,89 +3005,82 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(9, encryptedDeterministicSeed_);
+          .computeMessageSize(9, getEncryptedDeterministicSeed());
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.Key parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Key parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Key parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Key parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Key parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Key parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Key parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Key parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Key parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Key parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.Key prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.Key}
-     *
      * <pre>
      **
      * A key used to control FLO spending.
@@ -3263,1032 +3089,727 @@ public final class Protos {
      * If only the public key is provided, the key can only be used to watch the blockchain and verify
      * transactions, and not for spending.
      * </pre>
+     *
+     * Protobuf type {@code wallet.Key}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.Key, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.Key)
         org.floj.wallet.Protos.KeyOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_Key_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_Key_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.Key.class, org.floj.wallet.Protos.Key.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.Key.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getEncryptedDataFieldBuilder();
-          getDeterministicKeyFieldBuilder();
-          getEncryptedDeterministicSeedFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        type_ = org.floj.wallet.Protos.Key.Type.ORIGINAL;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        secretBytes_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        if (encryptedDataBuilder_ == null) {
-          encryptedData_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-        } else {
-          encryptedDataBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000004);
-        publicKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        label_ = "";
-        bitField0_ = (bitField0_ & ~0x00000010);
-        creationTimestamp_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
-        if (deterministicKeyBuilder_ == null) {
-          deterministicKey_ = org.floj.wallet.Protos.DeterministicKey.getDefaultInstance();
-        } else {
-          deterministicKeyBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000040);
-        deterministicSeed_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000080);
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          encryptedDeterministicSeed_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-        } else {
-          encryptedDeterministicSeedBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000100);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_Key_descriptor;
-      }
-
-      public org.floj.wallet.Protos.Key getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.Key.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.Key build() {
-        org.floj.wallet.Protos.Key result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.Key buildPartial() {
-        org.floj.wallet.Protos.Key result = new org.floj.wallet.Protos.Key(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.type_ = type_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.secretBytes_ = secretBytes_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        if (encryptedDataBuilder_ == null) {
-          result.encryptedData_ = encryptedData_;
-        } else {
-          result.encryptedData_ = encryptedDataBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.publicKey_ = publicKey_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.label_ = label_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        result.creationTimestamp_ = creationTimestamp_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000040;
-        }
-        if (deterministicKeyBuilder_ == null) {
-          result.deterministicKey_ = deterministicKey_;
-        } else {
-          result.deterministicKey_ = deterministicKeyBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-          to_bitField0_ |= 0x00000080;
-        }
-        result.deterministicSeed_ = deterministicSeed_;
-        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
-          to_bitField0_ |= 0x00000100;
-        }
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          result.encryptedDeterministicSeed_ = encryptedDeterministicSeed_;
-        } else {
-          result.encryptedDeterministicSeed_ = encryptedDeterministicSeedBuilder_.build();
-        }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.Key) {
-          return mergeFrom((org.floj.wallet.Protos.Key)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.Key other) {
-        if (other == org.floj.wallet.Protos.Key.getDefaultInstance()) return this;
-        if (other.hasType()) {
-          setType(other.getType());
-        }
-        if (other.hasSecretBytes()) {
-          setSecretBytes(other.getSecretBytes());
-        }
-        if (other.hasEncryptedData()) {
-          mergeEncryptedData(other.getEncryptedData());
-        }
-        if (other.hasPublicKey()) {
-          setPublicKey(other.getPublicKey());
-        }
-        if (other.hasLabel()) {
-          bitField0_ |= 0x00000010;
-          label_ = other.label_;
-          onChanged();
-        }
-        if (other.hasCreationTimestamp()) {
-          setCreationTimestamp(other.getCreationTimestamp());
-        }
-        if (other.hasDeterministicKey()) {
-          mergeDeterministicKey(other.getDeterministicKey());
-        }
-        if (other.hasDeterministicSeed()) {
-          setDeterministicSeed(other.getDeterministicSeed());
-        }
-        if (other.hasEncryptedDeterministicSeed()) {
-          mergeEncryptedDeterministicSeed(other.getEncryptedDeterministicSeed());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasType()) {
-          
-          return false;
-        }
-        if (hasEncryptedData()) {
-          if (!getEncryptedData().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasDeterministicKey()) {
-          if (!getDeterministicKey().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasEncryptedDeterministicSeed()) {
-          if (!getEncryptedDeterministicSeed().isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.Key parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.Key) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private org.floj.wallet.Protos.Key.Type type_ = org.floj.wallet.Protos.Key.Type.ORIGINAL;
       /**
        * <code>required .wallet.Key.Type type = 1;</code>
        */
       public boolean hasType() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasType();
       }
       /**
        * <code>required .wallet.Key.Type type = 1;</code>
        */
       public org.floj.wallet.Protos.Key.Type getType() {
-        return type_;
+        return instance.getType();
       }
       /**
        * <code>required .wallet.Key.Type type = 1;</code>
        */
       public Builder setType(org.floj.wallet.Protos.Key.Type value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        type_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setType(value);
         return this;
       }
       /**
        * <code>required .wallet.Key.Type type = 1;</code>
        */
       public Builder clearType() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        type_ = org.floj.wallet.Protos.Key.Type.ORIGINAL;
-        onChanged();
+        copyOnWrite();
+        instance.clearType();
         return this;
       }
 
-      private com.google.protobuf.ByteString secretBytes_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes secret_bytes = 2;</code>
-       *
        * <pre>
        * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
        * If the secret is encrypted, or this is a "watching entry" then this is missing.
        * </pre>
+       *
+       * <code>optional bytes secret_bytes = 2;</code>
        */
       public boolean hasSecretBytes() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasSecretBytes();
       }
       /**
-       * <code>optional bytes secret_bytes = 2;</code>
-       *
        * <pre>
        * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
        * If the secret is encrypted, or this is a "watching entry" then this is missing.
        * </pre>
+       *
+       * <code>optional bytes secret_bytes = 2;</code>
        */
       public com.google.protobuf.ByteString getSecretBytes() {
-        return secretBytes_;
+        return instance.getSecretBytes();
       }
       /**
-       * <code>optional bytes secret_bytes = 2;</code>
-       *
        * <pre>
        * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
        * If the secret is encrypted, or this is a "watching entry" then this is missing.
        * </pre>
+       *
+       * <code>optional bytes secret_bytes = 2;</code>
        */
       public Builder setSecretBytes(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        secretBytes_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSecretBytes(value);
         return this;
       }
       /**
-       * <code>optional bytes secret_bytes = 2;</code>
-       *
        * <pre>
        * Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
        * If the secret is encrypted, or this is a "watching entry" then this is missing.
        * </pre>
+       *
+       * <code>optional bytes secret_bytes = 2;</code>
        */
       public Builder clearSecretBytes() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        secretBytes_ = getDefaultInstance().getSecretBytes();
-        onChanged();
+        copyOnWrite();
+        instance.clearSecretBytes();
         return this;
       }
 
-      private org.floj.wallet.Protos.EncryptedData encryptedData_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.EncryptedData, org.floj.wallet.Protos.EncryptedData.Builder, org.floj.wallet.Protos.EncryptedDataOrBuilder> encryptedDataBuilder_;
       /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
        * <pre>
        * If the secret data is encrypted, then secret_bytes is missing and this field is set.
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
        */
       public boolean hasEncryptedData() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasEncryptedData();
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
        * <pre>
        * If the secret data is encrypted, then secret_bytes is missing and this field is set.
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
        */
       public org.floj.wallet.Protos.EncryptedData getEncryptedData() {
-        if (encryptedDataBuilder_ == null) {
-          return encryptedData_;
-        } else {
-          return encryptedDataBuilder_.getMessage();
-        }
+        return instance.getEncryptedData();
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
        * <pre>
        * If the secret data is encrypted, then secret_bytes is missing and this field is set.
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
        */
       public Builder setEncryptedData(org.floj.wallet.Protos.EncryptedData value) {
-        if (encryptedDataBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          encryptedData_ = value;
-          onChanged();
-        } else {
-          encryptedDataBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000004;
+        copyOnWrite();
+        instance.setEncryptedData(value);
         return this;
-      }
+        }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
        * <pre>
        * If the secret data is encrypted, then secret_bytes is missing and this field is set.
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
        */
       public Builder setEncryptedData(
           org.floj.wallet.Protos.EncryptedData.Builder builderForValue) {
-        if (encryptedDataBuilder_ == null) {
-          encryptedData_ = builderForValue.build();
-          onChanged();
-        } else {
-          encryptedDataBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000004;
+        copyOnWrite();
+        instance.setEncryptedData(builderForValue);
         return this;
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
        * <pre>
        * If the secret data is encrypted, then secret_bytes is missing and this field is set.
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
        */
       public Builder mergeEncryptedData(org.floj.wallet.Protos.EncryptedData value) {
-        if (encryptedDataBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
-              encryptedData_ != org.floj.wallet.Protos.EncryptedData.getDefaultInstance()) {
-            encryptedData_ =
-              org.floj.wallet.Protos.EncryptedData.newBuilder(encryptedData_).mergeFrom(value).buildPartial();
-          } else {
-            encryptedData_ = value;
-          }
-          onChanged();
-        } else {
-          encryptedDataBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000004;
+        copyOnWrite();
+        instance.mergeEncryptedData(value);
         return this;
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
        * <pre>
        * If the secret data is encrypted, then secret_bytes is missing and this field is set.
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
        */
-      public Builder clearEncryptedData() {
-        if (encryptedDataBuilder_ == null) {
-          encryptedData_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-          onChanged();
-        } else {
-          encryptedDataBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000004);
+      public Builder clearEncryptedData() {  copyOnWrite();
+        instance.clearEncryptedData();
         return this;
-      }
-      /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
-       * <pre>
-       * If the secret data is encrypted, then secret_bytes is missing and this field is set.
-       * </pre>
-       */
-      public org.floj.wallet.Protos.EncryptedData.Builder getEncryptedDataBuilder() {
-        bitField0_ |= 0x00000004;
-        onChanged();
-        return getEncryptedDataFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
-       * <pre>
-       * If the secret data is encrypted, then secret_bytes is missing and this field is set.
-       * </pre>
-       */
-      public org.floj.wallet.Protos.EncryptedDataOrBuilder getEncryptedDataOrBuilder() {
-        if (encryptedDataBuilder_ != null) {
-          return encryptedDataBuilder_.getMessageOrBuilder();
-        } else {
-          return encryptedData_;
-        }
-      }
-      /**
-       * <code>optional .wallet.EncryptedData encrypted_data = 6;</code>
-       *
-       * <pre>
-       * If the secret data is encrypted, then secret_bytes is missing and this field is set.
-       * </pre>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.EncryptedData, org.floj.wallet.Protos.EncryptedData.Builder, org.floj.wallet.Protos.EncryptedDataOrBuilder> 
-          getEncryptedDataFieldBuilder() {
-        if (encryptedDataBuilder_ == null) {
-          encryptedDataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.floj.wallet.Protos.EncryptedData, org.floj.wallet.Protos.EncryptedData.Builder, org.floj.wallet.Protos.EncryptedDataOrBuilder>(
-                  getEncryptedData(),
-                  getParentForChildren(),
-                  isClean());
-          encryptedData_ = null;
-        }
-        return encryptedDataBuilder_;
       }
 
-      private com.google.protobuf.ByteString publicKey_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes public_key = 3;</code>
-       *
        * <pre>
        * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
        * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
        * </pre>
+       *
+       * <code>optional bytes public_key = 3;</code>
        */
       public boolean hasPublicKey() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasPublicKey();
       }
       /**
-       * <code>optional bytes public_key = 3;</code>
-       *
        * <pre>
        * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
        * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
        * </pre>
+       *
+       * <code>optional bytes public_key = 3;</code>
        */
       public com.google.protobuf.ByteString getPublicKey() {
-        return publicKey_;
+        return instance.getPublicKey();
       }
       /**
-       * <code>optional bytes public_key = 3;</code>
-       *
        * <pre>
        * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
        * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
        * </pre>
+       *
+       * <code>optional bytes public_key = 3;</code>
        */
       public Builder setPublicKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        publicKey_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPublicKey(value);
         return this;
       }
       /**
-       * <code>optional bytes public_key = 3;</code>
-       *
        * <pre>
        * The public EC key derived from the private key. We allow both to be stored to avoid mobile clients having to
        * do lots of slow EC math on startup. For DETERMINISTIC_MNEMONIC entries this is missing.
        * </pre>
+       *
+       * <code>optional bytes public_key = 3;</code>
        */
       public Builder clearPublicKey() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        publicKey_ = getDefaultInstance().getPublicKey();
-        onChanged();
+        copyOnWrite();
+        instance.clearPublicKey();
         return this;
       }
 
-      private java.lang.Object label_ = "";
       /**
-       * <code>optional string label = 4;</code>
-       *
        * <pre>
        * User-provided label associated with the key.
        * </pre>
+       *
+       * <code>optional string label = 4;</code>
        */
       public boolean hasLabel() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasLabel();
       }
       /**
-       * <code>optional string label = 4;</code>
-       *
        * <pre>
        * User-provided label associated with the key.
        * </pre>
+       *
+       * <code>optional string label = 4;</code>
        */
       public java.lang.String getLabel() {
-        java.lang.Object ref = label_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            label_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getLabel();
       }
       /**
-       * <code>optional string label = 4;</code>
-       *
        * <pre>
        * User-provided label associated with the key.
        * </pre>
+       *
+       * <code>optional string label = 4;</code>
        */
       public com.google.protobuf.ByteString
           getLabelBytes() {
-        java.lang.Object ref = label_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          label_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getLabelBytes();
       }
       /**
-       * <code>optional string label = 4;</code>
-       *
        * <pre>
        * User-provided label associated with the key.
        * </pre>
+       *
+       * <code>optional string label = 4;</code>
        */
       public Builder setLabel(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-        label_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLabel(value);
         return this;
       }
       /**
-       * <code>optional string label = 4;</code>
-       *
        * <pre>
        * User-provided label associated with the key.
        * </pre>
+       *
+       * <code>optional string label = 4;</code>
        */
       public Builder clearLabel() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        label_ = getDefaultInstance().getLabel();
-        onChanged();
+        copyOnWrite();
+        instance.clearLabel();
         return this;
       }
       /**
-       * <code>optional string label = 4;</code>
-       *
        * <pre>
        * User-provided label associated with the key.
        * </pre>
+       *
+       * <code>optional string label = 4;</code>
        */
       public Builder setLabelBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-        label_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLabelBytes(value);
         return this;
       }
 
-      private long creationTimestamp_ ;
       /**
-       * <code>optional int64 creation_timestamp = 5;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
        * optional is that keys derived from a parent don't have this data.
        * </pre>
+       *
+       * <code>optional int64 creation_timestamp = 5;</code>
        */
       public boolean hasCreationTimestamp() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return instance.hasCreationTimestamp();
       }
       /**
-       * <code>optional int64 creation_timestamp = 5;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
        * optional is that keys derived from a parent don't have this data.
        * </pre>
+       *
+       * <code>optional int64 creation_timestamp = 5;</code>
        */
       public long getCreationTimestamp() {
-        return creationTimestamp_;
+        return instance.getCreationTimestamp();
       }
       /**
-       * <code>optional int64 creation_timestamp = 5;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
        * optional is that keys derived from a parent don't have this data.
        * </pre>
+       *
+       * <code>optional int64 creation_timestamp = 5;</code>
        */
       public Builder setCreationTimestamp(long value) {
-        bitField0_ |= 0x00000020;
-        creationTimestamp_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setCreationTimestamp(value);
         return this;
       }
       /**
-       * <code>optional int64 creation_timestamp = 5;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
        * optional is that keys derived from a parent don't have this data.
        * </pre>
+       *
+       * <code>optional int64 creation_timestamp = 5;</code>
        */
       public Builder clearCreationTimestamp() {
-        bitField0_ = (bitField0_ & ~0x00000020);
-        creationTimestamp_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearCreationTimestamp();
         return this;
       }
 
-      private org.floj.wallet.Protos.DeterministicKey deterministicKey_ = org.floj.wallet.Protos.DeterministicKey.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.DeterministicKey, org.floj.wallet.Protos.DeterministicKey.Builder, org.floj.wallet.Protos.DeterministicKeyOrBuilder> deterministicKeyBuilder_;
       /**
        * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
        */
       public boolean hasDeterministicKey() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return instance.hasDeterministicKey();
       }
       /**
        * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
        */
       public org.floj.wallet.Protos.DeterministicKey getDeterministicKey() {
-        if (deterministicKeyBuilder_ == null) {
-          return deterministicKey_;
-        } else {
-          return deterministicKeyBuilder_.getMessage();
-        }
+        return instance.getDeterministicKey();
       }
       /**
        * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
        */
       public Builder setDeterministicKey(org.floj.wallet.Protos.DeterministicKey value) {
-        if (deterministicKeyBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          deterministicKey_ = value;
-          onChanged();
-        } else {
-          deterministicKeyBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000040;
+        copyOnWrite();
+        instance.setDeterministicKey(value);
         return this;
-      }
+        }
       /**
        * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
        */
       public Builder setDeterministicKey(
           org.floj.wallet.Protos.DeterministicKey.Builder builderForValue) {
-        if (deterministicKeyBuilder_ == null) {
-          deterministicKey_ = builderForValue.build();
-          onChanged();
-        } else {
-          deterministicKeyBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000040;
+        copyOnWrite();
+        instance.setDeterministicKey(builderForValue);
         return this;
       }
       /**
        * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
        */
       public Builder mergeDeterministicKey(org.floj.wallet.Protos.DeterministicKey value) {
-        if (deterministicKeyBuilder_ == null) {
-          if (((bitField0_ & 0x00000040) == 0x00000040) &&
-              deterministicKey_ != org.floj.wallet.Protos.DeterministicKey.getDefaultInstance()) {
-            deterministicKey_ =
-              org.floj.wallet.Protos.DeterministicKey.newBuilder(deterministicKey_).mergeFrom(value).buildPartial();
-          } else {
-            deterministicKey_ = value;
-          }
-          onChanged();
-        } else {
-          deterministicKeyBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000040;
+        copyOnWrite();
+        instance.mergeDeterministicKey(value);
         return this;
       }
       /**
        * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
        */
-      public Builder clearDeterministicKey() {
-        if (deterministicKeyBuilder_ == null) {
-          deterministicKey_ = org.floj.wallet.Protos.DeterministicKey.getDefaultInstance();
-          onChanged();
-        } else {
-          deterministicKeyBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000040);
+      public Builder clearDeterministicKey() {  copyOnWrite();
+        instance.clearDeterministicKey();
         return this;
-      }
-      /**
-       * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
-       */
-      public org.floj.wallet.Protos.DeterministicKey.Builder getDeterministicKeyBuilder() {
-        bitField0_ |= 0x00000040;
-        onChanged();
-        return getDeterministicKeyFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
-       */
-      public org.floj.wallet.Protos.DeterministicKeyOrBuilder getDeterministicKeyOrBuilder() {
-        if (deterministicKeyBuilder_ != null) {
-          return deterministicKeyBuilder_.getMessageOrBuilder();
-        } else {
-          return deterministicKey_;
-        }
-      }
-      /**
-       * <code>optional .wallet.DeterministicKey deterministic_key = 7;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.DeterministicKey, org.floj.wallet.Protos.DeterministicKey.Builder, org.floj.wallet.Protos.DeterministicKeyOrBuilder> 
-          getDeterministicKeyFieldBuilder() {
-        if (deterministicKeyBuilder_ == null) {
-          deterministicKeyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.floj.wallet.Protos.DeterministicKey, org.floj.wallet.Protos.DeterministicKey.Builder, org.floj.wallet.Protos.DeterministicKeyOrBuilder>(
-                  getDeterministicKey(),
-                  getParentForChildren(),
-                  isClean());
-          deterministicKey_ = null;
-        }
-        return deterministicKeyBuilder_;
       }
 
-      private com.google.protobuf.ByteString deterministicSeed_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes deterministic_seed = 8;</code>
-       *
        * <pre>
        * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
        * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
        * </pre>
+       *
+       * <code>optional bytes deterministic_seed = 8;</code>
        */
       public boolean hasDeterministicSeed() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return instance.hasDeterministicSeed();
       }
       /**
-       * <code>optional bytes deterministic_seed = 8;</code>
-       *
        * <pre>
        * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
        * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
        * </pre>
+       *
+       * <code>optional bytes deterministic_seed = 8;</code>
        */
       public com.google.protobuf.ByteString getDeterministicSeed() {
-        return deterministicSeed_;
+        return instance.getDeterministicSeed();
       }
       /**
-       * <code>optional bytes deterministic_seed = 8;</code>
-       *
        * <pre>
        * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
        * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
        * </pre>
+       *
+       * <code>optional bytes deterministic_seed = 8;</code>
        */
       public Builder setDeterministicSeed(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000080;
-        deterministicSeed_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setDeterministicSeed(value);
         return this;
       }
       /**
-       * <code>optional bytes deterministic_seed = 8;</code>
-       *
        * <pre>
        * The seed for a deterministic key hierarchy.  Derived from the mnemonic,
        * but cached here for quick startup.  Only applicable to a DETERMINISTIC_MNEMONIC key entry.
        * </pre>
+       *
+       * <code>optional bytes deterministic_seed = 8;</code>
        */
       public Builder clearDeterministicSeed() {
-        bitField0_ = (bitField0_ & ~0x00000080);
-        deterministicSeed_ = getDefaultInstance().getDeterministicSeed();
-        onChanged();
+        copyOnWrite();
+        instance.clearDeterministicSeed();
         return this;
       }
 
-      private org.floj.wallet.Protos.EncryptedData encryptedDeterministicSeed_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.EncryptedData, org.floj.wallet.Protos.EncryptedData.Builder, org.floj.wallet.Protos.EncryptedDataOrBuilder> encryptedDeterministicSeedBuilder_;
       /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
        * <pre>
        * Encrypted version of the seed
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
        */
       public boolean hasEncryptedDeterministicSeed() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
+        return instance.hasEncryptedDeterministicSeed();
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
        * <pre>
        * Encrypted version of the seed
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
        */
       public org.floj.wallet.Protos.EncryptedData getEncryptedDeterministicSeed() {
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          return encryptedDeterministicSeed_;
-        } else {
-          return encryptedDeterministicSeedBuilder_.getMessage();
-        }
+        return instance.getEncryptedDeterministicSeed();
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
        * <pre>
        * Encrypted version of the seed
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
        */
       public Builder setEncryptedDeterministicSeed(org.floj.wallet.Protos.EncryptedData value) {
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          encryptedDeterministicSeed_ = value;
-          onChanged();
-        } else {
-          encryptedDeterministicSeedBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.setEncryptedDeterministicSeed(value);
         return this;
-      }
+        }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
        * <pre>
        * Encrypted version of the seed
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
        */
       public Builder setEncryptedDeterministicSeed(
           org.floj.wallet.Protos.EncryptedData.Builder builderForValue) {
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          encryptedDeterministicSeed_ = builderForValue.build();
-          onChanged();
-        } else {
-          encryptedDeterministicSeedBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.setEncryptedDeterministicSeed(builderForValue);
         return this;
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
        * <pre>
        * Encrypted version of the seed
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
        */
       public Builder mergeEncryptedDeterministicSeed(org.floj.wallet.Protos.EncryptedData value) {
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          if (((bitField0_ & 0x00000100) == 0x00000100) &&
-              encryptedDeterministicSeed_ != org.floj.wallet.Protos.EncryptedData.getDefaultInstance()) {
-            encryptedDeterministicSeed_ =
-              org.floj.wallet.Protos.EncryptedData.newBuilder(encryptedDeterministicSeed_).mergeFrom(value).buildPartial();
-          } else {
-            encryptedDeterministicSeed_ = value;
-          }
-          onChanged();
-        } else {
-          encryptedDeterministicSeedBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.mergeEncryptedDeterministicSeed(value);
         return this;
       }
       /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
        * <pre>
        * Encrypted version of the seed
        * </pre>
+       *
+       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
        */
-      public Builder clearEncryptedDeterministicSeed() {
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          encryptedDeterministicSeed_ = org.floj.wallet.Protos.EncryptedData.getDefaultInstance();
-          onChanged();
-        } else {
-          encryptedDeterministicSeedBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000100);
+      public Builder clearEncryptedDeterministicSeed() {  copyOnWrite();
+        instance.clearEncryptedDeterministicSeed();
         return this;
-      }
-      /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
-       * <pre>
-       * Encrypted version of the seed
-       * </pre>
-       */
-      public org.floj.wallet.Protos.EncryptedData.Builder getEncryptedDeterministicSeedBuilder() {
-        bitField0_ |= 0x00000100;
-        onChanged();
-        return getEncryptedDeterministicSeedFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
-       * <pre>
-       * Encrypted version of the seed
-       * </pre>
-       */
-      public org.floj.wallet.Protos.EncryptedDataOrBuilder getEncryptedDeterministicSeedOrBuilder() {
-        if (encryptedDeterministicSeedBuilder_ != null) {
-          return encryptedDeterministicSeedBuilder_.getMessageOrBuilder();
-        } else {
-          return encryptedDeterministicSeed_;
-        }
-      }
-      /**
-       * <code>optional .wallet.EncryptedData encrypted_deterministic_seed = 9;</code>
-       *
-       * <pre>
-       * Encrypted version of the seed
-       * </pre>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.EncryptedData, org.floj.wallet.Protos.EncryptedData.Builder, org.floj.wallet.Protos.EncryptedDataOrBuilder> 
-          getEncryptedDeterministicSeedFieldBuilder() {
-        if (encryptedDeterministicSeedBuilder_ == null) {
-          encryptedDeterministicSeedBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.floj.wallet.Protos.EncryptedData, org.floj.wallet.Protos.EncryptedData.Builder, org.floj.wallet.Protos.EncryptedDataOrBuilder>(
-                  getEncryptedDeterministicSeed(),
-                  getParentForChildren(),
-                  isClean());
-          encryptedDeterministicSeed_ = null;
-        }
-        return encryptedDeterministicSeedBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.Key)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.Key();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Key(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasType()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (hasEncryptedData()) {
+            if (!getEncryptedData().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasDeterministicKey()) {
+            if (!getDeterministicKey().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasEncryptedDeterministicSeed()) {
+            if (!getEncryptedDeterministicSeed().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.Key other = (org.floj.wallet.Protos.Key) arg1;
+          type_ = visitor.visitInt(hasType(), type_,
+              other.hasType(), other.type_);
+          secretBytes_ = visitor.visitByteString(
+              hasSecretBytes(), secretBytes_,
+              other.hasSecretBytes(), other.secretBytes_);
+          encryptedData_ = visitor.visitMessage(encryptedData_, other.encryptedData_);
+          publicKey_ = visitor.visitByteString(
+              hasPublicKey(), publicKey_,
+              other.hasPublicKey(), other.publicKey_);
+          label_ = visitor.visitString(
+              hasLabel(), label_,
+              other.hasLabel(), other.label_);
+          creationTimestamp_ = visitor.visitLong(
+              hasCreationTimestamp(), creationTimestamp_,
+              other.hasCreationTimestamp(), other.creationTimestamp_);
+          deterministicKey_ = visitor.visitMessage(deterministicKey_, other.deterministicKey_);
+          deterministicSeed_ = visitor.visitByteString(
+              hasDeterministicSeed(), deterministicSeed_,
+              other.hasDeterministicSeed(), other.deterministicSeed_);
+          encryptedDeterministicSeed_ = visitor.visitMessage(encryptedDeterministicSeed_, other.encryptedDeterministicSeed_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  int rawValue = input.readEnum();
+                  org.floj.wallet.Protos.Key.Type value = org.floj.wallet.Protos.Key.Type.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(1, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000001;
+                    type_ = rawValue;
+                  }
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  secretBytes_ = input.readBytes();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000008;
+                  publicKey_ = input.readBytes();
+                  break;
+                }
+                case 34: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000010;
+                  label_ = s;
+                  break;
+                }
+                case 40: {
+                  bitField0_ |= 0x00000020;
+                  creationTimestamp_ = input.readInt64();
+                  break;
+                }
+                case 50: {
+                  org.floj.wallet.Protos.EncryptedData.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000004) == 0x00000004)) {
+                    subBuilder = encryptedData_.toBuilder();
+                  }
+                  encryptedData_ = input.readMessage(org.floj.wallet.Protos.EncryptedData.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(encryptedData_);
+                    encryptedData_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000004;
+                  break;
+                }
+                case 58: {
+                  org.floj.wallet.Protos.DeterministicKey.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000040) == 0x00000040)) {
+                    subBuilder = deterministicKey_.toBuilder();
+                  }
+                  deterministicKey_ = input.readMessage(org.floj.wallet.Protos.DeterministicKey.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(deterministicKey_);
+                    deterministicKey_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000040;
+                  break;
+                }
+                case 66: {
+                  bitField0_ |= 0x00000080;
+                  deterministicSeed_ = input.readBytes();
+                  break;
+                }
+                case 74: {
+                  org.floj.wallet.Protos.EncryptedData.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000100) == 0x00000100)) {
+                    subBuilder = encryptedDeterministicSeed_.toBuilder();
+                  }
+                  encryptedDeterministicSeed_ = input.readMessage(org.floj.wallet.Protos.EncryptedData.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(encryptedDeterministicSeed_);
+                    encryptedDeterministicSeed_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000100;
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.Key.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.Key)
+    private static final org.floj.wallet.Protos.Key DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Key();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.Key getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Key> PARSER;
+
+    public static com.google.protobuf.Parser<Key> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ScriptOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.Script)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required bytes program = 1;</code>
@@ -4300,125 +3821,35 @@ public final class Protos {
     com.google.protobuf.ByteString getProgram();
 
     /**
-     * <code>required int64 creation_timestamp = 2;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
      * when watching for scripts on the blockchain.
      * </pre>
+     *
+     * <code>required int64 creation_timestamp = 2;</code>
      */
     boolean hasCreationTimestamp();
     /**
-     * <code>required int64 creation_timestamp = 2;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
      * when watching for scripts on the blockchain.
      * </pre>
+     *
+     * <code>required int64 creation_timestamp = 2;</code>
      */
     long getCreationTimestamp();
   }
   /**
    * Protobuf type {@code wallet.Script}
    */
-  public static final class Script extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Script extends
+      com.google.protobuf.GeneratedMessageLite<
+          Script, Script.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.Script)
       ScriptOrBuilder {
-    // Use Script.newBuilder() to construct.
-    private Script(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Script() {
+      program_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Script(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Script defaultInstance;
-    public static Script getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Script getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Script(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              program_ = input.readBytes();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              creationTimestamp_ = input.readInt64();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_Script_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_Script_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.Script.class, org.floj.wallet.Protos.Script.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Script> PARSER =
-        new com.google.protobuf.AbstractParser<Script>() {
-      public Script parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Script(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Script> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int PROGRAM_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString program_;
@@ -4434,67 +3865,84 @@ public final class Protos {
     public com.google.protobuf.ByteString getProgram() {
       return program_;
     }
+    /**
+     * <code>required bytes program = 1;</code>
+     */
+    private void setProgram(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      program_ = value;
+    }
+    /**
+     * <code>required bytes program = 1;</code>
+     */
+    private void clearProgram() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      program_ = getDefaultInstance().getProgram();
+    }
 
     public static final int CREATION_TIMESTAMP_FIELD_NUMBER = 2;
     private long creationTimestamp_;
     /**
-     * <code>required int64 creation_timestamp = 2;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
      * when watching for scripts on the blockchain.
      * </pre>
+     *
+     * <code>required int64 creation_timestamp = 2;</code>
      */
     public boolean hasCreationTimestamp() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required int64 creation_timestamp = 2;</code>
-     *
      * <pre>
      * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
      * when watching for scripts on the blockchain.
      * </pre>
+     *
+     * <code>required int64 creation_timestamp = 2;</code>
      */
     public long getCreationTimestamp() {
       return creationTimestamp_;
     }
-
-    private void initFields() {
-      program_ = com.google.protobuf.ByteString.EMPTY;
-      creationTimestamp_ = 0L;
+    /**
+     * <pre>
+     * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
+     * when watching for scripts on the blockchain.
+     * </pre>
+     *
+     * <code>required int64 creation_timestamp = 2;</code>
+     */
+    private void setCreationTimestamp(long value) {
+      bitField0_ |= 0x00000002;
+      creationTimestamp_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasProgram()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasCreationTimestamp()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
+     * when watching for scripts on the blockchain.
+     * </pre>
+     *
+     * <code>required int64 creation_timestamp = 2;</code>
+     */
+    private void clearCreationTimestamp() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      creationTimestamp_ = 0L;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, program_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeInt64(2, creationTimestamp_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -4508,671 +3956,634 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(2, creationTimestamp_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.Script parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Script parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Script parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Script parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Script parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Script parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Script parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Script parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Script parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Script parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.Script prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code wallet.Script}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.Script, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.Script)
         org.floj.wallet.Protos.ScriptOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_Script_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_Script_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.Script.class, org.floj.wallet.Protos.Script.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.Script.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        program_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        creationTimestamp_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_Script_descriptor;
-      }
-
-      public org.floj.wallet.Protos.Script getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.Script.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.Script build() {
-        org.floj.wallet.Protos.Script result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.Script buildPartial() {
-        org.floj.wallet.Protos.Script result = new org.floj.wallet.Protos.Script(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.program_ = program_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.creationTimestamp_ = creationTimestamp_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.Script) {
-          return mergeFrom((org.floj.wallet.Protos.Script)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.Script other) {
-        if (other == org.floj.wallet.Protos.Script.getDefaultInstance()) return this;
-        if (other.hasProgram()) {
-          setProgram(other.getProgram());
-        }
-        if (other.hasCreationTimestamp()) {
-          setCreationTimestamp(other.getCreationTimestamp());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasProgram()) {
-          
-          return false;
-        }
-        if (!hasCreationTimestamp()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.Script parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.Script) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString program_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes program = 1;</code>
        */
       public boolean hasProgram() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasProgram();
       }
       /**
        * <code>required bytes program = 1;</code>
        */
       public com.google.protobuf.ByteString getProgram() {
-        return program_;
+        return instance.getProgram();
       }
       /**
        * <code>required bytes program = 1;</code>
        */
       public Builder setProgram(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        program_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setProgram(value);
         return this;
       }
       /**
        * <code>required bytes program = 1;</code>
        */
       public Builder clearProgram() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        program_ = getDefaultInstance().getProgram();
-        onChanged();
+        copyOnWrite();
+        instance.clearProgram();
         return this;
       }
 
-      private long creationTimestamp_ ;
       /**
-       * <code>required int64 creation_timestamp = 2;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
        * when watching for scripts on the blockchain.
        * </pre>
+       *
+       * <code>required int64 creation_timestamp = 2;</code>
        */
       public boolean hasCreationTimestamp() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasCreationTimestamp();
       }
       /**
-       * <code>required int64 creation_timestamp = 2;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
        * when watching for scripts on the blockchain.
        * </pre>
+       *
+       * <code>required int64 creation_timestamp = 2;</code>
        */
       public long getCreationTimestamp() {
-        return creationTimestamp_;
+        return instance.getCreationTimestamp();
       }
       /**
-       * <code>required int64 creation_timestamp = 2;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
        * when watching for scripts on the blockchain.
        * </pre>
+       *
+       * <code>required int64 creation_timestamp = 2;</code>
        */
       public Builder setCreationTimestamp(long value) {
-        bitField0_ |= 0x00000002;
-        creationTimestamp_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setCreationTimestamp(value);
         return this;
       }
       /**
-       * <code>required int64 creation_timestamp = 2;</code>
-       *
        * <pre>
        * Timestamp stored as millis since epoch. Useful for skipping block bodies before this point
        * when watching for scripts on the blockchain.
        * </pre>
+       *
+       * <code>required int64 creation_timestamp = 2;</code>
        */
       public Builder clearCreationTimestamp() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        creationTimestamp_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearCreationTimestamp();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.Script)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.Script();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Script(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasProgram()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasCreationTimestamp()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.Script other = (org.floj.wallet.Protos.Script) arg1;
+          program_ = visitor.visitByteString(
+              hasProgram(), program_,
+              other.hasProgram(), other.program_);
+          creationTimestamp_ = visitor.visitLong(
+              hasCreationTimestamp(), creationTimestamp_,
+              other.hasCreationTimestamp(), other.creationTimestamp_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  program_ = input.readBytes();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  creationTimestamp_ = input.readInt64();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.Script.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.Script)
+    private static final org.floj.wallet.Protos.Script DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Script();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.Script getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Script> PARSER;
+
+    public static com.google.protobuf.Parser<Script> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface TransactionInputOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.TransactionInput)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes transaction_out_point_hash = 1;</code>
-     *
      * <pre>
      * Hash of the transaction this input is using.
      * </pre>
+     *
+     * <code>required bytes transaction_out_point_hash = 1;</code>
      */
     boolean hasTransactionOutPointHash();
     /**
-     * <code>required bytes transaction_out_point_hash = 1;</code>
-     *
      * <pre>
      * Hash of the transaction this input is using.
      * </pre>
+     *
+     * <code>required bytes transaction_out_point_hash = 1;</code>
      */
     com.google.protobuf.ByteString getTransactionOutPointHash();
 
     /**
-     * <code>required uint32 transaction_out_point_index = 2;</code>
-     *
      * <pre>
      * Index of transaction output used by this input.
      * </pre>
+     *
+     * <code>required uint32 transaction_out_point_index = 2;</code>
      */
     boolean hasTransactionOutPointIndex();
     /**
-     * <code>required uint32 transaction_out_point_index = 2;</code>
-     *
      * <pre>
      * Index of transaction output used by this input.
      * </pre>
+     *
+     * <code>required uint32 transaction_out_point_index = 2;</code>
      */
     int getTransactionOutPointIndex();
 
     /**
-     * <code>required bytes script_bytes = 3;</code>
-     *
      * <pre>
      * Script that contains the signatures/pubkeys.
      * </pre>
+     *
+     * <code>required bytes script_bytes = 3;</code>
      */
     boolean hasScriptBytes();
     /**
-     * <code>required bytes script_bytes = 3;</code>
-     *
      * <pre>
      * Script that contains the signatures/pubkeys.
      * </pre>
+     *
+     * <code>required bytes script_bytes = 3;</code>
      */
     com.google.protobuf.ByteString getScriptBytes();
 
     /**
-     * <code>optional uint32 sequence = 4;</code>
-     *
      * <pre>
      * Sequence number.
      * </pre>
+     *
+     * <code>optional uint32 sequence = 4;</code>
      */
     boolean hasSequence();
     /**
-     * <code>optional uint32 sequence = 4;</code>
-     *
      * <pre>
      * Sequence number.
      * </pre>
+     *
+     * <code>optional uint32 sequence = 4;</code>
      */
     int getSequence();
 
     /**
-     * <code>optional int64 value = 5;</code>
-     *
      * <pre>
      * Value of connected output, if known
      * </pre>
+     *
+     * <code>optional int64 value = 5;</code>
      */
     boolean hasValue();
     /**
-     * <code>optional int64 value = 5;</code>
-     *
      * <pre>
      * Value of connected output, if known
      * </pre>
+     *
+     * <code>optional int64 value = 5;</code>
      */
     long getValue();
   }
   /**
    * Protobuf type {@code wallet.TransactionInput}
    */
-  public static final class TransactionInput extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class TransactionInput extends
+      com.google.protobuf.GeneratedMessageLite<
+          TransactionInput, TransactionInput.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.TransactionInput)
       TransactionInputOrBuilder {
-    // Use TransactionInput.newBuilder() to construct.
-    private TransactionInput(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private TransactionInput() {
+      transactionOutPointHash_ = com.google.protobuf.ByteString.EMPTY;
+      scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private TransactionInput(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final TransactionInput defaultInstance;
-    public static TransactionInput getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public TransactionInput getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private TransactionInput(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              transactionOutPointHash_ = input.readBytes();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              transactionOutPointIndex_ = input.readUInt32();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              scriptBytes_ = input.readBytes();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              sequence_ = input.readUInt32();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              value_ = input.readInt64();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionInput_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionInput_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.TransactionInput.class, org.floj.wallet.Protos.TransactionInput.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<TransactionInput> PARSER =
-        new com.google.protobuf.AbstractParser<TransactionInput>() {
-      public TransactionInput parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TransactionInput(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<TransactionInput> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int TRANSACTION_OUT_POINT_HASH_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString transactionOutPointHash_;
     /**
-     * <code>required bytes transaction_out_point_hash = 1;</code>
-     *
      * <pre>
      * Hash of the transaction this input is using.
      * </pre>
+     *
+     * <code>required bytes transaction_out_point_hash = 1;</code>
      */
     public boolean hasTransactionOutPointHash() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bytes transaction_out_point_hash = 1;</code>
-     *
      * <pre>
      * Hash of the transaction this input is using.
      * </pre>
+     *
+     * <code>required bytes transaction_out_point_hash = 1;</code>
      */
     public com.google.protobuf.ByteString getTransactionOutPointHash() {
       return transactionOutPointHash_;
+    }
+    /**
+     * <pre>
+     * Hash of the transaction this input is using.
+     * </pre>
+     *
+     * <code>required bytes transaction_out_point_hash = 1;</code>
+     */
+    private void setTransactionOutPointHash(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      transactionOutPointHash_ = value;
+    }
+    /**
+     * <pre>
+     * Hash of the transaction this input is using.
+     * </pre>
+     *
+     * <code>required bytes transaction_out_point_hash = 1;</code>
+     */
+    private void clearTransactionOutPointHash() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      transactionOutPointHash_ = getDefaultInstance().getTransactionOutPointHash();
     }
 
     public static final int TRANSACTION_OUT_POINT_INDEX_FIELD_NUMBER = 2;
     private int transactionOutPointIndex_;
     /**
-     * <code>required uint32 transaction_out_point_index = 2;</code>
-     *
      * <pre>
      * Index of transaction output used by this input.
      * </pre>
+     *
+     * <code>required uint32 transaction_out_point_index = 2;</code>
      */
     public boolean hasTransactionOutPointIndex() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required uint32 transaction_out_point_index = 2;</code>
-     *
      * <pre>
      * Index of transaction output used by this input.
      * </pre>
+     *
+     * <code>required uint32 transaction_out_point_index = 2;</code>
      */
     public int getTransactionOutPointIndex() {
       return transactionOutPointIndex_;
+    }
+    /**
+     * <pre>
+     * Index of transaction output used by this input.
+     * </pre>
+     *
+     * <code>required uint32 transaction_out_point_index = 2;</code>
+     */
+    private void setTransactionOutPointIndex(int value) {
+      bitField0_ |= 0x00000002;
+      transactionOutPointIndex_ = value;
+    }
+    /**
+     * <pre>
+     * Index of transaction output used by this input.
+     * </pre>
+     *
+     * <code>required uint32 transaction_out_point_index = 2;</code>
+     */
+    private void clearTransactionOutPointIndex() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      transactionOutPointIndex_ = 0;
     }
 
     public static final int SCRIPT_BYTES_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString scriptBytes_;
     /**
-     * <code>required bytes script_bytes = 3;</code>
-     *
      * <pre>
      * Script that contains the signatures/pubkeys.
      * </pre>
+     *
+     * <code>required bytes script_bytes = 3;</code>
      */
     public boolean hasScriptBytes() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>required bytes script_bytes = 3;</code>
-     *
      * <pre>
      * Script that contains the signatures/pubkeys.
      * </pre>
+     *
+     * <code>required bytes script_bytes = 3;</code>
      */
     public com.google.protobuf.ByteString getScriptBytes() {
       return scriptBytes_;
+    }
+    /**
+     * <pre>
+     * Script that contains the signatures/pubkeys.
+     * </pre>
+     *
+     * <code>required bytes script_bytes = 3;</code>
+     */
+    private void setScriptBytes(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      scriptBytes_ = value;
+    }
+    /**
+     * <pre>
+     * Script that contains the signatures/pubkeys.
+     * </pre>
+     *
+     * <code>required bytes script_bytes = 3;</code>
+     */
+    private void clearScriptBytes() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      scriptBytes_ = getDefaultInstance().getScriptBytes();
     }
 
     public static final int SEQUENCE_FIELD_NUMBER = 4;
     private int sequence_;
     /**
-     * <code>optional uint32 sequence = 4;</code>
-     *
      * <pre>
      * Sequence number.
      * </pre>
+     *
+     * <code>optional uint32 sequence = 4;</code>
      */
     public boolean hasSequence() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional uint32 sequence = 4;</code>
-     *
      * <pre>
      * Sequence number.
      * </pre>
+     *
+     * <code>optional uint32 sequence = 4;</code>
      */
     public int getSequence() {
       return sequence_;
+    }
+    /**
+     * <pre>
+     * Sequence number.
+     * </pre>
+     *
+     * <code>optional uint32 sequence = 4;</code>
+     */
+    private void setSequence(int value) {
+      bitField0_ |= 0x00000008;
+      sequence_ = value;
+    }
+    /**
+     * <pre>
+     * Sequence number.
+     * </pre>
+     *
+     * <code>optional uint32 sequence = 4;</code>
+     */
+    private void clearSequence() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      sequence_ = 0;
     }
 
     public static final int VALUE_FIELD_NUMBER = 5;
     private long value_;
     /**
-     * <code>optional int64 value = 5;</code>
-     *
      * <pre>
      * Value of connected output, if known
      * </pre>
+     *
+     * <code>optional int64 value = 5;</code>
      */
     public boolean hasValue() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional int64 value = 5;</code>
-     *
      * <pre>
      * Value of connected output, if known
      * </pre>
+     *
+     * <code>optional int64 value = 5;</code>
      */
     public long getValue() {
       return value_;
     }
-
-    private void initFields() {
-      transactionOutPointHash_ = com.google.protobuf.ByteString.EMPTY;
-      transactionOutPointIndex_ = 0;
-      scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
-      sequence_ = 0;
-      value_ = 0L;
+    /**
+     * <pre>
+     * Value of connected output, if known
+     * </pre>
+     *
+     * <code>optional int64 value = 5;</code>
+     */
+    private void setValue(long value) {
+      bitField0_ |= 0x00000010;
+      value_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasTransactionOutPointHash()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasTransactionOutPointIndex()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasScriptBytes()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Value of connected output, if known
+     * </pre>
+     *
+     * <code>optional int64 value = 5;</code>
+     */
+    private void clearValue() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      value_ = 0L;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, transactionOutPointHash_);
       }
@@ -5188,10 +4599,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeInt64(5, value_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -5217,511 +4627,479 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(5, value_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.TransactionInput parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionInput parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionInput parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionInput parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionInput parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionInput parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionInput parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionInput parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionInput parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionInput parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.TransactionInput prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code wallet.TransactionInput}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.TransactionInput, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.TransactionInput)
         org.floj.wallet.Protos.TransactionInputOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionInput_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionInput_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.TransactionInput.class, org.floj.wallet.Protos.TransactionInput.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.TransactionInput.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        transactionOutPointHash_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        transactionOutPointIndex_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        sequence_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        value_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionInput_descriptor;
-      }
-
-      public org.floj.wallet.Protos.TransactionInput getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.TransactionInput.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.TransactionInput build() {
-        org.floj.wallet.Protos.TransactionInput result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.TransactionInput buildPartial() {
-        org.floj.wallet.Protos.TransactionInput result = new org.floj.wallet.Protos.TransactionInput(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.transactionOutPointHash_ = transactionOutPointHash_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.transactionOutPointIndex_ = transactionOutPointIndex_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.scriptBytes_ = scriptBytes_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.sequence_ = sequence_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.value_ = value_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.TransactionInput) {
-          return mergeFrom((org.floj.wallet.Protos.TransactionInput)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.TransactionInput other) {
-        if (other == org.floj.wallet.Protos.TransactionInput.getDefaultInstance()) return this;
-        if (other.hasTransactionOutPointHash()) {
-          setTransactionOutPointHash(other.getTransactionOutPointHash());
-        }
-        if (other.hasTransactionOutPointIndex()) {
-          setTransactionOutPointIndex(other.getTransactionOutPointIndex());
-        }
-        if (other.hasScriptBytes()) {
-          setScriptBytes(other.getScriptBytes());
-        }
-        if (other.hasSequence()) {
-          setSequence(other.getSequence());
-        }
-        if (other.hasValue()) {
-          setValue(other.getValue());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasTransactionOutPointHash()) {
-          
-          return false;
-        }
-        if (!hasTransactionOutPointIndex()) {
-          
-          return false;
-        }
-        if (!hasScriptBytes()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.TransactionInput parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.TransactionInput) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString transactionOutPointHash_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes transaction_out_point_hash = 1;</code>
-       *
        * <pre>
        * Hash of the transaction this input is using.
        * </pre>
+       *
+       * <code>required bytes transaction_out_point_hash = 1;</code>
        */
       public boolean hasTransactionOutPointHash() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasTransactionOutPointHash();
       }
       /**
-       * <code>required bytes transaction_out_point_hash = 1;</code>
-       *
        * <pre>
        * Hash of the transaction this input is using.
        * </pre>
+       *
+       * <code>required bytes transaction_out_point_hash = 1;</code>
        */
       public com.google.protobuf.ByteString getTransactionOutPointHash() {
-        return transactionOutPointHash_;
+        return instance.getTransactionOutPointHash();
       }
       /**
-       * <code>required bytes transaction_out_point_hash = 1;</code>
-       *
        * <pre>
        * Hash of the transaction this input is using.
        * </pre>
+       *
+       * <code>required bytes transaction_out_point_hash = 1;</code>
        */
       public Builder setTransactionOutPointHash(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        transactionOutPointHash_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTransactionOutPointHash(value);
         return this;
       }
       /**
-       * <code>required bytes transaction_out_point_hash = 1;</code>
-       *
        * <pre>
        * Hash of the transaction this input is using.
        * </pre>
+       *
+       * <code>required bytes transaction_out_point_hash = 1;</code>
        */
       public Builder clearTransactionOutPointHash() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        transactionOutPointHash_ = getDefaultInstance().getTransactionOutPointHash();
-        onChanged();
+        copyOnWrite();
+        instance.clearTransactionOutPointHash();
         return this;
       }
 
-      private int transactionOutPointIndex_ ;
       /**
-       * <code>required uint32 transaction_out_point_index = 2;</code>
-       *
        * <pre>
        * Index of transaction output used by this input.
        * </pre>
+       *
+       * <code>required uint32 transaction_out_point_index = 2;</code>
        */
       public boolean hasTransactionOutPointIndex() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasTransactionOutPointIndex();
       }
       /**
-       * <code>required uint32 transaction_out_point_index = 2;</code>
-       *
        * <pre>
        * Index of transaction output used by this input.
        * </pre>
+       *
+       * <code>required uint32 transaction_out_point_index = 2;</code>
        */
       public int getTransactionOutPointIndex() {
-        return transactionOutPointIndex_;
+        return instance.getTransactionOutPointIndex();
       }
       /**
-       * <code>required uint32 transaction_out_point_index = 2;</code>
-       *
        * <pre>
        * Index of transaction output used by this input.
        * </pre>
+       *
+       * <code>required uint32 transaction_out_point_index = 2;</code>
        */
       public Builder setTransactionOutPointIndex(int value) {
-        bitField0_ |= 0x00000002;
-        transactionOutPointIndex_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTransactionOutPointIndex(value);
         return this;
       }
       /**
-       * <code>required uint32 transaction_out_point_index = 2;</code>
-       *
        * <pre>
        * Index of transaction output used by this input.
        * </pre>
+       *
+       * <code>required uint32 transaction_out_point_index = 2;</code>
        */
       public Builder clearTransactionOutPointIndex() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        transactionOutPointIndex_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearTransactionOutPointIndex();
         return this;
       }
 
-      private com.google.protobuf.ByteString scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes script_bytes = 3;</code>
-       *
        * <pre>
        * Script that contains the signatures/pubkeys.
        * </pre>
+       *
+       * <code>required bytes script_bytes = 3;</code>
        */
       public boolean hasScriptBytes() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasScriptBytes();
       }
       /**
-       * <code>required bytes script_bytes = 3;</code>
-       *
        * <pre>
        * Script that contains the signatures/pubkeys.
        * </pre>
+       *
+       * <code>required bytes script_bytes = 3;</code>
        */
       public com.google.protobuf.ByteString getScriptBytes() {
-        return scriptBytes_;
+        return instance.getScriptBytes();
       }
       /**
-       * <code>required bytes script_bytes = 3;</code>
-       *
        * <pre>
        * Script that contains the signatures/pubkeys.
        * </pre>
+       *
+       * <code>required bytes script_bytes = 3;</code>
        */
       public Builder setScriptBytes(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        scriptBytes_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setScriptBytes(value);
         return this;
       }
       /**
-       * <code>required bytes script_bytes = 3;</code>
-       *
        * <pre>
        * Script that contains the signatures/pubkeys.
        * </pre>
+       *
+       * <code>required bytes script_bytes = 3;</code>
        */
       public Builder clearScriptBytes() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        scriptBytes_ = getDefaultInstance().getScriptBytes();
-        onChanged();
+        copyOnWrite();
+        instance.clearScriptBytes();
         return this;
       }
 
-      private int sequence_ ;
       /**
-       * <code>optional uint32 sequence = 4;</code>
-       *
        * <pre>
        * Sequence number.
        * </pre>
+       *
+       * <code>optional uint32 sequence = 4;</code>
        */
       public boolean hasSequence() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasSequence();
       }
       /**
-       * <code>optional uint32 sequence = 4;</code>
-       *
        * <pre>
        * Sequence number.
        * </pre>
+       *
+       * <code>optional uint32 sequence = 4;</code>
        */
       public int getSequence() {
-        return sequence_;
+        return instance.getSequence();
       }
       /**
-       * <code>optional uint32 sequence = 4;</code>
-       *
        * <pre>
        * Sequence number.
        * </pre>
+       *
+       * <code>optional uint32 sequence = 4;</code>
        */
       public Builder setSequence(int value) {
-        bitField0_ |= 0x00000008;
-        sequence_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSequence(value);
         return this;
       }
       /**
-       * <code>optional uint32 sequence = 4;</code>
-       *
        * <pre>
        * Sequence number.
        * </pre>
+       *
+       * <code>optional uint32 sequence = 4;</code>
        */
       public Builder clearSequence() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        sequence_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearSequence();
         return this;
       }
 
-      private long value_ ;
       /**
-       * <code>optional int64 value = 5;</code>
-       *
        * <pre>
        * Value of connected output, if known
        * </pre>
+       *
+       * <code>optional int64 value = 5;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasValue();
       }
       /**
-       * <code>optional int64 value = 5;</code>
-       *
        * <pre>
        * Value of connected output, if known
        * </pre>
+       *
+       * <code>optional int64 value = 5;</code>
        */
       public long getValue() {
-        return value_;
+        return instance.getValue();
       }
       /**
-       * <code>optional int64 value = 5;</code>
-       *
        * <pre>
        * Value of connected output, if known
        * </pre>
+       *
+       * <code>optional int64 value = 5;</code>
        */
       public Builder setValue(long value) {
-        bitField0_ |= 0x00000010;
-        value_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setValue(value);
         return this;
       }
       /**
-       * <code>optional int64 value = 5;</code>
-       *
        * <pre>
        * Value of connected output, if known
        * </pre>
+       *
+       * <code>optional int64 value = 5;</code>
        */
       public Builder clearValue() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        value_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearValue();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.TransactionInput)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.TransactionInput();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new TransactionInput(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasTransactionOutPointHash()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasTransactionOutPointIndex()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasScriptBytes()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.TransactionInput other = (org.floj.wallet.Protos.TransactionInput) arg1;
+          transactionOutPointHash_ = visitor.visitByteString(
+              hasTransactionOutPointHash(), transactionOutPointHash_,
+              other.hasTransactionOutPointHash(), other.transactionOutPointHash_);
+          transactionOutPointIndex_ = visitor.visitInt(
+              hasTransactionOutPointIndex(), transactionOutPointIndex_,
+              other.hasTransactionOutPointIndex(), other.transactionOutPointIndex_);
+          scriptBytes_ = visitor.visitByteString(
+              hasScriptBytes(), scriptBytes_,
+              other.hasScriptBytes(), other.scriptBytes_);
+          sequence_ = visitor.visitInt(
+              hasSequence(), sequence_,
+              other.hasSequence(), other.sequence_);
+          value_ = visitor.visitLong(
+              hasValue(), value_,
+              other.hasValue(), other.value_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  transactionOutPointHash_ = input.readBytes();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  transactionOutPointIndex_ = input.readUInt32();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  scriptBytes_ = input.readBytes();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000008;
+                  sequence_ = input.readUInt32();
+                  break;
+                }
+                case 40: {
+                  bitField0_ |= 0x00000010;
+                  value_ = input.readInt64();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.TransactionInput.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.TransactionInput)
+    private static final org.floj.wallet.Protos.TransactionInput DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new TransactionInput();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.TransactionInput getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<TransactionInput> PARSER;
+
+    public static com.google.protobuf.Parser<TransactionInput> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface TransactionOutputOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.TransactionOutput)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required int64 value = 1;</code>
@@ -5733,167 +5111,68 @@ public final class Protos {
     long getValue();
 
     /**
-     * <code>required bytes script_bytes = 2;</code>
-     *
      * <pre>
      * script of transaction output
      * </pre>
+     *
+     * <code>required bytes script_bytes = 2;</code>
      */
     boolean hasScriptBytes();
     /**
-     * <code>required bytes script_bytes = 2;</code>
-     *
      * <pre>
      * script of transaction output
      * </pre>
+     *
+     * <code>required bytes script_bytes = 2;</code>
      */
     com.google.protobuf.ByteString getScriptBytes();
 
     /**
-     * <code>optional bytes spent_by_transaction_hash = 3;</code>
-     *
      * <pre>
      * If spent, the hash of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional bytes spent_by_transaction_hash = 3;</code>
      */
     boolean hasSpentByTransactionHash();
     /**
-     * <code>optional bytes spent_by_transaction_hash = 3;</code>
-     *
      * <pre>
      * If spent, the hash of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional bytes spent_by_transaction_hash = 3;</code>
      */
     com.google.protobuf.ByteString getSpentByTransactionHash();
 
     /**
-     * <code>optional int32 spent_by_transaction_index = 4;</code>
-     *
      * <pre>
      * If spent, the index of the transaction input of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional int32 spent_by_transaction_index = 4;</code>
      */
     boolean hasSpentByTransactionIndex();
     /**
-     * <code>optional int32 spent_by_transaction_index = 4;</code>
-     *
      * <pre>
      * If spent, the index of the transaction input of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional int32 spent_by_transaction_index = 4;</code>
      */
     int getSpentByTransactionIndex();
   }
   /**
    * Protobuf type {@code wallet.TransactionOutput}
    */
-  public static final class TransactionOutput extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class TransactionOutput extends
+      com.google.protobuf.GeneratedMessageLite<
+          TransactionOutput, TransactionOutput.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.TransactionOutput)
       TransactionOutputOrBuilder {
-    // Use TransactionOutput.newBuilder() to construct.
-    private TransactionOutput(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private TransactionOutput() {
+      scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
+      spentByTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private TransactionOutput(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final TransactionOutput defaultInstance;
-    public static TransactionOutput getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public TransactionOutput getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private TransactionOutput(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              value_ = input.readInt64();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              scriptBytes_ = input.readBytes();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              spentByTransactionHash_ = input.readBytes();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              spentByTransactionIndex_ = input.readInt32();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionOutput_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionOutput_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.TransactionOutput.class, org.floj.wallet.Protos.TransactionOutput.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<TransactionOutput> PARSER =
-        new com.google.protobuf.AbstractParser<TransactionOutput>() {
-      public TransactionOutput parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TransactionOutput(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<TransactionOutput> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int VALUE_FIELD_NUMBER = 1;
     private long value_;
@@ -5909,103 +5188,164 @@ public final class Protos {
     public long getValue() {
       return value_;
     }
+    /**
+     * <code>required int64 value = 1;</code>
+     */
+    private void setValue(long value) {
+      bitField0_ |= 0x00000001;
+      value_ = value;
+    }
+    /**
+     * <code>required int64 value = 1;</code>
+     */
+    private void clearValue() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      value_ = 0L;
+    }
 
     public static final int SCRIPT_BYTES_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString scriptBytes_;
     /**
-     * <code>required bytes script_bytes = 2;</code>
-     *
      * <pre>
      * script of transaction output
      * </pre>
+     *
+     * <code>required bytes script_bytes = 2;</code>
      */
     public boolean hasScriptBytes() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required bytes script_bytes = 2;</code>
-     *
      * <pre>
      * script of transaction output
      * </pre>
+     *
+     * <code>required bytes script_bytes = 2;</code>
      */
     public com.google.protobuf.ByteString getScriptBytes() {
       return scriptBytes_;
+    }
+    /**
+     * <pre>
+     * script of transaction output
+     * </pre>
+     *
+     * <code>required bytes script_bytes = 2;</code>
+     */
+    private void setScriptBytes(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      scriptBytes_ = value;
+    }
+    /**
+     * <pre>
+     * script of transaction output
+     * </pre>
+     *
+     * <code>required bytes script_bytes = 2;</code>
+     */
+    private void clearScriptBytes() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      scriptBytes_ = getDefaultInstance().getScriptBytes();
     }
 
     public static final int SPENT_BY_TRANSACTION_HASH_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString spentByTransactionHash_;
     /**
-     * <code>optional bytes spent_by_transaction_hash = 3;</code>
-     *
      * <pre>
      * If spent, the hash of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional bytes spent_by_transaction_hash = 3;</code>
      */
     public boolean hasSpentByTransactionHash() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional bytes spent_by_transaction_hash = 3;</code>
-     *
      * <pre>
      * If spent, the hash of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional bytes spent_by_transaction_hash = 3;</code>
      */
     public com.google.protobuf.ByteString getSpentByTransactionHash() {
       return spentByTransactionHash_;
+    }
+    /**
+     * <pre>
+     * If spent, the hash of the transaction doing the spend.
+     * </pre>
+     *
+     * <code>optional bytes spent_by_transaction_hash = 3;</code>
+     */
+    private void setSpentByTransactionHash(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      spentByTransactionHash_ = value;
+    }
+    /**
+     * <pre>
+     * If spent, the hash of the transaction doing the spend.
+     * </pre>
+     *
+     * <code>optional bytes spent_by_transaction_hash = 3;</code>
+     */
+    private void clearSpentByTransactionHash() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      spentByTransactionHash_ = getDefaultInstance().getSpentByTransactionHash();
     }
 
     public static final int SPENT_BY_TRANSACTION_INDEX_FIELD_NUMBER = 4;
     private int spentByTransactionIndex_;
     /**
-     * <code>optional int32 spent_by_transaction_index = 4;</code>
-     *
      * <pre>
      * If spent, the index of the transaction input of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional int32 spent_by_transaction_index = 4;</code>
      */
     public boolean hasSpentByTransactionIndex() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional int32 spent_by_transaction_index = 4;</code>
-     *
      * <pre>
      * If spent, the index of the transaction input of the transaction doing the spend.
      * </pre>
+     *
+     * <code>optional int32 spent_by_transaction_index = 4;</code>
      */
     public int getSpentByTransactionIndex() {
       return spentByTransactionIndex_;
     }
-
-    private void initFields() {
-      value_ = 0L;
-      scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
-      spentByTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
-      spentByTransactionIndex_ = 0;
+    /**
+     * <pre>
+     * If spent, the index of the transaction input of the transaction doing the spend.
+     * </pre>
+     *
+     * <code>optional int32 spent_by_transaction_index = 4;</code>
+     */
+    private void setSpentByTransactionIndex(int value) {
+      bitField0_ |= 0x00000008;
+      spentByTransactionIndex_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasValue()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasScriptBytes()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * If spent, the index of the transaction input of the transaction doing the spend.
+     * </pre>
+     *
+     * <code>optional int32 spent_by_transaction_index = 4;</code>
+     */
+    private void clearSpentByTransactionIndex() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      spentByTransactionIndex_ = 0;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt64(1, value_);
       }
@@ -6018,10 +5358,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeInt32(4, spentByTransactionIndex_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -6043,506 +5382,476 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(4, spentByTransactionIndex_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionOutput parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.TransactionOutput prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code wallet.TransactionOutput}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.TransactionOutput, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.TransactionOutput)
         org.floj.wallet.Protos.TransactionOutputOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionOutput_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionOutput_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.TransactionOutput.class, org.floj.wallet.Protos.TransactionOutput.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.TransactionOutput.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        value_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        spentByTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        spentByTransactionIndex_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionOutput_descriptor;
-      }
-
-      public org.floj.wallet.Protos.TransactionOutput getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.TransactionOutput.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.TransactionOutput build() {
-        org.floj.wallet.Protos.TransactionOutput result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.TransactionOutput buildPartial() {
-        org.floj.wallet.Protos.TransactionOutput result = new org.floj.wallet.Protos.TransactionOutput(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.value_ = value_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.scriptBytes_ = scriptBytes_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.spentByTransactionHash_ = spentByTransactionHash_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.spentByTransactionIndex_ = spentByTransactionIndex_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.TransactionOutput) {
-          return mergeFrom((org.floj.wallet.Protos.TransactionOutput)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.TransactionOutput other) {
-        if (other == org.floj.wallet.Protos.TransactionOutput.getDefaultInstance()) return this;
-        if (other.hasValue()) {
-          setValue(other.getValue());
-        }
-        if (other.hasScriptBytes()) {
-          setScriptBytes(other.getScriptBytes());
-        }
-        if (other.hasSpentByTransactionHash()) {
-          setSpentByTransactionHash(other.getSpentByTransactionHash());
-        }
-        if (other.hasSpentByTransactionIndex()) {
-          setSpentByTransactionIndex(other.getSpentByTransactionIndex());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasValue()) {
-          
-          return false;
-        }
-        if (!hasScriptBytes()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.TransactionOutput parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.TransactionOutput) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private long value_ ;
       /**
        * <code>required int64 value = 1;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasValue();
       }
       /**
        * <code>required int64 value = 1;</code>
        */
       public long getValue() {
-        return value_;
+        return instance.getValue();
       }
       /**
        * <code>required int64 value = 1;</code>
        */
       public Builder setValue(long value) {
-        bitField0_ |= 0x00000001;
-        value_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setValue(value);
         return this;
       }
       /**
        * <code>required int64 value = 1;</code>
        */
       public Builder clearValue() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        value_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearValue();
         return this;
       }
 
-      private com.google.protobuf.ByteString scriptBytes_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes script_bytes = 2;</code>
-       *
        * <pre>
        * script of transaction output
        * </pre>
+       *
+       * <code>required bytes script_bytes = 2;</code>
        */
       public boolean hasScriptBytes() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasScriptBytes();
       }
       /**
-       * <code>required bytes script_bytes = 2;</code>
-       *
        * <pre>
        * script of transaction output
        * </pre>
+       *
+       * <code>required bytes script_bytes = 2;</code>
        */
       public com.google.protobuf.ByteString getScriptBytes() {
-        return scriptBytes_;
+        return instance.getScriptBytes();
       }
       /**
-       * <code>required bytes script_bytes = 2;</code>
-       *
        * <pre>
        * script of transaction output
        * </pre>
+       *
+       * <code>required bytes script_bytes = 2;</code>
        */
       public Builder setScriptBytes(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        scriptBytes_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setScriptBytes(value);
         return this;
       }
       /**
-       * <code>required bytes script_bytes = 2;</code>
-       *
        * <pre>
        * script of transaction output
        * </pre>
+       *
+       * <code>required bytes script_bytes = 2;</code>
        */
       public Builder clearScriptBytes() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        scriptBytes_ = getDefaultInstance().getScriptBytes();
-        onChanged();
+        copyOnWrite();
+        instance.clearScriptBytes();
         return this;
       }
 
-      private com.google.protobuf.ByteString spentByTransactionHash_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes spent_by_transaction_hash = 3;</code>
-       *
        * <pre>
        * If spent, the hash of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional bytes spent_by_transaction_hash = 3;</code>
        */
       public boolean hasSpentByTransactionHash() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasSpentByTransactionHash();
       }
       /**
-       * <code>optional bytes spent_by_transaction_hash = 3;</code>
-       *
        * <pre>
        * If spent, the hash of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional bytes spent_by_transaction_hash = 3;</code>
        */
       public com.google.protobuf.ByteString getSpentByTransactionHash() {
-        return spentByTransactionHash_;
+        return instance.getSpentByTransactionHash();
       }
       /**
-       * <code>optional bytes spent_by_transaction_hash = 3;</code>
-       *
        * <pre>
        * If spent, the hash of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional bytes spent_by_transaction_hash = 3;</code>
        */
       public Builder setSpentByTransactionHash(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        spentByTransactionHash_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSpentByTransactionHash(value);
         return this;
       }
       /**
-       * <code>optional bytes spent_by_transaction_hash = 3;</code>
-       *
        * <pre>
        * If spent, the hash of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional bytes spent_by_transaction_hash = 3;</code>
        */
       public Builder clearSpentByTransactionHash() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        spentByTransactionHash_ = getDefaultInstance().getSpentByTransactionHash();
-        onChanged();
+        copyOnWrite();
+        instance.clearSpentByTransactionHash();
         return this;
       }
 
-      private int spentByTransactionIndex_ ;
       /**
-       * <code>optional int32 spent_by_transaction_index = 4;</code>
-       *
        * <pre>
        * If spent, the index of the transaction input of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional int32 spent_by_transaction_index = 4;</code>
        */
       public boolean hasSpentByTransactionIndex() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasSpentByTransactionIndex();
       }
       /**
-       * <code>optional int32 spent_by_transaction_index = 4;</code>
-       *
        * <pre>
        * If spent, the index of the transaction input of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional int32 spent_by_transaction_index = 4;</code>
        */
       public int getSpentByTransactionIndex() {
-        return spentByTransactionIndex_;
+        return instance.getSpentByTransactionIndex();
       }
       /**
-       * <code>optional int32 spent_by_transaction_index = 4;</code>
-       *
        * <pre>
        * If spent, the index of the transaction input of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional int32 spent_by_transaction_index = 4;</code>
        */
       public Builder setSpentByTransactionIndex(int value) {
-        bitField0_ |= 0x00000008;
-        spentByTransactionIndex_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSpentByTransactionIndex(value);
         return this;
       }
       /**
-       * <code>optional int32 spent_by_transaction_index = 4;</code>
-       *
        * <pre>
        * If spent, the index of the transaction input of the transaction doing the spend.
        * </pre>
+       *
+       * <code>optional int32 spent_by_transaction_index = 4;</code>
        */
       public Builder clearSpentByTransactionIndex() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        spentByTransactionIndex_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearSpentByTransactionIndex();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.TransactionOutput)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.TransactionOutput();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new TransactionOutput(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasValue()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasScriptBytes()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.TransactionOutput other = (org.floj.wallet.Protos.TransactionOutput) arg1;
+          value_ = visitor.visitLong(
+              hasValue(), value_,
+              other.hasValue(), other.value_);
+          scriptBytes_ = visitor.visitByteString(
+              hasScriptBytes(), scriptBytes_,
+              other.hasScriptBytes(), other.scriptBytes_);
+          spentByTransactionHash_ = visitor.visitByteString(
+              hasSpentByTransactionHash(), spentByTransactionHash_,
+              other.hasSpentByTransactionHash(), other.spentByTransactionHash_);
+          spentByTransactionIndex_ = visitor.visitInt(
+              hasSpentByTransactionIndex(), spentByTransactionIndex_,
+              other.hasSpentByTransactionIndex(), other.spentByTransactionIndex_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  value_ = input.readInt64();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  scriptBytes_ = input.readBytes();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  spentByTransactionHash_ = input.readBytes();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000008;
+                  spentByTransactionIndex_ = input.readInt32();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.TransactionOutput.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.TransactionOutput)
+    private static final org.floj.wallet.Protos.TransactionOutput DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new TransactionOutput();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.TransactionOutput getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<TransactionOutput> PARSER;
+
+    public static com.google.protobuf.Parser<TransactionOutput> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface TransactionConfidenceOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.TransactionConfidence)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-     *
      * <pre>
      * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
      */
     boolean hasType();
     /**
-     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-     *
      * <pre>
      * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
      */
     org.floj.wallet.Protos.TransactionConfidence.Type getType();
 
     /**
-     * <code>optional int32 appeared_at_height = 2;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the chain height at which the transaction was included.
      * </pre>
+     *
+     * <code>optional int32 appeared_at_height = 2;</code>
      */
     boolean hasAppearedAtHeight();
     /**
-     * <code>optional int32 appeared_at_height = 2;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the chain height at which the transaction was included.
      * </pre>
+     *
+     * <code>optional int32 appeared_at_height = 2;</code>
      */
     int getAppearedAtHeight();
 
     /**
-     * <code>optional bytes overriding_transaction = 3;</code>
-     *
      * <pre>
      * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
      * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
      * bother to track them all, just the first. This only makes sense if type = DEAD.
      * </pre>
+     *
+     * <code>optional bytes overriding_transaction = 3;</code>
      */
     boolean hasOverridingTransaction();
     /**
-     * <code>optional bytes overriding_transaction = 3;</code>
-     *
      * <pre>
      * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
      * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
      * bother to track them all, just the first. This only makes sense if type = DEAD.
      * </pre>
+     *
+     * <code>optional bytes overriding_transaction = 3;</code>
      */
     com.google.protobuf.ByteString getOverridingTransaction();
 
     /**
-     * <code>optional int32 depth = 4;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the depth of the transaction in the blockchain.
      * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
      * </pre>
+     *
+     * <code>optional int32 depth = 4;</code>
      */
     boolean hasDepth();
     /**
-     * <code>optional int32 depth = 4;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the depth of the transaction in the blockchain.
      * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
      * </pre>
+     *
+     * <code>optional int32 depth = 4;</code>
      */
     int getDepth();
 
@@ -6559,31 +5868,21 @@ public final class Protos {
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
      */
     int getBroadcastByCount();
-    /**
-     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.PeerAddressOrBuilder> 
-        getBroadcastByOrBuilderList();
-    /**
-     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-     */
-    org.floj.wallet.Protos.PeerAddressOrBuilder getBroadcastByOrBuilder(
-        int index);
 
     /**
-     * <code>optional int64 last_broadcasted_at = 8;</code>
-     *
      * <pre>
      * Millis since epoch the transaction was last announced to us.
      * </pre>
+     *
+     * <code>optional int64 last_broadcasted_at = 8;</code>
      */
     boolean hasLastBroadcastedAt();
     /**
-     * <code>optional int64 last_broadcasted_at = 8;</code>
-     *
      * <pre>
      * Millis since epoch the transaction was last announced to us.
      * </pre>
+     *
+     * <code>optional int64 last_broadcasted_at = 8;</code>
      */
     long getLastBroadcastedAt();
 
@@ -6597,264 +5896,142 @@ public final class Protos {
     org.floj.wallet.Protos.TransactionConfidence.Source getSource();
   }
   /**
-   * Protobuf type {@code wallet.TransactionConfidence}
-   *
    * <pre>
    **
    * A description of the confidence we have that a transaction cannot be reversed in the future.
    * Parsing should be lenient, since this could change for different applications yet we should
    * maintain backward compatibility.
    * </pre>
+   *
+   * Protobuf type {@code wallet.TransactionConfidence}
    */
-  public static final class TransactionConfidence extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class TransactionConfidence extends
+      com.google.protobuf.GeneratedMessageLite<
+          TransactionConfidence, TransactionConfidence.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.TransactionConfidence)
       TransactionConfidenceOrBuilder {
-    // Use TransactionConfidence.newBuilder() to construct.
-    private TransactionConfidence(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private TransactionConfidence() {
+      overridingTransaction_ = com.google.protobuf.ByteString.EMPTY;
+      broadcastBy_ = emptyProtobufList();
     }
-    private TransactionConfidence(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final TransactionConfidence defaultInstance;
-    public static TransactionConfidence getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public TransactionConfidence getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private TransactionConfidence(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              int rawValue = input.readEnum();
-              org.floj.wallet.Protos.TransactionConfidence.Type value = org.floj.wallet.Protos.TransactionConfidence.Type.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(1, rawValue);
-              } else {
-                bitField0_ |= 0x00000001;
-                type_ = value;
-              }
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              appearedAtHeight_ = input.readInt32();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              overridingTransaction_ = input.readBytes();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              depth_ = input.readInt32();
-              break;
-            }
-            case 50: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                broadcastBy_ = new java.util.ArrayList<org.floj.wallet.Protos.PeerAddress>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              broadcastBy_.add(input.readMessage(org.floj.wallet.Protos.PeerAddress.PARSER, extensionRegistry));
-              break;
-            }
-            case 56: {
-              int rawValue = input.readEnum();
-              org.floj.wallet.Protos.TransactionConfidence.Source value = org.floj.wallet.Protos.TransactionConfidence.Source.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(7, rawValue);
-              } else {
-                bitField0_ |= 0x00000020;
-                source_ = value;
-              }
-              break;
-            }
-            case 64: {
-              bitField0_ |= 0x00000010;
-              lastBroadcastedAt_ = input.readInt64();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          broadcastBy_ = java.util.Collections.unmodifiableList(broadcastBy_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionConfidence_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionConfidence_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.TransactionConfidence.class, org.floj.wallet.Protos.TransactionConfidence.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<TransactionConfidence> PARSER =
-        new com.google.protobuf.AbstractParser<TransactionConfidence>() {
-      public TransactionConfidence parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TransactionConfidence(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<TransactionConfidence> getParserForType() {
-      return PARSER;
-    }
-
     /**
      * Protobuf enum {@code wallet.TransactionConfidence.Type}
      */
     public enum Type
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
-       * <code>UNKNOWN = 0;</code>
-       *
        * <pre>
        * See TransactionConfidence.java for a more thorough explanation of these types.
        * </pre>
-       */
-      UNKNOWN(0, 0),
-      /**
-       * <code>BUILDING = 1;</code>
        *
+       * <code>UNKNOWN = 0;</code>
+       */
+      UNKNOWN(0),
+      /**
        * <pre>
        * In best chain.  If and only if appeared_at_height is present.
        * </pre>
-       */
-      BUILDING(1, 1),
-      /**
-       * <code>PENDING = 2;</code>
        *
+       * <code>BUILDING = 1;</code>
+       */
+      BUILDING(1),
+      /**
        * <pre>
        * Unconfirmed and sitting in the networks memory pools, waiting to be included in the chain.
        * </pre>
-       */
-      PENDING(2, 2),
-      /**
-       * <code>NOT_IN_BEST_CHAIN = 3;</code>
        *
+       * <code>PENDING = 2;</code>
+       */
+      PENDING(2),
+      /**
        * <pre>
        * Deprecated: equivalent to PENDING.
        * </pre>
-       */
-      NOT_IN_BEST_CHAIN(3, 3),
-      /**
-       * <code>DEAD = 4;</code>
        *
+       * <code>NOT_IN_BEST_CHAIN = 3;</code>
+       */
+      NOT_IN_BEST_CHAIN(3),
+      /**
        * <pre>
        * Either if overriding_transaction is present or transaction is dead coinbase.
        * </pre>
-       */
-      DEAD(4, 4),
-      /**
-       * <code>IN_CONFLICT = 5;</code>
        *
+       * <code>DEAD = 4;</code>
+       */
+      DEAD(4),
+      /**
        * <pre>
        * There is another transaction spending one of this transaction inputs.
        * </pre>
+       *
+       * <code>IN_CONFLICT = 5;</code>
        */
-      IN_CONFLICT(5, 5),
+      IN_CONFLICT(5),
       ;
 
       /**
-       * <code>UNKNOWN = 0;</code>
-       *
        * <pre>
        * See TransactionConfidence.java for a more thorough explanation of these types.
        * </pre>
+       *
+       * <code>UNKNOWN = 0;</code>
        */
       public static final int UNKNOWN_VALUE = 0;
       /**
-       * <code>BUILDING = 1;</code>
-       *
        * <pre>
        * In best chain.  If and only if appeared_at_height is present.
        * </pre>
+       *
+       * <code>BUILDING = 1;</code>
        */
       public static final int BUILDING_VALUE = 1;
       /**
-       * <code>PENDING = 2;</code>
-       *
        * <pre>
        * Unconfirmed and sitting in the networks memory pools, waiting to be included in the chain.
        * </pre>
+       *
+       * <code>PENDING = 2;</code>
        */
       public static final int PENDING_VALUE = 2;
       /**
-       * <code>NOT_IN_BEST_CHAIN = 3;</code>
-       *
        * <pre>
        * Deprecated: equivalent to PENDING.
        * </pre>
+       *
+       * <code>NOT_IN_BEST_CHAIN = 3;</code>
        */
       public static final int NOT_IN_BEST_CHAIN_VALUE = 3;
       /**
-       * <code>DEAD = 4;</code>
-       *
        * <pre>
        * Either if overriding_transaction is present or transaction is dead coinbase.
        * </pre>
+       *
+       * <code>DEAD = 4;</code>
        */
       public static final int DEAD_VALUE = 4;
       /**
-       * <code>IN_CONFLICT = 5;</code>
-       *
        * <pre>
        * There is another transaction spending one of this transaction inputs.
        * </pre>
+       *
+       * <code>IN_CONFLICT = 5;</code>
        */
       public static final int IN_CONFLICT_VALUE = 5;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static Type valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static Type forNumber(int value) {
         switch (value) {
           case 0: return UNKNOWN;
           case 1: return BUILDING;
@@ -6870,43 +6047,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<Type>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          Type> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Type>() {
               public Type findValueByNumber(int number) {
-                return Type.valueOf(number);
+                return Type.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.TransactionConfidence.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final Type[] VALUES = values();
-
-      public static Type valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private Type(int index, int value) {
-        this.index = index;
+      private Type(int value) {
         this.value = value;
       }
 
@@ -6914,69 +6065,79 @@ public final class Protos {
     }
 
     /**
-     * Protobuf enum {@code wallet.TransactionConfidence.Source}
-     *
      * <pre>
      * Where did we get this transaction from? Knowing the source may help us to risk analyze pending transactions.
      * </pre>
+     *
+     * Protobuf enum {@code wallet.TransactionConfidence.Source}
      */
     public enum Source
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
-       * <code>SOURCE_UNKNOWN = 0;</code>
-       *
        * <pre>
        * We don't know where it came from, or this is a wallet from the future.
        * </pre>
-       */
-      SOURCE_UNKNOWN(0, 0),
-      /**
-       * <code>SOURCE_NETWORK = 1;</code>
        *
+       * <code>SOURCE_UNKNOWN = 0;</code>
+       */
+      SOURCE_UNKNOWN(0),
+      /**
        * <pre>
        * We received it from a network broadcast. This is the normal way to get payments.
        * </pre>
-       */
-      SOURCE_NETWORK(1, 1),
-      /**
-       * <code>SOURCE_SELF = 2;</code>
        *
+       * <code>SOURCE_NETWORK = 1;</code>
+       */
+      SOURCE_NETWORK(1),
+      /**
        * <pre>
        * We made it ourselves, so we know it should be valid.
        * </pre>
+       *
+       * <code>SOURCE_SELF = 2;</code>
        */
-      SOURCE_SELF(2, 2),
+      SOURCE_SELF(2),
       ;
 
       /**
-       * <code>SOURCE_UNKNOWN = 0;</code>
-       *
        * <pre>
        * We don't know where it came from, or this is a wallet from the future.
        * </pre>
+       *
+       * <code>SOURCE_UNKNOWN = 0;</code>
        */
       public static final int SOURCE_UNKNOWN_VALUE = 0;
       /**
-       * <code>SOURCE_NETWORK = 1;</code>
-       *
        * <pre>
        * We received it from a network broadcast. This is the normal way to get payments.
        * </pre>
+       *
+       * <code>SOURCE_NETWORK = 1;</code>
        */
       public static final int SOURCE_NETWORK_VALUE = 1;
       /**
-       * <code>SOURCE_SELF = 2;</code>
-       *
        * <pre>
        * We made it ourselves, so we know it should be valid.
        * </pre>
+       *
+       * <code>SOURCE_SELF = 2;</code>
        */
       public static final int SOURCE_SELF_VALUE = 2;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static Source valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static Source forNumber(int value) {
         switch (value) {
           case 0: return SOURCE_UNKNOWN;
           case 1: return SOURCE_NETWORK;
@@ -6989,43 +6150,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<Source>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          Source> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Source>() {
               public Source findValueByNumber(int number) {
-                return Source.valueOf(number);
+                return Source.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.TransactionConfidence.getDescriptor().getEnumTypes().get(1);
-      }
-
-      private static final Source[] VALUES = values();
-
-      public static Source valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private Source(int index, int value) {
-        this.index = index;
+      private Source(int value) {
         this.value = value;
       }
 
@@ -7034,105 +6169,206 @@ public final class Protos {
 
     private int bitField0_;
     public static final int TYPE_FIELD_NUMBER = 1;
-    private org.floj.wallet.Protos.TransactionConfidence.Type type_;
+    private int type_;
     /**
-     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-     *
      * <pre>
      * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
      */
     public boolean hasType() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-     *
      * <pre>
      * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
      */
     public org.floj.wallet.Protos.TransactionConfidence.Type getType() {
-      return type_;
+      org.floj.wallet.Protos.TransactionConfidence.Type result = org.floj.wallet.Protos.TransactionConfidence.Type.forNumber(type_);
+      return result == null ? org.floj.wallet.Protos.TransactionConfidence.Type.UNKNOWN : result;
+    }
+    /**
+     * <pre>
+     * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
+     * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
+     */
+    private void setType(org.floj.wallet.Protos.TransactionConfidence.Type value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      bitField0_ |= 0x00000001;
+      type_ = value.getNumber();
+    }
+    /**
+     * <pre>
+     * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
+     * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
+     */
+    private void clearType() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      type_ = 0;
     }
 
     public static final int APPEARED_AT_HEIGHT_FIELD_NUMBER = 2;
     private int appearedAtHeight_;
     /**
-     * <code>optional int32 appeared_at_height = 2;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the chain height at which the transaction was included.
      * </pre>
+     *
+     * <code>optional int32 appeared_at_height = 2;</code>
      */
     public boolean hasAppearedAtHeight() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional int32 appeared_at_height = 2;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the chain height at which the transaction was included.
      * </pre>
+     *
+     * <code>optional int32 appeared_at_height = 2;</code>
      */
     public int getAppearedAtHeight() {
       return appearedAtHeight_;
+    }
+    /**
+     * <pre>
+     * If type == BUILDING then this is the chain height at which the transaction was included.
+     * </pre>
+     *
+     * <code>optional int32 appeared_at_height = 2;</code>
+     */
+    private void setAppearedAtHeight(int value) {
+      bitField0_ |= 0x00000002;
+      appearedAtHeight_ = value;
+    }
+    /**
+     * <pre>
+     * If type == BUILDING then this is the chain height at which the transaction was included.
+     * </pre>
+     *
+     * <code>optional int32 appeared_at_height = 2;</code>
+     */
+    private void clearAppearedAtHeight() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      appearedAtHeight_ = 0;
     }
 
     public static final int OVERRIDING_TRANSACTION_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString overridingTransaction_;
     /**
-     * <code>optional bytes overriding_transaction = 3;</code>
-     *
      * <pre>
      * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
      * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
      * bother to track them all, just the first. This only makes sense if type = DEAD.
      * </pre>
+     *
+     * <code>optional bytes overriding_transaction = 3;</code>
      */
     public boolean hasOverridingTransaction() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional bytes overriding_transaction = 3;</code>
-     *
      * <pre>
      * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
      * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
      * bother to track them all, just the first. This only makes sense if type = DEAD.
      * </pre>
+     *
+     * <code>optional bytes overriding_transaction = 3;</code>
      */
     public com.google.protobuf.ByteString getOverridingTransaction() {
       return overridingTransaction_;
+    }
+    /**
+     * <pre>
+     * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
+     * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
+     * bother to track them all, just the first. This only makes sense if type = DEAD.
+     * </pre>
+     *
+     * <code>optional bytes overriding_transaction = 3;</code>
+     */
+    private void setOverridingTransaction(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      overridingTransaction_ = value;
+    }
+    /**
+     * <pre>
+     * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
+     * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
+     * bother to track them all, just the first. This only makes sense if type = DEAD.
+     * </pre>
+     *
+     * <code>optional bytes overriding_transaction = 3;</code>
+     */
+    private void clearOverridingTransaction() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      overridingTransaction_ = getDefaultInstance().getOverridingTransaction();
     }
 
     public static final int DEPTH_FIELD_NUMBER = 4;
     private int depth_;
     /**
-     * <code>optional int32 depth = 4;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the depth of the transaction in the blockchain.
      * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
      * </pre>
+     *
+     * <code>optional int32 depth = 4;</code>
      */
     public boolean hasDepth() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional int32 depth = 4;</code>
-     *
      * <pre>
      * If type == BUILDING then this is the depth of the transaction in the blockchain.
      * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
      * </pre>
+     *
+     * <code>optional int32 depth = 4;</code>
      */
     public int getDepth() {
       return depth_;
     }
+    /**
+     * <pre>
+     * If type == BUILDING then this is the depth of the transaction in the blockchain.
+     * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
+     * </pre>
+     *
+     * <code>optional int32 depth = 4;</code>
+     */
+    private void setDepth(int value) {
+      bitField0_ |= 0x00000008;
+      depth_ = value;
+    }
+    /**
+     * <pre>
+     * If type == BUILDING then this is the depth of the transaction in the blockchain.
+     * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
+     * </pre>
+     *
+     * <code>optional int32 depth = 4;</code>
+     */
+    private void clearDepth() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      depth_ = 0;
+    }
 
     public static final int BROADCAST_BY_FIELD_NUMBER = 6;
-    private java.util.List<org.floj.wallet.Protos.PeerAddress> broadcastBy_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.PeerAddress> broadcastBy_;
     /**
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
      */
@@ -7165,32 +6401,139 @@ public final class Protos {
         int index) {
       return broadcastBy_.get(index);
     }
+    private void ensureBroadcastByIsMutable() {
+      if (!broadcastBy_.isModifiable()) {
+        broadcastBy_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(broadcastBy_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void setBroadcastBy(
+        int index, org.floj.wallet.Protos.PeerAddress value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureBroadcastByIsMutable();
+      broadcastBy_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void setBroadcastBy(
+        int index, org.floj.wallet.Protos.PeerAddress.Builder builderForValue) {
+      ensureBroadcastByIsMutable();
+      broadcastBy_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void addBroadcastBy(org.floj.wallet.Protos.PeerAddress value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureBroadcastByIsMutable();
+      broadcastBy_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void addBroadcastBy(
+        int index, org.floj.wallet.Protos.PeerAddress value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureBroadcastByIsMutable();
+      broadcastBy_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void addBroadcastBy(
+        org.floj.wallet.Protos.PeerAddress.Builder builderForValue) {
+      ensureBroadcastByIsMutable();
+      broadcastBy_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void addBroadcastBy(
+        int index, org.floj.wallet.Protos.PeerAddress.Builder builderForValue) {
+      ensureBroadcastByIsMutable();
+      broadcastBy_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void addAllBroadcastBy(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.PeerAddress> values) {
+      ensureBroadcastByIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, broadcastBy_);
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void clearBroadcastBy() {
+      broadcastBy_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
+     */
+    private void removeBroadcastBy(int index) {
+      ensureBroadcastByIsMutable();
+      broadcastBy_.remove(index);
+    }
 
     public static final int LAST_BROADCASTED_AT_FIELD_NUMBER = 8;
     private long lastBroadcastedAt_;
     /**
-     * <code>optional int64 last_broadcasted_at = 8;</code>
-     *
      * <pre>
      * Millis since epoch the transaction was last announced to us.
      * </pre>
+     *
+     * <code>optional int64 last_broadcasted_at = 8;</code>
      */
     public boolean hasLastBroadcastedAt() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional int64 last_broadcasted_at = 8;</code>
-     *
      * <pre>
      * Millis since epoch the transaction was last announced to us.
      * </pre>
+     *
+     * <code>optional int64 last_broadcasted_at = 8;</code>
      */
     public long getLastBroadcastedAt() {
       return lastBroadcastedAt_;
     }
+    /**
+     * <pre>
+     * Millis since epoch the transaction was last announced to us.
+     * </pre>
+     *
+     * <code>optional int64 last_broadcasted_at = 8;</code>
+     */
+    private void setLastBroadcastedAt(long value) {
+      bitField0_ |= 0x00000010;
+      lastBroadcastedAt_ = value;
+    }
+    /**
+     * <pre>
+     * Millis since epoch the transaction was last announced to us.
+     * </pre>
+     *
+     * <code>optional int64 last_broadcasted_at = 8;</code>
+     */
+    private void clearLastBroadcastedAt() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      lastBroadcastedAt_ = 0L;
+    }
 
     public static final int SOURCE_FIELD_NUMBER = 7;
-    private org.floj.wallet.Protos.TransactionConfidence.Source source_;
+    private int source_;
     /**
      * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
      */
@@ -7201,39 +6544,31 @@ public final class Protos {
      * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
      */
     public org.floj.wallet.Protos.TransactionConfidence.Source getSource() {
-      return source_;
+      org.floj.wallet.Protos.TransactionConfidence.Source result = org.floj.wallet.Protos.TransactionConfidence.Source.forNumber(source_);
+      return result == null ? org.floj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN : result;
     }
-
-    private void initFields() {
-      type_ = org.floj.wallet.Protos.TransactionConfidence.Type.UNKNOWN;
-      appearedAtHeight_ = 0;
-      overridingTransaction_ = com.google.protobuf.ByteString.EMPTY;
-      depth_ = 0;
-      broadcastBy_ = java.util.Collections.emptyList();
-      lastBroadcastedAt_ = 0L;
-      source_ = org.floj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      for (int i = 0; i < getBroadcastByCount(); i++) {
-        if (!getBroadcastBy(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
+    /**
+     * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
+     */
+    private void setSource(org.floj.wallet.Protos.TransactionConfidence.Source value) {
+      if (value == null) {
+        throw new NullPointerException();
       }
-      memoizedIsInitialized = 1;
-      return true;
+      bitField0_ |= 0x00000020;
+      source_ = value.getNumber();
+    }
+    /**
+     * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
+     */
+    private void clearSource() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      source_ = 0;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, type_.getNumber());
+        output.writeEnum(1, type_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeInt32(2, appearedAtHeight_);
@@ -7248,15 +6583,14 @@ public final class Protos {
         output.writeMessage(6, broadcastBy_.get(i));
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        output.writeEnum(7, source_.getNumber());
+        output.writeEnum(7, source_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeInt64(8, lastBroadcastedAt_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -7264,7 +6598,7 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, type_.getNumber());
+          .computeEnumSize(1, type_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -7284,576 +6618,323 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(7, source_.getNumber());
+          .computeEnumSize(7, source_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(8, lastBroadcastedAt_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionConfidence parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.TransactionConfidence prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.TransactionConfidence}
-     *
      * <pre>
      **
      * A description of the confidence we have that a transaction cannot be reversed in the future.
      * Parsing should be lenient, since this could change for different applications yet we should
      * maintain backward compatibility.
      * </pre>
+     *
+     * Protobuf type {@code wallet.TransactionConfidence}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.TransactionConfidence, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.TransactionConfidence)
         org.floj.wallet.Protos.TransactionConfidenceOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionConfidence_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionConfidence_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.TransactionConfidence.class, org.floj.wallet.Protos.TransactionConfidence.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.TransactionConfidence.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getBroadcastByFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        type_ = org.floj.wallet.Protos.TransactionConfidence.Type.UNKNOWN;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        appearedAtHeight_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        overridingTransaction_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        depth_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        if (broadcastByBuilder_ == null) {
-          broadcastBy_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        } else {
-          broadcastByBuilder_.clear();
-        }
-        lastBroadcastedAt_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
-        source_ = org.floj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
-        bitField0_ = (bitField0_ & ~0x00000040);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionConfidence_descriptor;
-      }
-
-      public org.floj.wallet.Protos.TransactionConfidence getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.TransactionConfidence build() {
-        org.floj.wallet.Protos.TransactionConfidence result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.TransactionConfidence buildPartial() {
-        org.floj.wallet.Protos.TransactionConfidence result = new org.floj.wallet.Protos.TransactionConfidence(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.type_ = type_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.appearedAtHeight_ = appearedAtHeight_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.overridingTransaction_ = overridingTransaction_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.depth_ = depth_;
-        if (broadcastByBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010)) {
-            broadcastBy_ = java.util.Collections.unmodifiableList(broadcastBy_);
-            bitField0_ = (bitField0_ & ~0x00000010);
-          }
-          result.broadcastBy_ = broadcastBy_;
-        } else {
-          result.broadcastBy_ = broadcastByBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.lastBroadcastedAt_ = lastBroadcastedAt_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        result.source_ = source_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.TransactionConfidence) {
-          return mergeFrom((org.floj.wallet.Protos.TransactionConfidence)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.TransactionConfidence other) {
-        if (other == org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance()) return this;
-        if (other.hasType()) {
-          setType(other.getType());
-        }
-        if (other.hasAppearedAtHeight()) {
-          setAppearedAtHeight(other.getAppearedAtHeight());
-        }
-        if (other.hasOverridingTransaction()) {
-          setOverridingTransaction(other.getOverridingTransaction());
-        }
-        if (other.hasDepth()) {
-          setDepth(other.getDepth());
-        }
-        if (broadcastByBuilder_ == null) {
-          if (!other.broadcastBy_.isEmpty()) {
-            if (broadcastBy_.isEmpty()) {
-              broadcastBy_ = other.broadcastBy_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-            } else {
-              ensureBroadcastByIsMutable();
-              broadcastBy_.addAll(other.broadcastBy_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.broadcastBy_.isEmpty()) {
-            if (broadcastByBuilder_.isEmpty()) {
-              broadcastByBuilder_.dispose();
-              broadcastByBuilder_ = null;
-              broadcastBy_ = other.broadcastBy_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-              broadcastByBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getBroadcastByFieldBuilder() : null;
-            } else {
-              broadcastByBuilder_.addAllMessages(other.broadcastBy_);
-            }
-          }
-        }
-        if (other.hasLastBroadcastedAt()) {
-          setLastBroadcastedAt(other.getLastBroadcastedAt());
-        }
-        if (other.hasSource()) {
-          setSource(other.getSource());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        for (int i = 0; i < getBroadcastByCount(); i++) {
-          if (!getBroadcastBy(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.TransactionConfidence parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.TransactionConfidence) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private org.floj.wallet.Protos.TransactionConfidence.Type type_ = org.floj.wallet.Protos.TransactionConfidence.Type.UNKNOWN;
       /**
-       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-       *
        * <pre>
        * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
        */
       public boolean hasType() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasType();
       }
       /**
-       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-       *
        * <pre>
        * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
        */
       public org.floj.wallet.Protos.TransactionConfidence.Type getType() {
-        return type_;
+        return instance.getType();
       }
       /**
-       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-       *
        * <pre>
        * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
        */
       public Builder setType(org.floj.wallet.Protos.TransactionConfidence.Type value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        type_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setType(value);
         return this;
       }
       /**
-       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
-       *
        * <pre>
        * This is optional in case we add confidence types to prevent parse errors - backwards compatible.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence.Type type = 1;</code>
        */
       public Builder clearType() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        type_ = org.floj.wallet.Protos.TransactionConfidence.Type.UNKNOWN;
-        onChanged();
+        copyOnWrite();
+        instance.clearType();
         return this;
       }
 
-      private int appearedAtHeight_ ;
       /**
-       * <code>optional int32 appeared_at_height = 2;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the chain height at which the transaction was included.
        * </pre>
+       *
+       * <code>optional int32 appeared_at_height = 2;</code>
        */
       public boolean hasAppearedAtHeight() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasAppearedAtHeight();
       }
       /**
-       * <code>optional int32 appeared_at_height = 2;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the chain height at which the transaction was included.
        * </pre>
+       *
+       * <code>optional int32 appeared_at_height = 2;</code>
        */
       public int getAppearedAtHeight() {
-        return appearedAtHeight_;
+        return instance.getAppearedAtHeight();
       }
       /**
-       * <code>optional int32 appeared_at_height = 2;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the chain height at which the transaction was included.
        * </pre>
+       *
+       * <code>optional int32 appeared_at_height = 2;</code>
        */
       public Builder setAppearedAtHeight(int value) {
-        bitField0_ |= 0x00000002;
-        appearedAtHeight_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setAppearedAtHeight(value);
         return this;
       }
       /**
-       * <code>optional int32 appeared_at_height = 2;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the chain height at which the transaction was included.
        * </pre>
+       *
+       * <code>optional int32 appeared_at_height = 2;</code>
        */
       public Builder clearAppearedAtHeight() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        appearedAtHeight_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearAppearedAtHeight();
         return this;
       }
 
-      private com.google.protobuf.ByteString overridingTransaction_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes overriding_transaction = 3;</code>
-       *
        * <pre>
        * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
        * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
        * bother to track them all, just the first. This only makes sense if type = DEAD.
        * </pre>
+       *
+       * <code>optional bytes overriding_transaction = 3;</code>
        */
       public boolean hasOverridingTransaction() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasOverridingTransaction();
       }
       /**
-       * <code>optional bytes overriding_transaction = 3;</code>
-       *
        * <pre>
        * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
        * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
        * bother to track them all, just the first. This only makes sense if type = DEAD.
        * </pre>
+       *
+       * <code>optional bytes overriding_transaction = 3;</code>
        */
       public com.google.protobuf.ByteString getOverridingTransaction() {
-        return overridingTransaction_;
+        return instance.getOverridingTransaction();
       }
       /**
-       * <code>optional bytes overriding_transaction = 3;</code>
-       *
        * <pre>
        * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
        * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
        * bother to track them all, just the first. This only makes sense if type = DEAD.
        * </pre>
+       *
+       * <code>optional bytes overriding_transaction = 3;</code>
        */
       public Builder setOverridingTransaction(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        overridingTransaction_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setOverridingTransaction(value);
         return this;
       }
       /**
-       * <code>optional bytes overriding_transaction = 3;</code>
-       *
        * <pre>
        * If set, hash of the transaction that double spent this one into oblivion. A transaction can be double spent by
        * multiple transactions in the case of several inputs being re-spent by several transactions but we don't
        * bother to track them all, just the first. This only makes sense if type = DEAD.
        * </pre>
+       *
+       * <code>optional bytes overriding_transaction = 3;</code>
        */
       public Builder clearOverridingTransaction() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        overridingTransaction_ = getDefaultInstance().getOverridingTransaction();
-        onChanged();
+        copyOnWrite();
+        instance.clearOverridingTransaction();
         return this;
       }
 
-      private int depth_ ;
       /**
-       * <code>optional int32 depth = 4;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the depth of the transaction in the blockchain.
        * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
        * </pre>
+       *
+       * <code>optional int32 depth = 4;</code>
        */
       public boolean hasDepth() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasDepth();
       }
       /**
-       * <code>optional int32 depth = 4;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the depth of the transaction in the blockchain.
        * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
        * </pre>
+       *
+       * <code>optional int32 depth = 4;</code>
        */
       public int getDepth() {
-        return depth_;
+        return instance.getDepth();
       }
       /**
-       * <code>optional int32 depth = 4;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the depth of the transaction in the blockchain.
        * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
        * </pre>
+       *
+       * <code>optional int32 depth = 4;</code>
        */
       public Builder setDepth(int value) {
-        bitField0_ |= 0x00000008;
-        depth_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setDepth(value);
         return this;
       }
       /**
-       * <code>optional int32 depth = 4;</code>
-       *
        * <pre>
        * If type == BUILDING then this is the depth of the transaction in the blockchain.
        * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
        * </pre>
+       *
+       * <code>optional int32 depth = 4;</code>
        */
       public Builder clearDepth() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        depth_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearDepth();
         return this;
       }
-
-      private java.util.List<org.floj.wallet.Protos.PeerAddress> broadcastBy_ =
-        java.util.Collections.emptyList();
-      private void ensureBroadcastByIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          broadcastBy_ = new java.util.ArrayList<org.floj.wallet.Protos.PeerAddress>(broadcastBy_);
-          bitField0_ |= 0x00000010;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.PeerAddress, org.floj.wallet.Protos.PeerAddress.Builder, org.floj.wallet.Protos.PeerAddressOrBuilder> broadcastByBuilder_;
 
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
       public java.util.List<org.floj.wallet.Protos.PeerAddress> getBroadcastByList() {
-        if (broadcastByBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(broadcastBy_);
-        } else {
-          return broadcastByBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getBroadcastByList());
       }
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
       public int getBroadcastByCount() {
-        if (broadcastByBuilder_ == null) {
-          return broadcastBy_.size();
-        } else {
-          return broadcastByBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getBroadcastByCount();
+      }/**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
       public org.floj.wallet.Protos.PeerAddress getBroadcastBy(int index) {
-        if (broadcastByBuilder_ == null) {
-          return broadcastBy_.get(index);
-        } else {
-          return broadcastByBuilder_.getMessage(index);
-        }
+        return instance.getBroadcastBy(index);
       }
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
       public Builder setBroadcastBy(
           int index, org.floj.wallet.Protos.PeerAddress value) {
-        if (broadcastByBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureBroadcastByIsMutable();
-          broadcastBy_.set(index, value);
-          onChanged();
-        } else {
-          broadcastByBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setBroadcastBy(index, value);
         return this;
       }
       /**
@@ -7861,29 +6942,16 @@ public final class Protos {
        */
       public Builder setBroadcastBy(
           int index, org.floj.wallet.Protos.PeerAddress.Builder builderForValue) {
-        if (broadcastByBuilder_ == null) {
-          ensureBroadcastByIsMutable();
-          broadcastBy_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          broadcastByBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setBroadcastBy(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
       public Builder addBroadcastBy(org.floj.wallet.Protos.PeerAddress value) {
-        if (broadcastByBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureBroadcastByIsMutable();
-          broadcastBy_.add(value);
-          onChanged();
-        } else {
-          broadcastByBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addBroadcastBy(value);
         return this;
       }
       /**
@@ -7891,16 +6959,8 @@ public final class Protos {
        */
       public Builder addBroadcastBy(
           int index, org.floj.wallet.Protos.PeerAddress value) {
-        if (broadcastByBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureBroadcastByIsMutable();
-          broadcastBy_.add(index, value);
-          onChanged();
-        } else {
-          broadcastByBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addBroadcastBy(index, value);
         return this;
       }
       /**
@@ -7908,13 +6968,8 @@ public final class Protos {
        */
       public Builder addBroadcastBy(
           org.floj.wallet.Protos.PeerAddress.Builder builderForValue) {
-        if (broadcastByBuilder_ == null) {
-          ensureBroadcastByIsMutable();
-          broadcastBy_.add(builderForValue.build());
-          onChanged();
-        } else {
-          broadcastByBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addBroadcastBy(builderForValue);
         return this;
       }
       /**
@@ -7922,13 +6977,8 @@ public final class Protos {
        */
       public Builder addBroadcastBy(
           int index, org.floj.wallet.Protos.PeerAddress.Builder builderForValue) {
-        if (broadcastByBuilder_ == null) {
-          ensureBroadcastByIsMutable();
-          broadcastBy_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          broadcastByBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addBroadcastBy(index, builderForValue);
         return this;
       }
       /**
@@ -7936,219 +6986,296 @@ public final class Protos {
        */
       public Builder addAllBroadcastBy(
           java.lang.Iterable<? extends org.floj.wallet.Protos.PeerAddress> values) {
-        if (broadcastByBuilder_ == null) {
-          ensureBroadcastByIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, broadcastBy_);
-          onChanged();
-        } else {
-          broadcastByBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllBroadcastBy(values);
         return this;
       }
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
       public Builder clearBroadcastBy() {
-        if (broadcastByBuilder_ == null) {
-          broadcastBy_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-          onChanged();
-        } else {
-          broadcastByBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearBroadcastBy();
         return this;
       }
       /**
        * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
        */
       public Builder removeBroadcastBy(int index) {
-        if (broadcastByBuilder_ == null) {
-          ensureBroadcastByIsMutable();
-          broadcastBy_.remove(index);
-          onChanged();
-        } else {
-          broadcastByBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeBroadcastBy(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-       */
-      public org.floj.wallet.Protos.PeerAddress.Builder getBroadcastByBuilder(
-          int index) {
-        return getBroadcastByFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-       */
-      public org.floj.wallet.Protos.PeerAddressOrBuilder getBroadcastByOrBuilder(
-          int index) {
-        if (broadcastByBuilder_ == null) {
-          return broadcastBy_.get(index);  } else {
-          return broadcastByBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.PeerAddressOrBuilder> 
-           getBroadcastByOrBuilderList() {
-        if (broadcastByBuilder_ != null) {
-          return broadcastByBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(broadcastBy_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-       */
-      public org.floj.wallet.Protos.PeerAddress.Builder addBroadcastByBuilder() {
-        return getBroadcastByFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.PeerAddress.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-       */
-      public org.floj.wallet.Protos.PeerAddress.Builder addBroadcastByBuilder(
-          int index) {
-        return getBroadcastByFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.PeerAddress.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.PeerAddress.Builder> 
-           getBroadcastByBuilderList() {
-        return getBroadcastByFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.PeerAddress, org.floj.wallet.Protos.PeerAddress.Builder, org.floj.wallet.Protos.PeerAddressOrBuilder> 
-          getBroadcastByFieldBuilder() {
-        if (broadcastByBuilder_ == null) {
-          broadcastByBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.PeerAddress, org.floj.wallet.Protos.PeerAddress.Builder, org.floj.wallet.Protos.PeerAddressOrBuilder>(
-                  broadcastBy_,
-                  ((bitField0_ & 0x00000010) == 0x00000010),
-                  getParentForChildren(),
-                  isClean());
-          broadcastBy_ = null;
-        }
-        return broadcastByBuilder_;
-      }
 
-      private long lastBroadcastedAt_ ;
       /**
-       * <code>optional int64 last_broadcasted_at = 8;</code>
-       *
        * <pre>
        * Millis since epoch the transaction was last announced to us.
        * </pre>
+       *
+       * <code>optional int64 last_broadcasted_at = 8;</code>
        */
       public boolean hasLastBroadcastedAt() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return instance.hasLastBroadcastedAt();
       }
       /**
-       * <code>optional int64 last_broadcasted_at = 8;</code>
-       *
        * <pre>
        * Millis since epoch the transaction was last announced to us.
        * </pre>
+       *
+       * <code>optional int64 last_broadcasted_at = 8;</code>
        */
       public long getLastBroadcastedAt() {
-        return lastBroadcastedAt_;
+        return instance.getLastBroadcastedAt();
       }
       /**
-       * <code>optional int64 last_broadcasted_at = 8;</code>
-       *
        * <pre>
        * Millis since epoch the transaction was last announced to us.
        * </pre>
+       *
+       * <code>optional int64 last_broadcasted_at = 8;</code>
        */
       public Builder setLastBroadcastedAt(long value) {
-        bitField0_ |= 0x00000020;
-        lastBroadcastedAt_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLastBroadcastedAt(value);
         return this;
       }
       /**
-       * <code>optional int64 last_broadcasted_at = 8;</code>
-       *
        * <pre>
        * Millis since epoch the transaction was last announced to us.
        * </pre>
+       *
+       * <code>optional int64 last_broadcasted_at = 8;</code>
        */
       public Builder clearLastBroadcastedAt() {
-        bitField0_ = (bitField0_ & ~0x00000020);
-        lastBroadcastedAt_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearLastBroadcastedAt();
         return this;
       }
 
-      private org.floj.wallet.Protos.TransactionConfidence.Source source_ = org.floj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
       /**
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public boolean hasSource() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return instance.hasSource();
       }
       /**
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public org.floj.wallet.Protos.TransactionConfidence.Source getSource() {
-        return source_;
+        return instance.getSource();
       }
       /**
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public Builder setSource(org.floj.wallet.Protos.TransactionConfidence.Source value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000040;
-        source_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSource(value);
         return this;
       }
       /**
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public Builder clearSource() {
-        bitField0_ = (bitField0_ & ~0x00000040);
-        source_ = org.floj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
-        onChanged();
+        copyOnWrite();
+        instance.clearSource();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.TransactionConfidence)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.TransactionConfidence();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new TransactionConfidence(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          for (int i = 0; i < getBroadcastByCount(); i++) {
+            if (!getBroadcastBy(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          broadcastBy_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.TransactionConfidence other = (org.floj.wallet.Protos.TransactionConfidence) arg1;
+          type_ = visitor.visitInt(hasType(), type_,
+              other.hasType(), other.type_);
+          appearedAtHeight_ = visitor.visitInt(
+              hasAppearedAtHeight(), appearedAtHeight_,
+              other.hasAppearedAtHeight(), other.appearedAtHeight_);
+          overridingTransaction_ = visitor.visitByteString(
+              hasOverridingTransaction(), overridingTransaction_,
+              other.hasOverridingTransaction(), other.overridingTransaction_);
+          depth_ = visitor.visitInt(
+              hasDepth(), depth_,
+              other.hasDepth(), other.depth_);
+          broadcastBy_= visitor.visitList(broadcastBy_, other.broadcastBy_);
+          lastBroadcastedAt_ = visitor.visitLong(
+              hasLastBroadcastedAt(), lastBroadcastedAt_,
+              other.hasLastBroadcastedAt(), other.lastBroadcastedAt_);
+          source_ = visitor.visitInt(hasSource(), source_,
+              other.hasSource(), other.source_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  int rawValue = input.readEnum();
+                  org.floj.wallet.Protos.TransactionConfidence.Type value = org.floj.wallet.Protos.TransactionConfidence.Type.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(1, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000001;
+                    type_ = rawValue;
+                  }
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  appearedAtHeight_ = input.readInt32();
+                  break;
+                }
+                case 26: {
+                  bitField0_ |= 0x00000004;
+                  overridingTransaction_ = input.readBytes();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000008;
+                  depth_ = input.readInt32();
+                  break;
+                }
+                case 50: {
+                  if (!broadcastBy_.isModifiable()) {
+                    broadcastBy_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(broadcastBy_);
+                  }
+                  broadcastBy_.add(
+                      input.readMessage(org.floj.wallet.Protos.PeerAddress.parser(), extensionRegistry));
+                  break;
+                }
+                case 56: {
+                  int rawValue = input.readEnum();
+                  org.floj.wallet.Protos.TransactionConfidence.Source value = org.floj.wallet.Protos.TransactionConfidence.Source.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(7, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000020;
+                    source_ = rawValue;
+                  }
+                  break;
+                }
+                case 64: {
+                  bitField0_ |= 0x00000010;
+                  lastBroadcastedAt_ = input.readInt64();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.TransactionConfidence.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.TransactionConfidence)
+    private static final org.floj.wallet.Protos.TransactionConfidence DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new TransactionConfidence();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.TransactionConfidence getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<TransactionConfidence> PARSER;
+
+    public static com.google.protobuf.Parser<TransactionConfidence> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface TransactionOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.Transaction)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required int32 version = 1;</code>
-     *
      * <pre>
      * See Wallet.java for detailed description of pool semantics
      * </pre>
+     *
+     * <code>required int32 version = 1;</code>
      */
     boolean hasVersion();
     /**
-     * <code>required int32 version = 1;</code>
-     *
      * <pre>
      * See Wallet.java for detailed description of pool semantics
      * </pre>
+     *
+     * <code>required int32 version = 1;</code>
      */
     int getVersion();
 
@@ -8162,59 +7289,59 @@ public final class Protos {
     com.google.protobuf.ByteString getHash();
 
     /**
-     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-     *
      * <pre>
      * If pool is not present, that means either:
      *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
      *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
      *  - Or the Pool enum got a new value which your software is too old to parse.
      * </pre>
+     *
+     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
      */
     boolean hasPool();
     /**
-     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-     *
      * <pre>
      * If pool is not present, that means either:
      *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
      *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
      *  - Or the Pool enum got a new value which your software is too old to parse.
      * </pre>
+     *
+     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
      */
     org.floj.wallet.Protos.Transaction.Pool getPool();
 
     /**
-     * <code>optional uint32 lock_time = 4;</code>
-     *
      * <pre>
      * The nLockTime field is useful for contracts.
      * </pre>
+     *
+     * <code>optional uint32 lock_time = 4;</code>
      */
     boolean hasLockTime();
     /**
-     * <code>optional uint32 lock_time = 4;</code>
-     *
      * <pre>
      * The nLockTime field is useful for contracts.
      * </pre>
+     *
+     * <code>optional uint32 lock_time = 4;</code>
      */
     int getLockTime();
 
     /**
-     * <code>optional int64 updated_at = 5;</code>
-     *
      * <pre>
      * millis since epoch the transaction was last updated
      * </pre>
+     *
+     * <code>optional int64 updated_at = 5;</code>
      */
     boolean hasUpdatedAt();
     /**
-     * <code>optional int64 updated_at = 5;</code>
-     *
      * <pre>
      * millis since epoch the transaction was last updated
      * </pre>
+     *
+     * <code>optional int64 updated_at = 5;</code>
      */
     long getUpdatedAt();
 
@@ -8231,16 +7358,6 @@ public final class Protos {
      * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
      */
     int getTransactionInputCount();
-    /**
-     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.TransactionInputOrBuilder> 
-        getTransactionInputOrBuilderList();
-    /**
-     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-     */
-    org.floj.wallet.Protos.TransactionInputOrBuilder getTransactionInputOrBuilder(
-        int index);
 
     /**
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
@@ -8255,42 +7372,32 @@ public final class Protos {
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
      */
     int getTransactionOutputCount();
-    /**
-     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.TransactionOutputOrBuilder> 
-        getTransactionOutputOrBuilderList();
-    /**
-     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-     */
-    org.floj.wallet.Protos.TransactionOutputOrBuilder getTransactionOutputOrBuilder(
-        int index);
 
     /**
-     * <code>repeated bytes block_hash = 8;</code>
-     *
      * <pre>
      * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
      * ordering within a block.
      * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
      */
     java.util.List<com.google.protobuf.ByteString> getBlockHashList();
     /**
-     * <code>repeated bytes block_hash = 8;</code>
-     *
      * <pre>
      * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
      * ordering within a block.
      * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
      */
     int getBlockHashCount();
     /**
-     * <code>repeated bytes block_hash = 8;</code>
-     *
      * <pre>
      * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
      * ordering within a block.
      * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
      */
     com.google.protobuf.ByteString getBlockHash(int index);
 
@@ -8308,29 +7415,21 @@ public final class Protos {
     int getBlockRelativityOffsets(int index);
 
     /**
-     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-     *
      * <pre>
      * Data describing where the transaction is in the chain.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
      */
     boolean hasConfidence();
     /**
-     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-     *
      * <pre>
      * Data describing where the transaction is in the chain.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
      */
     org.floj.wallet.Protos.TransactionConfidence getConfidence();
-    /**
-     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-     *
-     * <pre>
-     * Data describing where the transaction is in the chain.
-     * </pre>
-     */
-    org.floj.wallet.Protos.TransactionConfidenceOrBuilder getConfidenceOrBuilder();
 
     /**
      * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
@@ -8342,306 +7441,87 @@ public final class Protos {
     org.floj.wallet.Protos.Transaction.Purpose getPurpose();
 
     /**
-     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-     *
      * <pre>
      * Exchange rate that was valid when the transaction was sent.
      * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
      */
     boolean hasExchangeRate();
     /**
-     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-     *
      * <pre>
      * Exchange rate that was valid when the transaction was sent.
      * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
      */
     org.floj.wallet.Protos.ExchangeRate getExchangeRate();
-    /**
-     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-     *
-     * <pre>
-     * Exchange rate that was valid when the transaction was sent.
-     * </pre>
-     */
-    org.floj.wallet.Protos.ExchangeRateOrBuilder getExchangeRateOrBuilder();
 
     /**
-     * <code>optional string memo = 13;</code>
-     *
      * <pre>
      * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
      * transaction.
      * </pre>
+     *
+     * <code>optional string memo = 13;</code>
      */
     boolean hasMemo();
     /**
-     * <code>optional string memo = 13;</code>
-     *
      * <pre>
      * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
      * transaction.
      * </pre>
+     *
+     * <code>optional string memo = 13;</code>
      */
     java.lang.String getMemo();
     /**
-     * <code>optional string memo = 13;</code>
-     *
      * <pre>
      * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
      * transaction.
      * </pre>
+     *
+     * <code>optional string memo = 13;</code>
      */
     com.google.protobuf.ByteString
         getMemoBytes();
 
     /**
-     * <code>optional bytes flo_data = 14;</code>
-     *
      * <pre>
      * Next tag: 14
      * </pre>
+     *
+     * <code>optional bytes flo_data = 14;</code>
      */
     boolean hasFloData();
     /**
-     * <code>optional bytes flo_data = 14;</code>
-     *
      * <pre>
      * Next tag: 14
      * </pre>
+     *
+     * <code>optional bytes flo_data = 14;</code>
      */
     com.google.protobuf.ByteString getFloData();
   }
   /**
    * Protobuf type {@code wallet.Transaction}
    */
-  public static final class Transaction extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Transaction extends
+      com.google.protobuf.GeneratedMessageLite<
+          Transaction, Transaction.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.Transaction)
       TransactionOrBuilder {
-    // Use Transaction.newBuilder() to construct.
-    private Transaction(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Transaction() {
+      hash_ = com.google.protobuf.ByteString.EMPTY;
+      pool_ = 4;
+      transactionInput_ = emptyProtobufList();
+      transactionOutput_ = emptyProtobufList();
+      blockHash_ = emptyProtobufList();
+      blockRelativityOffsets_ = emptyIntList();
+      memo_ = "";
+      floData_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Transaction(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Transaction defaultInstance;
-    public static Transaction getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Transaction getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Transaction(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              version_ = input.readInt32();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              hash_ = input.readBytes();
-              break;
-            }
-            case 24: {
-              int rawValue = input.readEnum();
-              org.floj.wallet.Protos.Transaction.Pool value = org.floj.wallet.Protos.Transaction.Pool.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(3, rawValue);
-              } else {
-                bitField0_ |= 0x00000004;
-                pool_ = value;
-              }
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              lockTime_ = input.readUInt32();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              updatedAt_ = input.readInt64();
-              break;
-            }
-            case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                transactionInput_ = new java.util.ArrayList<org.floj.wallet.Protos.TransactionInput>();
-                mutable_bitField0_ |= 0x00000020;
-              }
-              transactionInput_.add(input.readMessage(org.floj.wallet.Protos.TransactionInput.PARSER, extensionRegistry));
-              break;
-            }
-            case 58: {
-              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-                transactionOutput_ = new java.util.ArrayList<org.floj.wallet.Protos.TransactionOutput>();
-                mutable_bitField0_ |= 0x00000040;
-              }
-              transactionOutput_.add(input.readMessage(org.floj.wallet.Protos.TransactionOutput.PARSER, extensionRegistry));
-              break;
-            }
-            case 66: {
-              if (!((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
-                blockHash_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
-                mutable_bitField0_ |= 0x00000080;
-              }
-              blockHash_.add(input.readBytes());
-              break;
-            }
-            case 74: {
-              org.floj.wallet.Protos.TransactionConfidence.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                subBuilder = confidence_.toBuilder();
-              }
-              confidence_ = input.readMessage(org.floj.wallet.Protos.TransactionConfidence.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(confidence_);
-                confidence_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000020;
-              break;
-            }
-            case 80: {
-              int rawValue = input.readEnum();
-              org.floj.wallet.Protos.Transaction.Purpose value = org.floj.wallet.Protos.Transaction.Purpose.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(10, rawValue);
-              } else {
-                bitField0_ |= 0x00000040;
-                purpose_ = value;
-              }
-              break;
-            }
-            case 88: {
-              if (!((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
-                blockRelativityOffsets_ = new java.util.ArrayList<java.lang.Integer>();
-                mutable_bitField0_ |= 0x00000100;
-              }
-              blockRelativityOffsets_.add(input.readInt32());
-              break;
-            }
-            case 90: {
-              int length = input.readRawVarint32();
-              int limit = input.pushLimit(length);
-              if (!((mutable_bitField0_ & 0x00000100) == 0x00000100) && input.getBytesUntilLimit() > 0) {
-                blockRelativityOffsets_ = new java.util.ArrayList<java.lang.Integer>();
-                mutable_bitField0_ |= 0x00000100;
-              }
-              while (input.getBytesUntilLimit() > 0) {
-                blockRelativityOffsets_.add(input.readInt32());
-              }
-              input.popLimit(limit);
-              break;
-            }
-            case 98: {
-              org.floj.wallet.Protos.ExchangeRate.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                subBuilder = exchangeRate_.toBuilder();
-              }
-              exchangeRate_ = input.readMessage(org.floj.wallet.Protos.ExchangeRate.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(exchangeRate_);
-                exchangeRate_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000080;
-              break;
-            }
-            case 106: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000100;
-              memo_ = bs;
-              break;
-            }
-            case 114: {
-              bitField0_ |= 0x00000200;
-              floData_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-          transactionInput_ = java.util.Collections.unmodifiableList(transactionInput_);
-        }
-        if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-          transactionOutput_ = java.util.Collections.unmodifiableList(transactionOutput_);
-        }
-        if (((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
-          blockHash_ = java.util.Collections.unmodifiableList(blockHash_);
-        }
-        if (((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
-          blockRelativityOffsets_ = java.util.Collections.unmodifiableList(blockRelativityOffsets_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_Transaction_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_Transaction_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.Transaction.class, org.floj.wallet.Protos.Transaction.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Transaction> PARSER =
-        new com.google.protobuf.AbstractParser<Transaction>() {
-      public Transaction parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Transaction(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Transaction> getParserForType() {
-      return PARSER;
-    }
-
     /**
-     * Protobuf enum {@code wallet.Transaction.Pool}
-     *
      * <pre>
      **
      * This is a bitfield oriented enum, with the following bits:
@@ -8654,112 +7534,124 @@ public final class Protos {
      * 
      * Not all combinations are interesting, just the ones actually used in the enum.
      * </pre>
+     *
+     * Protobuf enum {@code wallet.Transaction.Pool}
      */
     public enum Pool
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
-       * <code>UNSPENT = 4;</code>
-       *
        * <pre>
        * In best chain, not all outputs spent
        * </pre>
-       */
-      UNSPENT(0, 4),
-      /**
-       * <code>SPENT = 5;</code>
        *
+       * <code>UNSPENT = 4;</code>
+       */
+      UNSPENT(4),
+      /**
        * <pre>
        * In best chain, all outputs spent
        * </pre>
-       */
-      SPENT(1, 5),
-      /**
-       * <code>INACTIVE = 2;</code>
        *
+       * <code>SPENT = 5;</code>
+       */
+      SPENT(5),
+      /**
        * <pre>
        * In non-best chain, not our transaction
        * </pre>
-       */
-      INACTIVE(2, 2),
-      /**
-       * <code>DEAD = 10;</code>
        *
+       * <code>INACTIVE = 2;</code>
+       */
+      INACTIVE(2),
+      /**
        * <pre>
        * Double-spent by a transaction in the best chain
        * </pre>
-       */
-      DEAD(3, 10),
-      /**
-       * <code>PENDING = 16;</code>
        *
+       * <code>DEAD = 10;</code>
+       */
+      DEAD(10),
+      /**
        * <pre>
        * Our transaction, not in any chain
        * </pre>
-       */
-      PENDING(4, 16),
-      /**
-       * <code>PENDING_INACTIVE = 18;</code>
        *
+       * <code>PENDING = 16;</code>
+       */
+      PENDING(16),
+      /**
        * <pre>
        * In non-best chain, our transaction
        * </pre>
+       *
+       * <code>PENDING_INACTIVE = 18;</code>
        */
-      PENDING_INACTIVE(5, 18),
+      PENDING_INACTIVE(18),
       ;
 
       /**
-       * <code>UNSPENT = 4;</code>
-       *
        * <pre>
        * In best chain, not all outputs spent
        * </pre>
+       *
+       * <code>UNSPENT = 4;</code>
        */
       public static final int UNSPENT_VALUE = 4;
       /**
-       * <code>SPENT = 5;</code>
-       *
        * <pre>
        * In best chain, all outputs spent
        * </pre>
+       *
+       * <code>SPENT = 5;</code>
        */
       public static final int SPENT_VALUE = 5;
       /**
-       * <code>INACTIVE = 2;</code>
-       *
        * <pre>
        * In non-best chain, not our transaction
        * </pre>
+       *
+       * <code>INACTIVE = 2;</code>
        */
       public static final int INACTIVE_VALUE = 2;
       /**
-       * <code>DEAD = 10;</code>
-       *
        * <pre>
        * Double-spent by a transaction in the best chain
        * </pre>
+       *
+       * <code>DEAD = 10;</code>
        */
       public static final int DEAD_VALUE = 10;
       /**
-       * <code>PENDING = 16;</code>
-       *
        * <pre>
        * Our transaction, not in any chain
        * </pre>
+       *
+       * <code>PENDING = 16;</code>
        */
       public static final int PENDING_VALUE = 16;
       /**
-       * <code>PENDING_INACTIVE = 18;</code>
-       *
        * <pre>
        * In non-best chain, our transaction
        * </pre>
+       *
+       * <code>PENDING_INACTIVE = 18;</code>
        */
       public static final int PENDING_INACTIVE_VALUE = 18;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static Pool valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static Pool forNumber(int value) {
         switch (value) {
           case 4: return UNSPENT;
           case 5: return SPENT;
@@ -8775,43 +7667,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<Pool>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          Pool> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Pool>() {
               public Pool findValueByNumber(int number) {
-                return Pool.valueOf(number);
+                return Pool.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.Transaction.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final Pool[] VALUES = values();
-
-      public static Pool valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private Pool(int index, int value) {
-        this.index = index;
+      private Pool(int value) {
         this.value = value;
       }
 
@@ -8819,94 +7685,94 @@ public final class Protos {
     }
 
     /**
-     * Protobuf enum {@code wallet.Transaction.Purpose}
-     *
      * <pre>
      * For what purpose the transaction was created.
      * </pre>
+     *
+     * Protobuf enum {@code wallet.Transaction.Purpose}
      */
     public enum Purpose
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
-       * <code>UNKNOWN = 0;</code>
-       *
        * <pre>
        * Old wallets or the purpose genuinely is a mystery (e.g. imported from some external source).
        * </pre>
-       */
-      UNKNOWN(0, 0),
-      /**
-       * <code>USER_PAYMENT = 1;</code>
        *
+       * <code>UNKNOWN = 0;</code>
+       */
+      UNKNOWN(0),
+      /**
        * <pre>
        * Created in response to a user request for payment. This is the normal case.
        * </pre>
-       */
-      USER_PAYMENT(1, 1),
-      /**
-       * <code>KEY_ROTATION = 2;</code>
        *
+       * <code>USER_PAYMENT = 1;</code>
+       */
+      USER_PAYMENT(1),
+      /**
        * <pre>
        * Created automatically to move money from rotated keys.
        * </pre>
-       */
-      KEY_ROTATION(2, 2),
-      /**
-       * <code>ASSURANCE_CONTRACT_CLAIM = 3;</code>
        *
+       * <code>KEY_ROTATION = 2;</code>
+       */
+      KEY_ROTATION(2),
+      /**
        * <pre>
        * Stuff used by Lighthouse.
        * </pre>
+       *
+       * <code>ASSURANCE_CONTRACT_CLAIM = 3;</code>
        */
-      ASSURANCE_CONTRACT_CLAIM(3, 3),
+      ASSURANCE_CONTRACT_CLAIM(3),
       /**
        * <code>ASSURANCE_CONTRACT_PLEDGE = 4;</code>
        */
-      ASSURANCE_CONTRACT_PLEDGE(4, 4),
+      ASSURANCE_CONTRACT_PLEDGE(4),
       /**
        * <code>ASSURANCE_CONTRACT_STUB = 5;</code>
        */
-      ASSURANCE_CONTRACT_STUB(5, 5),
+      ASSURANCE_CONTRACT_STUB(5),
       /**
-       * <code>RAISE_FEE = 6;</code>
-       *
        * <pre>
        * Raise fee, e.g. child-pays-for-parent.
        * </pre>
+       *
+       * <code>RAISE_FEE = 6;</code>
        */
-      RAISE_FEE(6, 6),
+      RAISE_FEE(6),
       ;
 
       /**
-       * <code>UNKNOWN = 0;</code>
-       *
        * <pre>
        * Old wallets or the purpose genuinely is a mystery (e.g. imported from some external source).
        * </pre>
+       *
+       * <code>UNKNOWN = 0;</code>
        */
       public static final int UNKNOWN_VALUE = 0;
       /**
-       * <code>USER_PAYMENT = 1;</code>
-       *
        * <pre>
        * Created in response to a user request for payment. This is the normal case.
        * </pre>
+       *
+       * <code>USER_PAYMENT = 1;</code>
        */
       public static final int USER_PAYMENT_VALUE = 1;
       /**
-       * <code>KEY_ROTATION = 2;</code>
-       *
        * <pre>
        * Created automatically to move money from rotated keys.
        * </pre>
+       *
+       * <code>KEY_ROTATION = 2;</code>
        */
       public static final int KEY_ROTATION_VALUE = 2;
       /**
-       * <code>ASSURANCE_CONTRACT_CLAIM = 3;</code>
-       *
        * <pre>
        * Stuff used by Lighthouse.
        * </pre>
+       *
+       * <code>ASSURANCE_CONTRACT_CLAIM = 3;</code>
        */
       public static final int ASSURANCE_CONTRACT_CLAIM_VALUE = 3;
       /**
@@ -8918,18 +7784,28 @@ public final class Protos {
        */
       public static final int ASSURANCE_CONTRACT_STUB_VALUE = 5;
       /**
-       * <code>RAISE_FEE = 6;</code>
-       *
        * <pre>
        * Raise fee, e.g. child-pays-for-parent.
        * </pre>
+       *
+       * <code>RAISE_FEE = 6;</code>
        */
       public static final int RAISE_FEE_VALUE = 6;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static Purpose valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static Purpose forNumber(int value) {
         switch (value) {
           case 0: return UNKNOWN;
           case 1: return USER_PAYMENT;
@@ -8946,43 +7822,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<Purpose>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          Purpose> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Purpose>() {
               public Purpose findValueByNumber(int number) {
-                return Purpose.valueOf(number);
+                return Purpose.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.Transaction.getDescriptor().getEnumTypes().get(1);
-      }
-
-      private static final Purpose[] VALUES = values();
-
-      public static Purpose valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private Purpose(int index, int value) {
-        this.index = index;
+      private Purpose(int value) {
         this.value = value;
       }
 
@@ -8993,24 +7843,46 @@ public final class Protos {
     public static final int VERSION_FIELD_NUMBER = 1;
     private int version_;
     /**
-     * <code>required int32 version = 1;</code>
-     *
      * <pre>
      * See Wallet.java for detailed description of pool semantics
      * </pre>
+     *
+     * <code>required int32 version = 1;</code>
      */
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required int32 version = 1;</code>
-     *
      * <pre>
      * See Wallet.java for detailed description of pool semantics
      * </pre>
+     *
+     * <code>required int32 version = 1;</code>
      */
     public int getVersion() {
       return version_;
+    }
+    /**
+     * <pre>
+     * See Wallet.java for detailed description of pool semantics
+     * </pre>
+     *
+     * <code>required int32 version = 1;</code>
+     */
+    private void setVersion(int value) {
+      bitField0_ |= 0x00000001;
+      version_ = value;
+    }
+    /**
+     * <pre>
+     * See Wallet.java for detailed description of pool semantics
+     * </pre>
+     *
+     * <code>required int32 version = 1;</code>
+     */
+    private void clearVersion() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      version_ = 0;
     }
 
     public static final int HASH_FIELD_NUMBER = 2;
@@ -9027,84 +7899,177 @@ public final class Protos {
     public com.google.protobuf.ByteString getHash() {
       return hash_;
     }
+    /**
+     * <code>required bytes hash = 2;</code>
+     */
+    private void setHash(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      hash_ = value;
+    }
+    /**
+     * <code>required bytes hash = 2;</code>
+     */
+    private void clearHash() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      hash_ = getDefaultInstance().getHash();
+    }
 
     public static final int POOL_FIELD_NUMBER = 3;
-    private org.floj.wallet.Protos.Transaction.Pool pool_;
+    private int pool_;
     /**
-     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-     *
      * <pre>
      * If pool is not present, that means either:
      *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
      *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
      *  - Or the Pool enum got a new value which your software is too old to parse.
      * </pre>
+     *
+     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
      */
     public boolean hasPool() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-     *
      * <pre>
      * If pool is not present, that means either:
      *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
      *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
      *  - Or the Pool enum got a new value which your software is too old to parse.
      * </pre>
+     *
+     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
      */
     public org.floj.wallet.Protos.Transaction.Pool getPool() {
-      return pool_;
+      org.floj.wallet.Protos.Transaction.Pool result = org.floj.wallet.Protos.Transaction.Pool.forNumber(pool_);
+      return result == null ? org.floj.wallet.Protos.Transaction.Pool.UNSPENT : result;
+    }
+    /**
+     * <pre>
+     * If pool is not present, that means either:
+     *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
+     *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
+     *  - Or the Pool enum got a new value which your software is too old to parse.
+     * </pre>
+     *
+     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
+     */
+    private void setPool(org.floj.wallet.Protos.Transaction.Pool value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      bitField0_ |= 0x00000004;
+      pool_ = value.getNumber();
+    }
+    /**
+     * <pre>
+     * If pool is not present, that means either:
+     *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
+     *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
+     *  - Or the Pool enum got a new value which your software is too old to parse.
+     * </pre>
+     *
+     * <code>optional .wallet.Transaction.Pool pool = 3;</code>
+     */
+    private void clearPool() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      pool_ = 4;
     }
 
     public static final int LOCK_TIME_FIELD_NUMBER = 4;
     private int lockTime_;
     /**
-     * <code>optional uint32 lock_time = 4;</code>
-     *
      * <pre>
      * The nLockTime field is useful for contracts.
      * </pre>
+     *
+     * <code>optional uint32 lock_time = 4;</code>
      */
     public boolean hasLockTime() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional uint32 lock_time = 4;</code>
-     *
      * <pre>
      * The nLockTime field is useful for contracts.
      * </pre>
+     *
+     * <code>optional uint32 lock_time = 4;</code>
      */
     public int getLockTime() {
       return lockTime_;
+    }
+    /**
+     * <pre>
+     * The nLockTime field is useful for contracts.
+     * </pre>
+     *
+     * <code>optional uint32 lock_time = 4;</code>
+     */
+    private void setLockTime(int value) {
+      bitField0_ |= 0x00000008;
+      lockTime_ = value;
+    }
+    /**
+     * <pre>
+     * The nLockTime field is useful for contracts.
+     * </pre>
+     *
+     * <code>optional uint32 lock_time = 4;</code>
+     */
+    private void clearLockTime() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      lockTime_ = 0;
     }
 
     public static final int UPDATED_AT_FIELD_NUMBER = 5;
     private long updatedAt_;
     /**
-     * <code>optional int64 updated_at = 5;</code>
-     *
      * <pre>
      * millis since epoch the transaction was last updated
      * </pre>
+     *
+     * <code>optional int64 updated_at = 5;</code>
      */
     public boolean hasUpdatedAt() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional int64 updated_at = 5;</code>
-     *
      * <pre>
      * millis since epoch the transaction was last updated
      * </pre>
+     *
+     * <code>optional int64 updated_at = 5;</code>
      */
     public long getUpdatedAt() {
       return updatedAt_;
     }
+    /**
+     * <pre>
+     * millis since epoch the transaction was last updated
+     * </pre>
+     *
+     * <code>optional int64 updated_at = 5;</code>
+     */
+    private void setUpdatedAt(long value) {
+      bitField0_ |= 0x00000010;
+      updatedAt_ = value;
+    }
+    /**
+     * <pre>
+     * millis since epoch the transaction was last updated
+     * </pre>
+     *
+     * <code>optional int64 updated_at = 5;</code>
+     */
+    private void clearUpdatedAt() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      updatedAt_ = 0L;
+    }
 
     public static final int TRANSACTION_INPUT_FIELD_NUMBER = 6;
-    private java.util.List<org.floj.wallet.Protos.TransactionInput> transactionInput_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.TransactionInput> transactionInput_;
     /**
      * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
      */
@@ -9137,9 +8102,94 @@ public final class Protos {
         int index) {
       return transactionInput_.get(index);
     }
+    private void ensureTransactionInputIsMutable() {
+      if (!transactionInput_.isModifiable()) {
+        transactionInput_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(transactionInput_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void setTransactionInput(
+        int index, org.floj.wallet.Protos.TransactionInput value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionInputIsMutable();
+      transactionInput_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void setTransactionInput(
+        int index, org.floj.wallet.Protos.TransactionInput.Builder builderForValue) {
+      ensureTransactionInputIsMutable();
+      transactionInput_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void addTransactionInput(org.floj.wallet.Protos.TransactionInput value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionInputIsMutable();
+      transactionInput_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void addTransactionInput(
+        int index, org.floj.wallet.Protos.TransactionInput value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionInputIsMutable();
+      transactionInput_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void addTransactionInput(
+        org.floj.wallet.Protos.TransactionInput.Builder builderForValue) {
+      ensureTransactionInputIsMutable();
+      transactionInput_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void addTransactionInput(
+        int index, org.floj.wallet.Protos.TransactionInput.Builder builderForValue) {
+      ensureTransactionInputIsMutable();
+      transactionInput_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void addAllTransactionInput(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.TransactionInput> values) {
+      ensureTransactionInputIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, transactionInput_);
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void clearTransactionInput() {
+      transactionInput_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
+     */
+    private void removeTransactionInput(int index) {
+      ensureTransactionInputIsMutable();
+      transactionInput_.remove(index);
+    }
 
     public static final int TRANSACTION_OUTPUT_FIELD_NUMBER = 7;
-    private java.util.List<org.floj.wallet.Protos.TransactionOutput> transactionOutput_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.TransactionOutput> transactionOutput_;
     /**
      * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
      */
@@ -9172,46 +8222,193 @@ public final class Protos {
         int index) {
       return transactionOutput_.get(index);
     }
+    private void ensureTransactionOutputIsMutable() {
+      if (!transactionOutput_.isModifiable()) {
+        transactionOutput_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(transactionOutput_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void setTransactionOutput(
+        int index, org.floj.wallet.Protos.TransactionOutput value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionOutputIsMutable();
+      transactionOutput_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void setTransactionOutput(
+        int index, org.floj.wallet.Protos.TransactionOutput.Builder builderForValue) {
+      ensureTransactionOutputIsMutable();
+      transactionOutput_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void addTransactionOutput(org.floj.wallet.Protos.TransactionOutput value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionOutputIsMutable();
+      transactionOutput_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void addTransactionOutput(
+        int index, org.floj.wallet.Protos.TransactionOutput value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionOutputIsMutable();
+      transactionOutput_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void addTransactionOutput(
+        org.floj.wallet.Protos.TransactionOutput.Builder builderForValue) {
+      ensureTransactionOutputIsMutable();
+      transactionOutput_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void addTransactionOutput(
+        int index, org.floj.wallet.Protos.TransactionOutput.Builder builderForValue) {
+      ensureTransactionOutputIsMutable();
+      transactionOutput_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void addAllTransactionOutput(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.TransactionOutput> values) {
+      ensureTransactionOutputIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, transactionOutput_);
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void clearTransactionOutput() {
+      transactionOutput_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
+     */
+    private void removeTransactionOutput(int index) {
+      ensureTransactionOutputIsMutable();
+      transactionOutput_.remove(index);
+    }
 
     public static final int BLOCK_HASH_FIELD_NUMBER = 8;
-    private java.util.List<com.google.protobuf.ByteString> blockHash_;
+    private com.google.protobuf.Internal.ProtobufList<com.google.protobuf.ByteString> blockHash_;
     /**
-     * <code>repeated bytes block_hash = 8;</code>
-     *
      * <pre>
      * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
      * ordering within a block.
      * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
      */
     public java.util.List<com.google.protobuf.ByteString>
         getBlockHashList() {
       return blockHash_;
     }
     /**
-     * <code>repeated bytes block_hash = 8;</code>
-     *
      * <pre>
      * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
      * ordering within a block.
      * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
      */
     public int getBlockHashCount() {
       return blockHash_.size();
     }
     /**
-     * <code>repeated bytes block_hash = 8;</code>
-     *
      * <pre>
      * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
      * ordering within a block.
      * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
      */
     public com.google.protobuf.ByteString getBlockHash(int index) {
       return blockHash_.get(index);
     }
+    private void ensureBlockHashIsMutable() {
+      if (!blockHash_.isModifiable()) {
+        blockHash_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(blockHash_);
+       }
+    }
+    /**
+     * <pre>
+     * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
+     * ordering within a block.
+     * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
+     */
+    private void setBlockHash(
+        int index, com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureBlockHashIsMutable();
+      blockHash_.set(index, value);
+    }
+    /**
+     * <pre>
+     * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
+     * ordering within a block.
+     * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
+     */
+    private void addBlockHash(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureBlockHashIsMutable();
+      blockHash_.add(value);
+    }
+    /**
+     * <pre>
+     * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
+     * ordering within a block.
+     * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
+     */
+    private void addAllBlockHash(
+        java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
+      ensureBlockHashIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, blockHash_);
+    }
+    /**
+     * <pre>
+     * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
+     * ordering within a block.
+     * </pre>
+     *
+     * <code>repeated bytes block_hash = 8;</code>
+     */
+    private void clearBlockHash() {
+      blockHash_ = emptyProtobufList();
+    }
 
     public static final int BLOCK_RELATIVITY_OFFSETS_FIELD_NUMBER = 11;
-    private java.util.List<java.lang.Integer> blockRelativityOffsets_;
+    private com.google.protobuf.Internal.IntList blockRelativityOffsets_;
     /**
      * <code>repeated int32 block_relativity_offsets = 11;</code>
      */
@@ -9229,44 +8426,123 @@ public final class Protos {
      * <code>repeated int32 block_relativity_offsets = 11;</code>
      */
     public int getBlockRelativityOffsets(int index) {
-      return blockRelativityOffsets_.get(index);
+      return blockRelativityOffsets_.getInt(index);
+    }
+    private void ensureBlockRelativityOffsetsIsMutable() {
+      if (!blockRelativityOffsets_.isModifiable()) {
+        blockRelativityOffsets_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(blockRelativityOffsets_);
+       }
+    }
+    /**
+     * <code>repeated int32 block_relativity_offsets = 11;</code>
+     */
+    private void setBlockRelativityOffsets(
+        int index, int value) {
+      ensureBlockRelativityOffsetsIsMutable();
+      blockRelativityOffsets_.setInt(index, value);
+    }
+    /**
+     * <code>repeated int32 block_relativity_offsets = 11;</code>
+     */
+    private void addBlockRelativityOffsets(int value) {
+      ensureBlockRelativityOffsetsIsMutable();
+      blockRelativityOffsets_.addInt(value);
+    }
+    /**
+     * <code>repeated int32 block_relativity_offsets = 11;</code>
+     */
+    private void addAllBlockRelativityOffsets(
+        java.lang.Iterable<? extends java.lang.Integer> values) {
+      ensureBlockRelativityOffsetsIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, blockRelativityOffsets_);
+    }
+    /**
+     * <code>repeated int32 block_relativity_offsets = 11;</code>
+     */
+    private void clearBlockRelativityOffsets() {
+      blockRelativityOffsets_ = emptyIntList();
     }
 
     public static final int CONFIDENCE_FIELD_NUMBER = 9;
     private org.floj.wallet.Protos.TransactionConfidence confidence_;
     /**
-     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-     *
      * <pre>
      * Data describing where the transaction is in the chain.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
      */
     public boolean hasConfidence() {
       return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
-     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-     *
      * <pre>
      * Data describing where the transaction is in the chain.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
      */
     public org.floj.wallet.Protos.TransactionConfidence getConfidence() {
-      return confidence_;
+      return confidence_ == null ? org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance() : confidence_;
     }
     /**
-     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-     *
      * <pre>
      * Data describing where the transaction is in the chain.
      * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
      */
-    public org.floj.wallet.Protos.TransactionConfidenceOrBuilder getConfidenceOrBuilder() {
-      return confidence_;
+    private void setConfidence(org.floj.wallet.Protos.TransactionConfidence value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      confidence_ = value;
+      bitField0_ |= 0x00000020;
+      }
+    /**
+     * <pre>
+     * Data describing where the transaction is in the chain.
+     * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
+     */
+    private void setConfidence(
+        org.floj.wallet.Protos.TransactionConfidence.Builder builderForValue) {
+      confidence_ = builderForValue.build();
+      bitField0_ |= 0x00000020;
+    }
+    /**
+     * <pre>
+     * Data describing where the transaction is in the chain.
+     * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
+     */
+    private void mergeConfidence(org.floj.wallet.Protos.TransactionConfidence value) {
+      if (confidence_ != null &&
+          confidence_ != org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance()) {
+        confidence_ =
+          org.floj.wallet.Protos.TransactionConfidence.newBuilder(confidence_).mergeFrom(value).buildPartial();
+      } else {
+        confidence_ = value;
+      }
+      bitField0_ |= 0x00000020;
+    }
+    /**
+     * <pre>
+     * Data describing where the transaction is in the chain.
+     * </pre>
+     *
+     * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
+     */
+    private void clearConfidence() {  confidence_ = null;
+      bitField0_ = (bitField0_ & ~0x00000020);
     }
 
     public static final int PURPOSE_FIELD_NUMBER = 10;
-    private org.floj.wallet.Protos.Transaction.Purpose purpose_;
+    private int purpose_;
     /**
      * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
      */
@@ -9277,183 +8553,234 @@ public final class Protos {
      * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
      */
     public org.floj.wallet.Protos.Transaction.Purpose getPurpose() {
-      return purpose_;
+      org.floj.wallet.Protos.Transaction.Purpose result = org.floj.wallet.Protos.Transaction.Purpose.forNumber(purpose_);
+      return result == null ? org.floj.wallet.Protos.Transaction.Purpose.UNKNOWN : result;
+    }
+    /**
+     * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
+     */
+    private void setPurpose(org.floj.wallet.Protos.Transaction.Purpose value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      bitField0_ |= 0x00000040;
+      purpose_ = value.getNumber();
+    }
+    /**
+     * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
+     */
+    private void clearPurpose() {
+      bitField0_ = (bitField0_ & ~0x00000040);
+      purpose_ = 0;
     }
 
     public static final int EXCHANGE_RATE_FIELD_NUMBER = 12;
     private org.floj.wallet.Protos.ExchangeRate exchangeRate_;
     /**
-     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-     *
      * <pre>
      * Exchange rate that was valid when the transaction was sent.
      * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
      */
     public boolean hasExchangeRate() {
       return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
-     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-     *
      * <pre>
      * Exchange rate that was valid when the transaction was sent.
      * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
      */
     public org.floj.wallet.Protos.ExchangeRate getExchangeRate() {
-      return exchangeRate_;
+      return exchangeRate_ == null ? org.floj.wallet.Protos.ExchangeRate.getDefaultInstance() : exchangeRate_;
     }
     /**
-     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-     *
      * <pre>
      * Exchange rate that was valid when the transaction was sent.
      * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
      */
-    public org.floj.wallet.Protos.ExchangeRateOrBuilder getExchangeRateOrBuilder() {
-      return exchangeRate_;
+    private void setExchangeRate(org.floj.wallet.Protos.ExchangeRate value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      exchangeRate_ = value;
+      bitField0_ |= 0x00000080;
+      }
+    /**
+     * <pre>
+     * Exchange rate that was valid when the transaction was sent.
+     * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
+     */
+    private void setExchangeRate(
+        org.floj.wallet.Protos.ExchangeRate.Builder builderForValue) {
+      exchangeRate_ = builderForValue.build();
+      bitField0_ |= 0x00000080;
+    }
+    /**
+     * <pre>
+     * Exchange rate that was valid when the transaction was sent.
+     * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
+     */
+    private void mergeExchangeRate(org.floj.wallet.Protos.ExchangeRate value) {
+      if (exchangeRate_ != null &&
+          exchangeRate_ != org.floj.wallet.Protos.ExchangeRate.getDefaultInstance()) {
+        exchangeRate_ =
+          org.floj.wallet.Protos.ExchangeRate.newBuilder(exchangeRate_).mergeFrom(value).buildPartial();
+      } else {
+        exchangeRate_ = value;
+      }
+      bitField0_ |= 0x00000080;
+    }
+    /**
+     * <pre>
+     * Exchange rate that was valid when the transaction was sent.
+     * </pre>
+     *
+     * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
+     */
+    private void clearExchangeRate() {  exchangeRate_ = null;
+      bitField0_ = (bitField0_ & ~0x00000080);
     }
 
     public static final int MEMO_FIELD_NUMBER = 13;
-    private java.lang.Object memo_;
+    private java.lang.String memo_;
     /**
-     * <code>optional string memo = 13;</code>
-     *
      * <pre>
      * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
      * transaction.
      * </pre>
+     *
+     * <code>optional string memo = 13;</code>
      */
     public boolean hasMemo() {
       return ((bitField0_ & 0x00000100) == 0x00000100);
     }
     /**
-     * <code>optional string memo = 13;</code>
-     *
      * <pre>
      * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
      * transaction.
      * </pre>
+     *
+     * <code>optional string memo = 13;</code>
      */
     public java.lang.String getMemo() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          memo_ = s;
-        }
-        return s;
-      }
+      return memo_;
     }
     /**
-     * <code>optional string memo = 13;</code>
-     *
      * <pre>
      * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
      * transaction.
      * </pre>
+     *
+     * <code>optional string memo = 13;</code>
      */
     public com.google.protobuf.ByteString
         getMemoBytes() {
-      java.lang.Object ref = memo_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        memo_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(memo_);
+    }
+    /**
+     * <pre>
+     * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
+     * transaction.
+     * </pre>
+     *
+     * <code>optional string memo = 13;</code>
+     */
+    private void setMemo(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000100;
+      memo_ = value;
+    }
+    /**
+     * <pre>
+     * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
+     * transaction.
+     * </pre>
+     *
+     * <code>optional string memo = 13;</code>
+     */
+    private void clearMemo() {
+      bitField0_ = (bitField0_ & ~0x00000100);
+      memo_ = getDefaultInstance().getMemo();
+    }
+    /**
+     * <pre>
+     * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
+     * transaction.
+     * </pre>
+     *
+     * <code>optional string memo = 13;</code>
+     */
+    private void setMemoBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000100;
+      memo_ = value.toStringUtf8();
     }
 
     public static final int FLO_DATA_FIELD_NUMBER = 14;
     private com.google.protobuf.ByteString floData_;
     /**
-     * <code>optional bytes flo_data = 14;</code>
-     *
      * <pre>
      * Next tag: 14
      * </pre>
+     *
+     * <code>optional bytes flo_data = 14;</code>
      */
     public boolean hasFloData() {
       return ((bitField0_ & 0x00000200) == 0x00000200);
     }
     /**
-     * <code>optional bytes flo_data = 14;</code>
-     *
      * <pre>
      * Next tag: 14
      * </pre>
+     *
+     * <code>optional bytes flo_data = 14;</code>
      */
     public com.google.protobuf.ByteString getFloData() {
       return floData_;
     }
-
-    private void initFields() {
-      version_ = 0;
-      hash_ = com.google.protobuf.ByteString.EMPTY;
-      pool_ = org.floj.wallet.Protos.Transaction.Pool.UNSPENT;
-      lockTime_ = 0;
-      updatedAt_ = 0L;
-      transactionInput_ = java.util.Collections.emptyList();
-      transactionOutput_ = java.util.Collections.emptyList();
-      blockHash_ = java.util.Collections.emptyList();
-      blockRelativityOffsets_ = java.util.Collections.emptyList();
-      confidence_ = org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance();
-      purpose_ = org.floj.wallet.Protos.Transaction.Purpose.UNKNOWN;
-      exchangeRate_ = org.floj.wallet.Protos.ExchangeRate.getDefaultInstance();
-      memo_ = "";
-      floData_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * Next tag: 14
+     * </pre>
+     *
+     * <code>optional bytes flo_data = 14;</code>
+     */
+    private void setFloData(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000200;
+      floData_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasVersion()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasHash()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      for (int i = 0; i < getTransactionInputCount(); i++) {
-        if (!getTransactionInput(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      for (int i = 0; i < getTransactionOutputCount(); i++) {
-        if (!getTransactionOutput(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasConfidence()) {
-        if (!getConfidence().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasExchangeRate()) {
-        if (!getExchangeRate().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * Next tag: 14
+     * </pre>
+     *
+     * <code>optional bytes flo_data = 14;</code>
+     */
+    private void clearFloData() {
+      bitField0_ = (bitField0_ & ~0x00000200);
+      floData_ = getDefaultInstance().getFloData();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt32(1, version_);
       }
@@ -9461,7 +8788,7 @@ public final class Protos {
         output.writeBytes(2, hash_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeEnum(3, pool_.getNumber());
+        output.writeEnum(3, pool_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeUInt32(4, lockTime_);
@@ -9479,27 +8806,26 @@ public final class Protos {
         output.writeBytes(8, blockHash_.get(i));
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        output.writeMessage(9, confidence_);
+        output.writeMessage(9, getConfidence());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
-        output.writeEnum(10, purpose_.getNumber());
+        output.writeEnum(10, purpose_);
       }
       for (int i = 0; i < blockRelativityOffsets_.size(); i++) {
-        output.writeInt32(11, blockRelativityOffsets_.get(i));
+        output.writeInt32(11, blockRelativityOffsets_.getInt(i));
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
-        output.writeMessage(12, exchangeRate_);
+        output.writeMessage(12, getExchangeRate());
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        output.writeBytes(13, getMemoBytes());
+        output.writeString(13, getMemo());
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
         output.writeBytes(14, floData_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -9515,7 +8841,7 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(3, pool_.getNumber());
+          .computeEnumSize(3, pool_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
@@ -9544,780 +8870,366 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(9, confidence_);
+          .computeMessageSize(9, getConfidence());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(10, purpose_.getNumber());
+          .computeEnumSize(10, purpose_);
       }
       {
         int dataSize = 0;
         for (int i = 0; i < blockRelativityOffsets_.size(); i++) {
           dataSize += com.google.protobuf.CodedOutputStream
-            .computeInt32SizeNoTag(blockRelativityOffsets_.get(i));
+            .computeInt32SizeNoTag(blockRelativityOffsets_.getInt(i));
         }
         size += dataSize;
         size += 1 * getBlockRelativityOffsetsList().size();
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(12, exchangeRate_);
+          .computeMessageSize(12, getExchangeRate());
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(13, getMemoBytes());
+          .computeStringSize(13, getMemo());
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(14, floData_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.Transaction parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Transaction parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Transaction parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Transaction parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Transaction parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Transaction parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Transaction parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Transaction parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Transaction parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Transaction parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.Transaction prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
      * Protobuf type {@code wallet.Transaction}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.Transaction, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.Transaction)
         org.floj.wallet.Protos.TransactionOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_Transaction_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_Transaction_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.Transaction.class, org.floj.wallet.Protos.Transaction.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.Transaction.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getTransactionInputFieldBuilder();
-          getTransactionOutputFieldBuilder();
-          getConfidenceFieldBuilder();
-          getExchangeRateFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        version_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        hash_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        pool_ = org.floj.wallet.Protos.Transaction.Pool.UNSPENT;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        lockTime_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        updatedAt_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
-        if (transactionInputBuilder_ == null) {
-          transactionInput_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
-        } else {
-          transactionInputBuilder_.clear();
-        }
-        if (transactionOutputBuilder_ == null) {
-          transactionOutput_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000040);
-        } else {
-          transactionOutputBuilder_.clear();
-        }
-        blockHash_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000080);
-        blockRelativityOffsets_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000100);
-        if (confidenceBuilder_ == null) {
-          confidence_ = org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance();
-        } else {
-          confidenceBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000200);
-        purpose_ = org.floj.wallet.Protos.Transaction.Purpose.UNKNOWN;
-        bitField0_ = (bitField0_ & ~0x00000400);
-        if (exchangeRateBuilder_ == null) {
-          exchangeRate_ = org.floj.wallet.Protos.ExchangeRate.getDefaultInstance();
-        } else {
-          exchangeRateBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000800);
-        memo_ = "";
-        bitField0_ = (bitField0_ & ~0x00001000);
-        floData_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00002000);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_Transaction_descriptor;
-      }
-
-      public org.floj.wallet.Protos.Transaction getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.Transaction.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.Transaction build() {
-        org.floj.wallet.Protos.Transaction result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.Transaction buildPartial() {
-        org.floj.wallet.Protos.Transaction result = new org.floj.wallet.Protos.Transaction(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.hash_ = hash_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.pool_ = pool_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.lockTime_ = lockTime_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.updatedAt_ = updatedAt_;
-        if (transactionInputBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
-            transactionInput_ = java.util.Collections.unmodifiableList(transactionInput_);
-            bitField0_ = (bitField0_ & ~0x00000020);
-          }
-          result.transactionInput_ = transactionInput_;
-        } else {
-          result.transactionInput_ = transactionInputBuilder_.build();
-        }
-        if (transactionOutputBuilder_ == null) {
-          if (((bitField0_ & 0x00000040) == 0x00000040)) {
-            transactionOutput_ = java.util.Collections.unmodifiableList(transactionOutput_);
-            bitField0_ = (bitField0_ & ~0x00000040);
-          }
-          result.transactionOutput_ = transactionOutput_;
-        } else {
-          result.transactionOutput_ = transactionOutputBuilder_.build();
-        }
-        if (((bitField0_ & 0x00000080) == 0x00000080)) {
-          blockHash_ = java.util.Collections.unmodifiableList(blockHash_);
-          bitField0_ = (bitField0_ & ~0x00000080);
-        }
-        result.blockHash_ = blockHash_;
-        if (((bitField0_ & 0x00000100) == 0x00000100)) {
-          blockRelativityOffsets_ = java.util.Collections.unmodifiableList(blockRelativityOffsets_);
-          bitField0_ = (bitField0_ & ~0x00000100);
-        }
-        result.blockRelativityOffsets_ = blockRelativityOffsets_;
-        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        if (confidenceBuilder_ == null) {
-          result.confidence_ = confidence_;
-        } else {
-          result.confidence_ = confidenceBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
-          to_bitField0_ |= 0x00000040;
-        }
-        result.purpose_ = purpose_;
-        if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
-          to_bitField0_ |= 0x00000080;
-        }
-        if (exchangeRateBuilder_ == null) {
-          result.exchangeRate_ = exchangeRate_;
-        } else {
-          result.exchangeRate_ = exchangeRateBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
-          to_bitField0_ |= 0x00000100;
-        }
-        result.memo_ = memo_;
-        if (((from_bitField0_ & 0x00002000) == 0x00002000)) {
-          to_bitField0_ |= 0x00000200;
-        }
-        result.floData_ = floData_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.Transaction) {
-          return mergeFrom((org.floj.wallet.Protos.Transaction)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.Transaction other) {
-        if (other == org.floj.wallet.Protos.Transaction.getDefaultInstance()) return this;
-        if (other.hasVersion()) {
-          setVersion(other.getVersion());
-        }
-        if (other.hasHash()) {
-          setHash(other.getHash());
-        }
-        if (other.hasPool()) {
-          setPool(other.getPool());
-        }
-        if (other.hasLockTime()) {
-          setLockTime(other.getLockTime());
-        }
-        if (other.hasUpdatedAt()) {
-          setUpdatedAt(other.getUpdatedAt());
-        }
-        if (transactionInputBuilder_ == null) {
-          if (!other.transactionInput_.isEmpty()) {
-            if (transactionInput_.isEmpty()) {
-              transactionInput_ = other.transactionInput_;
-              bitField0_ = (bitField0_ & ~0x00000020);
-            } else {
-              ensureTransactionInputIsMutable();
-              transactionInput_.addAll(other.transactionInput_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.transactionInput_.isEmpty()) {
-            if (transactionInputBuilder_.isEmpty()) {
-              transactionInputBuilder_.dispose();
-              transactionInputBuilder_ = null;
-              transactionInput_ = other.transactionInput_;
-              bitField0_ = (bitField0_ & ~0x00000020);
-              transactionInputBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getTransactionInputFieldBuilder() : null;
-            } else {
-              transactionInputBuilder_.addAllMessages(other.transactionInput_);
-            }
-          }
-        }
-        if (transactionOutputBuilder_ == null) {
-          if (!other.transactionOutput_.isEmpty()) {
-            if (transactionOutput_.isEmpty()) {
-              transactionOutput_ = other.transactionOutput_;
-              bitField0_ = (bitField0_ & ~0x00000040);
-            } else {
-              ensureTransactionOutputIsMutable();
-              transactionOutput_.addAll(other.transactionOutput_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.transactionOutput_.isEmpty()) {
-            if (transactionOutputBuilder_.isEmpty()) {
-              transactionOutputBuilder_.dispose();
-              transactionOutputBuilder_ = null;
-              transactionOutput_ = other.transactionOutput_;
-              bitField0_ = (bitField0_ & ~0x00000040);
-              transactionOutputBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getTransactionOutputFieldBuilder() : null;
-            } else {
-              transactionOutputBuilder_.addAllMessages(other.transactionOutput_);
-            }
-          }
-        }
-        if (!other.blockHash_.isEmpty()) {
-          if (blockHash_.isEmpty()) {
-            blockHash_ = other.blockHash_;
-            bitField0_ = (bitField0_ & ~0x00000080);
-          } else {
-            ensureBlockHashIsMutable();
-            blockHash_.addAll(other.blockHash_);
-          }
-          onChanged();
-        }
-        if (!other.blockRelativityOffsets_.isEmpty()) {
-          if (blockRelativityOffsets_.isEmpty()) {
-            blockRelativityOffsets_ = other.blockRelativityOffsets_;
-            bitField0_ = (bitField0_ & ~0x00000100);
-          } else {
-            ensureBlockRelativityOffsetsIsMutable();
-            blockRelativityOffsets_.addAll(other.blockRelativityOffsets_);
-          }
-          onChanged();
-        }
-        if (other.hasConfidence()) {
-          mergeConfidence(other.getConfidence());
-        }
-        if (other.hasPurpose()) {
-          setPurpose(other.getPurpose());
-        }
-        if (other.hasExchangeRate()) {
-          mergeExchangeRate(other.getExchangeRate());
-        }
-        if (other.hasMemo()) {
-          bitField0_ |= 0x00001000;
-          memo_ = other.memo_;
-          onChanged();
-        }
-        if (other.hasFloData()) {
-          setFloData(other.getFloData());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasVersion()) {
-          
-          return false;
-        }
-        if (!hasHash()) {
-          
-          return false;
-        }
-        for (int i = 0; i < getTransactionInputCount(); i++) {
-          if (!getTransactionInput(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        for (int i = 0; i < getTransactionOutputCount(); i++) {
-          if (!getTransactionOutput(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasConfidence()) {
-          if (!getConfidence().isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasExchangeRate()) {
-          if (!getExchangeRate().isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.Transaction parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.Transaction) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private int version_ ;
       /**
-       * <code>required int32 version = 1;</code>
-       *
        * <pre>
        * See Wallet.java for detailed description of pool semantics
        * </pre>
+       *
+       * <code>required int32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasVersion();
       }
       /**
-       * <code>required int32 version = 1;</code>
-       *
        * <pre>
        * See Wallet.java for detailed description of pool semantics
        * </pre>
+       *
+       * <code>required int32 version = 1;</code>
        */
       public int getVersion() {
-        return version_;
+        return instance.getVersion();
       }
       /**
-       * <code>required int32 version = 1;</code>
-       *
        * <pre>
        * See Wallet.java for detailed description of pool semantics
        * </pre>
+       *
+       * <code>required int32 version = 1;</code>
        */
       public Builder setVersion(int value) {
-        bitField0_ |= 0x00000001;
-        version_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setVersion(value);
         return this;
       }
       /**
-       * <code>required int32 version = 1;</code>
-       *
        * <pre>
        * See Wallet.java for detailed description of pool semantics
        * </pre>
+       *
+       * <code>required int32 version = 1;</code>
        */
       public Builder clearVersion() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        version_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearVersion();
         return this;
       }
 
-      private com.google.protobuf.ByteString hash_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes hash = 2;</code>
        */
       public boolean hasHash() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasHash();
       }
       /**
        * <code>required bytes hash = 2;</code>
        */
       public com.google.protobuf.ByteString getHash() {
-        return hash_;
+        return instance.getHash();
       }
       /**
        * <code>required bytes hash = 2;</code>
        */
       public Builder setHash(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        hash_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setHash(value);
         return this;
       }
       /**
        * <code>required bytes hash = 2;</code>
        */
       public Builder clearHash() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        hash_ = getDefaultInstance().getHash();
-        onChanged();
+        copyOnWrite();
+        instance.clearHash();
         return this;
       }
 
-      private org.floj.wallet.Protos.Transaction.Pool pool_ = org.floj.wallet.Protos.Transaction.Pool.UNSPENT;
       /**
-       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-       *
        * <pre>
        * If pool is not present, that means either:
        *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
        *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
        *  - Or the Pool enum got a new value which your software is too old to parse.
        * </pre>
+       *
+       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
        */
       public boolean hasPool() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasPool();
       }
       /**
-       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-       *
        * <pre>
        * If pool is not present, that means either:
        *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
        *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
        *  - Or the Pool enum got a new value which your software is too old to parse.
        * </pre>
+       *
+       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
        */
       public org.floj.wallet.Protos.Transaction.Pool getPool() {
-        return pool_;
+        return instance.getPool();
       }
       /**
-       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-       *
        * <pre>
        * If pool is not present, that means either:
        *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
        *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
        *  - Or the Pool enum got a new value which your software is too old to parse.
        * </pre>
+       *
+       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
        */
       public Builder setPool(org.floj.wallet.Protos.Transaction.Pool value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000004;
-        pool_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPool(value);
         return this;
       }
       /**
-       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
-       *
        * <pre>
        * If pool is not present, that means either:
        *  - This Transaction is either not in a wallet at all (the proto is re-used elsewhere)
        *  - Or it is stored but for other purposes, for example, because it is the overriding transaction of a double spend.
        *  - Or the Pool enum got a new value which your software is too old to parse.
        * </pre>
+       *
+       * <code>optional .wallet.Transaction.Pool pool = 3;</code>
        */
       public Builder clearPool() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        pool_ = org.floj.wallet.Protos.Transaction.Pool.UNSPENT;
-        onChanged();
+        copyOnWrite();
+        instance.clearPool();
         return this;
       }
 
-      private int lockTime_ ;
       /**
-       * <code>optional uint32 lock_time = 4;</code>
-       *
        * <pre>
        * The nLockTime field is useful for contracts.
        * </pre>
+       *
+       * <code>optional uint32 lock_time = 4;</code>
        */
       public boolean hasLockTime() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasLockTime();
       }
       /**
-       * <code>optional uint32 lock_time = 4;</code>
-       *
        * <pre>
        * The nLockTime field is useful for contracts.
        * </pre>
+       *
+       * <code>optional uint32 lock_time = 4;</code>
        */
       public int getLockTime() {
-        return lockTime_;
+        return instance.getLockTime();
       }
       /**
-       * <code>optional uint32 lock_time = 4;</code>
-       *
        * <pre>
        * The nLockTime field is useful for contracts.
        * </pre>
+       *
+       * <code>optional uint32 lock_time = 4;</code>
        */
       public Builder setLockTime(int value) {
-        bitField0_ |= 0x00000008;
-        lockTime_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLockTime(value);
         return this;
       }
       /**
-       * <code>optional uint32 lock_time = 4;</code>
-       *
        * <pre>
        * The nLockTime field is useful for contracts.
        * </pre>
+       *
+       * <code>optional uint32 lock_time = 4;</code>
        */
       public Builder clearLockTime() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        lockTime_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearLockTime();
         return this;
       }
 
-      private long updatedAt_ ;
       /**
-       * <code>optional int64 updated_at = 5;</code>
-       *
        * <pre>
        * millis since epoch the transaction was last updated
        * </pre>
+       *
+       * <code>optional int64 updated_at = 5;</code>
        */
       public boolean hasUpdatedAt() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return instance.hasUpdatedAt();
       }
       /**
-       * <code>optional int64 updated_at = 5;</code>
-       *
        * <pre>
        * millis since epoch the transaction was last updated
        * </pre>
+       *
+       * <code>optional int64 updated_at = 5;</code>
        */
       public long getUpdatedAt() {
-        return updatedAt_;
+        return instance.getUpdatedAt();
       }
       /**
-       * <code>optional int64 updated_at = 5;</code>
-       *
        * <pre>
        * millis since epoch the transaction was last updated
        * </pre>
+       *
+       * <code>optional int64 updated_at = 5;</code>
        */
       public Builder setUpdatedAt(long value) {
-        bitField0_ |= 0x00000010;
-        updatedAt_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setUpdatedAt(value);
         return this;
       }
       /**
-       * <code>optional int64 updated_at = 5;</code>
-       *
        * <pre>
        * millis since epoch the transaction was last updated
        * </pre>
+       *
+       * <code>optional int64 updated_at = 5;</code>
        */
       public Builder clearUpdatedAt() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        updatedAt_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearUpdatedAt();
         return this;
       }
-
-      private java.util.List<org.floj.wallet.Protos.TransactionInput> transactionInput_ =
-        java.util.Collections.emptyList();
-      private void ensureTransactionInputIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-          transactionInput_ = new java.util.ArrayList<org.floj.wallet.Protos.TransactionInput>(transactionInput_);
-          bitField0_ |= 0x00000020;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.TransactionInput, org.floj.wallet.Protos.TransactionInput.Builder, org.floj.wallet.Protos.TransactionInputOrBuilder> transactionInputBuilder_;
 
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
       public java.util.List<org.floj.wallet.Protos.TransactionInput> getTransactionInputList() {
-        if (transactionInputBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(transactionInput_);
-        } else {
-          return transactionInputBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getTransactionInputList());
       }
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
       public int getTransactionInputCount() {
-        if (transactionInputBuilder_ == null) {
-          return transactionInput_.size();
-        } else {
-          return transactionInputBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getTransactionInputCount();
+      }/**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
       public org.floj.wallet.Protos.TransactionInput getTransactionInput(int index) {
-        if (transactionInputBuilder_ == null) {
-          return transactionInput_.get(index);
-        } else {
-          return transactionInputBuilder_.getMessage(index);
-        }
+        return instance.getTransactionInput(index);
       }
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
       public Builder setTransactionInput(
           int index, org.floj.wallet.Protos.TransactionInput value) {
-        if (transactionInputBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionInputIsMutable();
-          transactionInput_.set(index, value);
-          onChanged();
-        } else {
-          transactionInputBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setTransactionInput(index, value);
         return this;
       }
       /**
@@ -10325,29 +9237,16 @@ public final class Protos {
        */
       public Builder setTransactionInput(
           int index, org.floj.wallet.Protos.TransactionInput.Builder builderForValue) {
-        if (transactionInputBuilder_ == null) {
-          ensureTransactionInputIsMutable();
-          transactionInput_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionInputBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setTransactionInput(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
       public Builder addTransactionInput(org.floj.wallet.Protos.TransactionInput value) {
-        if (transactionInputBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionInputIsMutable();
-          transactionInput_.add(value);
-          onChanged();
-        } else {
-          transactionInputBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addTransactionInput(value);
         return this;
       }
       /**
@@ -10355,16 +9254,8 @@ public final class Protos {
        */
       public Builder addTransactionInput(
           int index, org.floj.wallet.Protos.TransactionInput value) {
-        if (transactionInputBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionInputIsMutable();
-          transactionInput_.add(index, value);
-          onChanged();
-        } else {
-          transactionInputBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addTransactionInput(index, value);
         return this;
       }
       /**
@@ -10372,13 +9263,8 @@ public final class Protos {
        */
       public Builder addTransactionInput(
           org.floj.wallet.Protos.TransactionInput.Builder builderForValue) {
-        if (transactionInputBuilder_ == null) {
-          ensureTransactionInputIsMutable();
-          transactionInput_.add(builderForValue.build());
-          onChanged();
-        } else {
-          transactionInputBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransactionInput(builderForValue);
         return this;
       }
       /**
@@ -10386,13 +9272,8 @@ public final class Protos {
        */
       public Builder addTransactionInput(
           int index, org.floj.wallet.Protos.TransactionInput.Builder builderForValue) {
-        if (transactionInputBuilder_ == null) {
-          ensureTransactionInputIsMutable();
-          transactionInput_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionInputBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransactionInput(index, builderForValue);
         return this;
       }
       /**
@@ -10400,164 +9281,52 @@ public final class Protos {
        */
       public Builder addAllTransactionInput(
           java.lang.Iterable<? extends org.floj.wallet.Protos.TransactionInput> values) {
-        if (transactionInputBuilder_ == null) {
-          ensureTransactionInputIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, transactionInput_);
-          onChanged();
-        } else {
-          transactionInputBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllTransactionInput(values);
         return this;
       }
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
       public Builder clearTransactionInput() {
-        if (transactionInputBuilder_ == null) {
-          transactionInput_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
-          onChanged();
-        } else {
-          transactionInputBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearTransactionInput();
         return this;
       }
       /**
        * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
        */
       public Builder removeTransactionInput(int index) {
-        if (transactionInputBuilder_ == null) {
-          ensureTransactionInputIsMutable();
-          transactionInput_.remove(index);
-          onChanged();
-        } else {
-          transactionInputBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeTransactionInput(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-       */
-      public org.floj.wallet.Protos.TransactionInput.Builder getTransactionInputBuilder(
-          int index) {
-        return getTransactionInputFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-       */
-      public org.floj.wallet.Protos.TransactionInputOrBuilder getTransactionInputOrBuilder(
-          int index) {
-        if (transactionInputBuilder_ == null) {
-          return transactionInput_.get(index);  } else {
-          return transactionInputBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.TransactionInputOrBuilder> 
-           getTransactionInputOrBuilderList() {
-        if (transactionInputBuilder_ != null) {
-          return transactionInputBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(transactionInput_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-       */
-      public org.floj.wallet.Protos.TransactionInput.Builder addTransactionInputBuilder() {
-        return getTransactionInputFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.TransactionInput.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-       */
-      public org.floj.wallet.Protos.TransactionInput.Builder addTransactionInputBuilder(
-          int index) {
-        return getTransactionInputFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.TransactionInput.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.TransactionInput transaction_input = 6;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.TransactionInput.Builder> 
-           getTransactionInputBuilderList() {
-        return getTransactionInputFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.TransactionInput, org.floj.wallet.Protos.TransactionInput.Builder, org.floj.wallet.Protos.TransactionInputOrBuilder> 
-          getTransactionInputFieldBuilder() {
-        if (transactionInputBuilder_ == null) {
-          transactionInputBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.TransactionInput, org.floj.wallet.Protos.TransactionInput.Builder, org.floj.wallet.Protos.TransactionInputOrBuilder>(
-                  transactionInput_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
-                  getParentForChildren(),
-                  isClean());
-          transactionInput_ = null;
-        }
-        return transactionInputBuilder_;
-      }
-
-      private java.util.List<org.floj.wallet.Protos.TransactionOutput> transactionOutput_ =
-        java.util.Collections.emptyList();
-      private void ensureTransactionOutputIsMutable() {
-        if (!((bitField0_ & 0x00000040) == 0x00000040)) {
-          transactionOutput_ = new java.util.ArrayList<org.floj.wallet.Protos.TransactionOutput>(transactionOutput_);
-          bitField0_ |= 0x00000040;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.TransactionOutput, org.floj.wallet.Protos.TransactionOutput.Builder, org.floj.wallet.Protos.TransactionOutputOrBuilder> transactionOutputBuilder_;
 
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
       public java.util.List<org.floj.wallet.Protos.TransactionOutput> getTransactionOutputList() {
-        if (transactionOutputBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(transactionOutput_);
-        } else {
-          return transactionOutputBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getTransactionOutputList());
       }
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
       public int getTransactionOutputCount() {
-        if (transactionOutputBuilder_ == null) {
-          return transactionOutput_.size();
-        } else {
-          return transactionOutputBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getTransactionOutputCount();
+      }/**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
       public org.floj.wallet.Protos.TransactionOutput getTransactionOutput(int index) {
-        if (transactionOutputBuilder_ == null) {
-          return transactionOutput_.get(index);
-        } else {
-          return transactionOutputBuilder_.getMessage(index);
-        }
+        return instance.getTransactionOutput(index);
       }
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
       public Builder setTransactionOutput(
           int index, org.floj.wallet.Protos.TransactionOutput value) {
-        if (transactionOutputBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionOutputIsMutable();
-          transactionOutput_.set(index, value);
-          onChanged();
-        } else {
-          transactionOutputBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setTransactionOutput(index, value);
         return this;
       }
       /**
@@ -10565,29 +9334,16 @@ public final class Protos {
        */
       public Builder setTransactionOutput(
           int index, org.floj.wallet.Protos.TransactionOutput.Builder builderForValue) {
-        if (transactionOutputBuilder_ == null) {
-          ensureTransactionOutputIsMutable();
-          transactionOutput_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionOutputBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setTransactionOutput(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
       public Builder addTransactionOutput(org.floj.wallet.Protos.TransactionOutput value) {
-        if (transactionOutputBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionOutputIsMutable();
-          transactionOutput_.add(value);
-          onChanged();
-        } else {
-          transactionOutputBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addTransactionOutput(value);
         return this;
       }
       /**
@@ -10595,16 +9351,8 @@ public final class Protos {
        */
       public Builder addTransactionOutput(
           int index, org.floj.wallet.Protos.TransactionOutput value) {
-        if (transactionOutputBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionOutputIsMutable();
-          transactionOutput_.add(index, value);
-          onChanged();
-        } else {
-          transactionOutputBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addTransactionOutput(index, value);
         return this;
       }
       /**
@@ -10612,13 +9360,8 @@ public final class Protos {
        */
       public Builder addTransactionOutput(
           org.floj.wallet.Protos.TransactionOutput.Builder builderForValue) {
-        if (transactionOutputBuilder_ == null) {
-          ensureTransactionOutputIsMutable();
-          transactionOutput_.add(builderForValue.build());
-          onChanged();
-        } else {
-          transactionOutputBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransactionOutput(builderForValue);
         return this;
       }
       /**
@@ -10626,13 +9369,8 @@ public final class Protos {
        */
       public Builder addTransactionOutput(
           int index, org.floj.wallet.Protos.TransactionOutput.Builder builderForValue) {
-        if (transactionOutputBuilder_ == null) {
-          ensureTransactionOutputIsMutable();
-          transactionOutput_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionOutputBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransactionOutput(index, builderForValue);
         return this;
       }
       /**
@@ -10640,257 +9378,152 @@ public final class Protos {
        */
       public Builder addAllTransactionOutput(
           java.lang.Iterable<? extends org.floj.wallet.Protos.TransactionOutput> values) {
-        if (transactionOutputBuilder_ == null) {
-          ensureTransactionOutputIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, transactionOutput_);
-          onChanged();
-        } else {
-          transactionOutputBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllTransactionOutput(values);
         return this;
       }
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
       public Builder clearTransactionOutput() {
-        if (transactionOutputBuilder_ == null) {
-          transactionOutput_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000040);
-          onChanged();
-        } else {
-          transactionOutputBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearTransactionOutput();
         return this;
       }
       /**
        * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
        */
       public Builder removeTransactionOutput(int index) {
-        if (transactionOutputBuilder_ == null) {
-          ensureTransactionOutputIsMutable();
-          transactionOutput_.remove(index);
-          onChanged();
-        } else {
-          transactionOutputBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeTransactionOutput(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-       */
-      public org.floj.wallet.Protos.TransactionOutput.Builder getTransactionOutputBuilder(
-          int index) {
-        return getTransactionOutputFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-       */
-      public org.floj.wallet.Protos.TransactionOutputOrBuilder getTransactionOutputOrBuilder(
-          int index) {
-        if (transactionOutputBuilder_ == null) {
-          return transactionOutput_.get(index);  } else {
-          return transactionOutputBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.TransactionOutputOrBuilder> 
-           getTransactionOutputOrBuilderList() {
-        if (transactionOutputBuilder_ != null) {
-          return transactionOutputBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(transactionOutput_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-       */
-      public org.floj.wallet.Protos.TransactionOutput.Builder addTransactionOutputBuilder() {
-        return getTransactionOutputFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.TransactionOutput.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-       */
-      public org.floj.wallet.Protos.TransactionOutput.Builder addTransactionOutputBuilder(
-          int index) {
-        return getTransactionOutputFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.TransactionOutput.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.TransactionOutput transaction_output = 7;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.TransactionOutput.Builder> 
-           getTransactionOutputBuilderList() {
-        return getTransactionOutputFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.TransactionOutput, org.floj.wallet.Protos.TransactionOutput.Builder, org.floj.wallet.Protos.TransactionOutputOrBuilder> 
-          getTransactionOutputFieldBuilder() {
-        if (transactionOutputBuilder_ == null) {
-          transactionOutputBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.TransactionOutput, org.floj.wallet.Protos.TransactionOutput.Builder, org.floj.wallet.Protos.TransactionOutputOrBuilder>(
-                  transactionOutput_,
-                  ((bitField0_ & 0x00000040) == 0x00000040),
-                  getParentForChildren(),
-                  isClean());
-          transactionOutput_ = null;
-        }
-        return transactionOutputBuilder_;
-      }
 
-      private java.util.List<com.google.protobuf.ByteString> blockHash_ = java.util.Collections.emptyList();
-      private void ensureBlockHashIsMutable() {
-        if (!((bitField0_ & 0x00000080) == 0x00000080)) {
-          blockHash_ = new java.util.ArrayList<com.google.protobuf.ByteString>(blockHash_);
-          bitField0_ |= 0x00000080;
-         }
-      }
       /**
-       * <code>repeated bytes block_hash = 8;</code>
-       *
        * <pre>
        * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
        * ordering within a block.
        * </pre>
+       *
+       * <code>repeated bytes block_hash = 8;</code>
        */
       public java.util.List<com.google.protobuf.ByteString>
           getBlockHashList() {
-        return java.util.Collections.unmodifiableList(blockHash_);
+        return java.util.Collections.unmodifiableList(
+            instance.getBlockHashList());
       }
       /**
-       * <code>repeated bytes block_hash = 8;</code>
-       *
        * <pre>
        * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
        * ordering within a block.
        * </pre>
+       *
+       * <code>repeated bytes block_hash = 8;</code>
        */
       public int getBlockHashCount() {
-        return blockHash_.size();
+        return instance.getBlockHashCount();
       }
       /**
-       * <code>repeated bytes block_hash = 8;</code>
-       *
        * <pre>
        * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
        * ordering within a block.
        * </pre>
+       *
+       * <code>repeated bytes block_hash = 8;</code>
        */
       public com.google.protobuf.ByteString getBlockHash(int index) {
-        return blockHash_.get(index);
+        return instance.getBlockHash(index);
       }
       /**
-       * <code>repeated bytes block_hash = 8;</code>
-       *
        * <pre>
        * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
        * ordering within a block.
        * </pre>
+       *
+       * <code>repeated bytes block_hash = 8;</code>
        */
       public Builder setBlockHash(
           int index, com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureBlockHashIsMutable();
-        blockHash_.set(index, value);
-        onChanged();
+        copyOnWrite();
+        instance.setBlockHash(index, value);
         return this;
       }
       /**
-       * <code>repeated bytes block_hash = 8;</code>
-       *
        * <pre>
        * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
        * ordering within a block.
        * </pre>
+       *
+       * <code>repeated bytes block_hash = 8;</code>
        */
       public Builder addBlockHash(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureBlockHashIsMutable();
-        blockHash_.add(value);
-        onChanged();
+        copyOnWrite();
+        instance.addBlockHash(value);
         return this;
       }
       /**
-       * <code>repeated bytes block_hash = 8;</code>
-       *
        * <pre>
        * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
        * ordering within a block.
        * </pre>
+       *
+       * <code>repeated bytes block_hash = 8;</code>
        */
       public Builder addAllBlockHash(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
-        ensureBlockHashIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, blockHash_);
-        onChanged();
+        copyOnWrite();
+        instance.addAllBlockHash(values);
         return this;
       }
       /**
-       * <code>repeated bytes block_hash = 8;</code>
-       *
        * <pre>
        * A list of blocks in which the transaction has been observed (on any chain). Also, a number used to disambiguate
        * ordering within a block.
        * </pre>
+       *
+       * <code>repeated bytes block_hash = 8;</code>
        */
       public Builder clearBlockHash() {
-        blockHash_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000080);
-        onChanged();
+        copyOnWrite();
+        instance.clearBlockHash();
         return this;
       }
 
-      private java.util.List<java.lang.Integer> blockRelativityOffsets_ = java.util.Collections.emptyList();
-      private void ensureBlockRelativityOffsetsIsMutable() {
-        if (!((bitField0_ & 0x00000100) == 0x00000100)) {
-          blockRelativityOffsets_ = new java.util.ArrayList<java.lang.Integer>(blockRelativityOffsets_);
-          bitField0_ |= 0x00000100;
-         }
-      }
       /**
        * <code>repeated int32 block_relativity_offsets = 11;</code>
        */
       public java.util.List<java.lang.Integer>
           getBlockRelativityOffsetsList() {
-        return java.util.Collections.unmodifiableList(blockRelativityOffsets_);
+        return java.util.Collections.unmodifiableList(
+            instance.getBlockRelativityOffsetsList());
       }
       /**
        * <code>repeated int32 block_relativity_offsets = 11;</code>
        */
       public int getBlockRelativityOffsetsCount() {
-        return blockRelativityOffsets_.size();
+        return instance.getBlockRelativityOffsetsCount();
       }
       /**
        * <code>repeated int32 block_relativity_offsets = 11;</code>
        */
       public int getBlockRelativityOffsets(int index) {
-        return blockRelativityOffsets_.get(index);
+        return instance.getBlockRelativityOffsets(index);
       }
       /**
        * <code>repeated int32 block_relativity_offsets = 11;</code>
        */
       public Builder setBlockRelativityOffsets(
           int index, int value) {
-        ensureBlockRelativityOffsetsIsMutable();
-        blockRelativityOffsets_.set(index, value);
-        onChanged();
+        copyOnWrite();
+        instance.setBlockRelativityOffsets(index, value);
         return this;
       }
       /**
        * <code>repeated int32 block_relativity_offsets = 11;</code>
        */
       public Builder addBlockRelativityOffsets(int value) {
-        ensureBlockRelativityOffsetsIsMutable();
-        blockRelativityOffsets_.add(value);
-        onChanged();
+        copyOnWrite();
+        instance.addBlockRelativityOffsets(value);
         return this;
       }
       /**
@@ -10898,604 +9531,682 @@ public final class Protos {
        */
       public Builder addAllBlockRelativityOffsets(
           java.lang.Iterable<? extends java.lang.Integer> values) {
-        ensureBlockRelativityOffsetsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, blockRelativityOffsets_);
-        onChanged();
+        copyOnWrite();
+        instance.addAllBlockRelativityOffsets(values);
         return this;
       }
       /**
        * <code>repeated int32 block_relativity_offsets = 11;</code>
        */
       public Builder clearBlockRelativityOffsets() {
-        blockRelativityOffsets_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000100);
-        onChanged();
+        copyOnWrite();
+        instance.clearBlockRelativityOffsets();
         return this;
       }
 
-      private org.floj.wallet.Protos.TransactionConfidence confidence_ = org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.TransactionConfidence, org.floj.wallet.Protos.TransactionConfidence.Builder, org.floj.wallet.Protos.TransactionConfidenceOrBuilder> confidenceBuilder_;
       /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
        * <pre>
        * Data describing where the transaction is in the chain.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
        */
       public boolean hasConfidence() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
+        return instance.hasConfidence();
       }
       /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
        * <pre>
        * Data describing where the transaction is in the chain.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
        */
       public org.floj.wallet.Protos.TransactionConfidence getConfidence() {
-        if (confidenceBuilder_ == null) {
-          return confidence_;
-        } else {
-          return confidenceBuilder_.getMessage();
-        }
+        return instance.getConfidence();
       }
       /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
        * <pre>
        * Data describing where the transaction is in the chain.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
        */
       public Builder setConfidence(org.floj.wallet.Protos.TransactionConfidence value) {
-        if (confidenceBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          confidence_ = value;
-          onChanged();
-        } else {
-          confidenceBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000200;
+        copyOnWrite();
+        instance.setConfidence(value);
         return this;
-      }
+        }
       /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
        * <pre>
        * Data describing where the transaction is in the chain.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
        */
       public Builder setConfidence(
           org.floj.wallet.Protos.TransactionConfidence.Builder builderForValue) {
-        if (confidenceBuilder_ == null) {
-          confidence_ = builderForValue.build();
-          onChanged();
-        } else {
-          confidenceBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000200;
+        copyOnWrite();
+        instance.setConfidence(builderForValue);
         return this;
       }
       /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
        * <pre>
        * Data describing where the transaction is in the chain.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
        */
       public Builder mergeConfidence(org.floj.wallet.Protos.TransactionConfidence value) {
-        if (confidenceBuilder_ == null) {
-          if (((bitField0_ & 0x00000200) == 0x00000200) &&
-              confidence_ != org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance()) {
-            confidence_ =
-              org.floj.wallet.Protos.TransactionConfidence.newBuilder(confidence_).mergeFrom(value).buildPartial();
-          } else {
-            confidence_ = value;
-          }
-          onChanged();
-        } else {
-          confidenceBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000200;
+        copyOnWrite();
+        instance.mergeConfidence(value);
         return this;
       }
       /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
        * <pre>
        * Data describing where the transaction is in the chain.
        * </pre>
+       *
+       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
        */
-      public Builder clearConfidence() {
-        if (confidenceBuilder_ == null) {
-          confidence_ = org.floj.wallet.Protos.TransactionConfidence.getDefaultInstance();
-          onChanged();
-        } else {
-          confidenceBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000200);
+      public Builder clearConfidence() {  copyOnWrite();
+        instance.clearConfidence();
         return this;
-      }
-      /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
-       * <pre>
-       * Data describing where the transaction is in the chain.
-       * </pre>
-       */
-      public org.floj.wallet.Protos.TransactionConfidence.Builder getConfidenceBuilder() {
-        bitField0_ |= 0x00000200;
-        onChanged();
-        return getConfidenceFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
-       * <pre>
-       * Data describing where the transaction is in the chain.
-       * </pre>
-       */
-      public org.floj.wallet.Protos.TransactionConfidenceOrBuilder getConfidenceOrBuilder() {
-        if (confidenceBuilder_ != null) {
-          return confidenceBuilder_.getMessageOrBuilder();
-        } else {
-          return confidence_;
-        }
-      }
-      /**
-       * <code>optional .wallet.TransactionConfidence confidence = 9;</code>
-       *
-       * <pre>
-       * Data describing where the transaction is in the chain.
-       * </pre>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.TransactionConfidence, org.floj.wallet.Protos.TransactionConfidence.Builder, org.floj.wallet.Protos.TransactionConfidenceOrBuilder> 
-          getConfidenceFieldBuilder() {
-        if (confidenceBuilder_ == null) {
-          confidenceBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.floj.wallet.Protos.TransactionConfidence, org.floj.wallet.Protos.TransactionConfidence.Builder, org.floj.wallet.Protos.TransactionConfidenceOrBuilder>(
-                  getConfidence(),
-                  getParentForChildren(),
-                  isClean());
-          confidence_ = null;
-        }
-        return confidenceBuilder_;
       }
 
-      private org.floj.wallet.Protos.Transaction.Purpose purpose_ = org.floj.wallet.Protos.Transaction.Purpose.UNKNOWN;
       /**
        * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
        */
       public boolean hasPurpose() {
-        return ((bitField0_ & 0x00000400) == 0x00000400);
+        return instance.hasPurpose();
       }
       /**
        * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
        */
       public org.floj.wallet.Protos.Transaction.Purpose getPurpose() {
-        return purpose_;
+        return instance.getPurpose();
       }
       /**
        * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
        */
       public Builder setPurpose(org.floj.wallet.Protos.Transaction.Purpose value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000400;
-        purpose_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setPurpose(value);
         return this;
       }
       /**
        * <code>optional .wallet.Transaction.Purpose purpose = 10 [default = UNKNOWN];</code>
        */
       public Builder clearPurpose() {
-        bitField0_ = (bitField0_ & ~0x00000400);
-        purpose_ = org.floj.wallet.Protos.Transaction.Purpose.UNKNOWN;
-        onChanged();
+        copyOnWrite();
+        instance.clearPurpose();
         return this;
       }
 
-      private org.floj.wallet.Protos.ExchangeRate exchangeRate_ = org.floj.wallet.Protos.ExchangeRate.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.ExchangeRate, org.floj.wallet.Protos.ExchangeRate.Builder, org.floj.wallet.Protos.ExchangeRateOrBuilder> exchangeRateBuilder_;
       /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
        * <pre>
        * Exchange rate that was valid when the transaction was sent.
        * </pre>
+       *
+       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
        */
       public boolean hasExchangeRate() {
-        return ((bitField0_ & 0x00000800) == 0x00000800);
+        return instance.hasExchangeRate();
       }
       /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
        * <pre>
        * Exchange rate that was valid when the transaction was sent.
        * </pre>
+       *
+       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
        */
       public org.floj.wallet.Protos.ExchangeRate getExchangeRate() {
-        if (exchangeRateBuilder_ == null) {
-          return exchangeRate_;
-        } else {
-          return exchangeRateBuilder_.getMessage();
-        }
+        return instance.getExchangeRate();
       }
       /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
        * <pre>
        * Exchange rate that was valid when the transaction was sent.
        * </pre>
+       *
+       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
        */
       public Builder setExchangeRate(org.floj.wallet.Protos.ExchangeRate value) {
-        if (exchangeRateBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          exchangeRate_ = value;
-          onChanged();
-        } else {
-          exchangeRateBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000800;
+        copyOnWrite();
+        instance.setExchangeRate(value);
         return this;
-      }
+        }
       /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
        * <pre>
        * Exchange rate that was valid when the transaction was sent.
        * </pre>
+       *
+       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
        */
       public Builder setExchangeRate(
           org.floj.wallet.Protos.ExchangeRate.Builder builderForValue) {
-        if (exchangeRateBuilder_ == null) {
-          exchangeRate_ = builderForValue.build();
-          onChanged();
-        } else {
-          exchangeRateBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000800;
+        copyOnWrite();
+        instance.setExchangeRate(builderForValue);
         return this;
       }
       /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
        * <pre>
        * Exchange rate that was valid when the transaction was sent.
        * </pre>
+       *
+       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
        */
       public Builder mergeExchangeRate(org.floj.wallet.Protos.ExchangeRate value) {
-        if (exchangeRateBuilder_ == null) {
-          if (((bitField0_ & 0x00000800) == 0x00000800) &&
-              exchangeRate_ != org.floj.wallet.Protos.ExchangeRate.getDefaultInstance()) {
-            exchangeRate_ =
-              org.floj.wallet.Protos.ExchangeRate.newBuilder(exchangeRate_).mergeFrom(value).buildPartial();
-          } else {
-            exchangeRate_ = value;
-          }
-          onChanged();
-        } else {
-          exchangeRateBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000800;
+        copyOnWrite();
+        instance.mergeExchangeRate(value);
         return this;
       }
       /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
        * <pre>
        * Exchange rate that was valid when the transaction was sent.
        * </pre>
+       *
+       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
        */
-      public Builder clearExchangeRate() {
-        if (exchangeRateBuilder_ == null) {
-          exchangeRate_ = org.floj.wallet.Protos.ExchangeRate.getDefaultInstance();
-          onChanged();
-        } else {
-          exchangeRateBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000800);
+      public Builder clearExchangeRate() {  copyOnWrite();
+        instance.clearExchangeRate();
         return this;
-      }
-      /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
-       * <pre>
-       * Exchange rate that was valid when the transaction was sent.
-       * </pre>
-       */
-      public org.floj.wallet.Protos.ExchangeRate.Builder getExchangeRateBuilder() {
-        bitField0_ |= 0x00000800;
-        onChanged();
-        return getExchangeRateFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
-       * <pre>
-       * Exchange rate that was valid when the transaction was sent.
-       * </pre>
-       */
-      public org.floj.wallet.Protos.ExchangeRateOrBuilder getExchangeRateOrBuilder() {
-        if (exchangeRateBuilder_ != null) {
-          return exchangeRateBuilder_.getMessageOrBuilder();
-        } else {
-          return exchangeRate_;
-        }
-      }
-      /**
-       * <code>optional .wallet.ExchangeRate exchange_rate = 12;</code>
-       *
-       * <pre>
-       * Exchange rate that was valid when the transaction was sent.
-       * </pre>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.ExchangeRate, org.floj.wallet.Protos.ExchangeRate.Builder, org.floj.wallet.Protos.ExchangeRateOrBuilder> 
-          getExchangeRateFieldBuilder() {
-        if (exchangeRateBuilder_ == null) {
-          exchangeRateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.floj.wallet.Protos.ExchangeRate, org.floj.wallet.Protos.ExchangeRate.Builder, org.floj.wallet.Protos.ExchangeRateOrBuilder>(
-                  getExchangeRate(),
-                  getParentForChildren(),
-                  isClean());
-          exchangeRate_ = null;
-        }
-        return exchangeRateBuilder_;
       }
 
-      private java.lang.Object memo_ = "";
       /**
-       * <code>optional string memo = 13;</code>
-       *
        * <pre>
        * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
        * transaction.
        * </pre>
+       *
+       * <code>optional string memo = 13;</code>
        */
       public boolean hasMemo() {
-        return ((bitField0_ & 0x00001000) == 0x00001000);
+        return instance.hasMemo();
       }
       /**
-       * <code>optional string memo = 13;</code>
-       *
        * <pre>
        * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
        * transaction.
        * </pre>
+       *
+       * <code>optional string memo = 13;</code>
        */
       public java.lang.String getMemo() {
-        java.lang.Object ref = memo_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            memo_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getMemo();
       }
       /**
-       * <code>optional string memo = 13;</code>
-       *
        * <pre>
        * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
        * transaction.
        * </pre>
+       *
+       * <code>optional string memo = 13;</code>
        */
       public com.google.protobuf.ByteString
           getMemoBytes() {
-        java.lang.Object ref = memo_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          memo_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getMemoBytes();
       }
       /**
-       * <code>optional string memo = 13;</code>
-       *
        * <pre>
        * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
        * transaction.
        * </pre>
+       *
+       * <code>optional string memo = 13;</code>
        */
       public Builder setMemo(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00001000;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemo(value);
         return this;
       }
       /**
-       * <code>optional string memo = 13;</code>
-       *
        * <pre>
        * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
        * transaction.
        * </pre>
+       *
+       * <code>optional string memo = 13;</code>
        */
       public Builder clearMemo() {
-        bitField0_ = (bitField0_ & ~0x00001000);
-        memo_ = getDefaultInstance().getMemo();
-        onChanged();
+        copyOnWrite();
+        instance.clearMemo();
         return this;
       }
       /**
-       * <code>optional string memo = 13;</code>
-       *
        * <pre>
        * Memo of the transaction. It can be used to record the memo of the payment request that initiated the
        * transaction.
        * </pre>
+       *
+       * <code>optional string memo = 13;</code>
        */
       public Builder setMemoBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00001000;
-        memo_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMemoBytes(value);
         return this;
       }
 
-      private com.google.protobuf.ByteString floData_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes flo_data = 14;</code>
-       *
        * <pre>
        * Next tag: 14
        * </pre>
+       *
+       * <code>optional bytes flo_data = 14;</code>
        */
       public boolean hasFloData() {
-        return ((bitField0_ & 0x00002000) == 0x00002000);
+        return instance.hasFloData();
       }
       /**
-       * <code>optional bytes flo_data = 14;</code>
-       *
        * <pre>
        * Next tag: 14
        * </pre>
+       *
+       * <code>optional bytes flo_data = 14;</code>
        */
       public com.google.protobuf.ByteString getFloData() {
-        return floData_;
+        return instance.getFloData();
       }
       /**
-       * <code>optional bytes flo_data = 14;</code>
-       *
        * <pre>
        * Next tag: 14
        * </pre>
+       *
+       * <code>optional bytes flo_data = 14;</code>
        */
       public Builder setFloData(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00002000;
-        floData_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setFloData(value);
         return this;
       }
       /**
-       * <code>optional bytes flo_data = 14;</code>
-       *
        * <pre>
        * Next tag: 14
        * </pre>
+       *
+       * <code>optional bytes flo_data = 14;</code>
        */
       public Builder clearFloData() {
-        bitField0_ = (bitField0_ & ~0x00002000);
-        floData_ = getDefaultInstance().getFloData();
-        onChanged();
+        copyOnWrite();
+        instance.clearFloData();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.Transaction)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.Transaction();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Transaction(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasVersion()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasHash()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          for (int i = 0; i < getTransactionInputCount(); i++) {
+            if (!getTransactionInput(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          for (int i = 0; i < getTransactionOutputCount(); i++) {
+            if (!getTransactionOutput(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasConfidence()) {
+            if (!getConfidence().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasExchangeRate()) {
+            if (!getExchangeRate().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          transactionInput_.makeImmutable();
+          transactionOutput_.makeImmutable();
+          blockHash_.makeImmutable();
+          blockRelativityOffsets_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.Transaction other = (org.floj.wallet.Protos.Transaction) arg1;
+          version_ = visitor.visitInt(
+              hasVersion(), version_,
+              other.hasVersion(), other.version_);
+          hash_ = visitor.visitByteString(
+              hasHash(), hash_,
+              other.hasHash(), other.hash_);
+          pool_ = visitor.visitInt(hasPool(), pool_,
+              other.hasPool(), other.pool_);
+          lockTime_ = visitor.visitInt(
+              hasLockTime(), lockTime_,
+              other.hasLockTime(), other.lockTime_);
+          updatedAt_ = visitor.visitLong(
+              hasUpdatedAt(), updatedAt_,
+              other.hasUpdatedAt(), other.updatedAt_);
+          transactionInput_= visitor.visitList(transactionInput_, other.transactionInput_);
+          transactionOutput_= visitor.visitList(transactionOutput_, other.transactionOutput_);
+          blockHash_= visitor.visitList(blockHash_, other.blockHash_);
+          blockRelativityOffsets_= visitor.visitIntList(blockRelativityOffsets_, other.blockRelativityOffsets_);
+          confidence_ = visitor.visitMessage(confidence_, other.confidence_);
+          purpose_ = visitor.visitInt(hasPurpose(), purpose_,
+              other.hasPurpose(), other.purpose_);
+          exchangeRate_ = visitor.visitMessage(exchangeRate_, other.exchangeRate_);
+          memo_ = visitor.visitString(
+              hasMemo(), memo_,
+              other.hasMemo(), other.memo_);
+          floData_ = visitor.visitByteString(
+              hasFloData(), floData_,
+              other.hasFloData(), other.floData_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  version_ = input.readInt32();
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  hash_ = input.readBytes();
+                  break;
+                }
+                case 24: {
+                  int rawValue = input.readEnum();
+                  org.floj.wallet.Protos.Transaction.Pool value = org.floj.wallet.Protos.Transaction.Pool.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(3, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000004;
+                    pool_ = rawValue;
+                  }
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000008;
+                  lockTime_ = input.readUInt32();
+                  break;
+                }
+                case 40: {
+                  bitField0_ |= 0x00000010;
+                  updatedAt_ = input.readInt64();
+                  break;
+                }
+                case 50: {
+                  if (!transactionInput_.isModifiable()) {
+                    transactionInput_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(transactionInput_);
+                  }
+                  transactionInput_.add(
+                      input.readMessage(org.floj.wallet.Protos.TransactionInput.parser(), extensionRegistry));
+                  break;
+                }
+                case 58: {
+                  if (!transactionOutput_.isModifiable()) {
+                    transactionOutput_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(transactionOutput_);
+                  }
+                  transactionOutput_.add(
+                      input.readMessage(org.floj.wallet.Protos.TransactionOutput.parser(), extensionRegistry));
+                  break;
+                }
+                case 66: {
+                  if (!blockHash_.isModifiable()) {
+                    blockHash_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(blockHash_);
+                  }
+                  blockHash_.add(input.readBytes());
+                  break;
+                }
+                case 74: {
+                  org.floj.wallet.Protos.TransactionConfidence.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                    subBuilder = confidence_.toBuilder();
+                  }
+                  confidence_ = input.readMessage(org.floj.wallet.Protos.TransactionConfidence.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(confidence_);
+                    confidence_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000020;
+                  break;
+                }
+                case 80: {
+                  int rawValue = input.readEnum();
+                  org.floj.wallet.Protos.Transaction.Purpose value = org.floj.wallet.Protos.Transaction.Purpose.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(10, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000040;
+                    purpose_ = rawValue;
+                  }
+                  break;
+                }
+                case 88: {
+                  if (!blockRelativityOffsets_.isModifiable()) {
+                    blockRelativityOffsets_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(blockRelativityOffsets_);
+                  }
+                  blockRelativityOffsets_.addInt(input.readInt32());
+                  break;
+                }
+                case 90: {
+                  int length = input.readRawVarint32();
+                  int limit = input.pushLimit(length);
+                  if (!blockRelativityOffsets_.isModifiable() && input.getBytesUntilLimit() > 0) {
+                    blockRelativityOffsets_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(blockRelativityOffsets_);
+                  }
+                  while (input.getBytesUntilLimit() > 0) {
+                    blockRelativityOffsets_.addInt(input.readInt32());
+                  }
+                  input.popLimit(limit);
+                  break;
+                }
+                case 98: {
+                  org.floj.wallet.Protos.ExchangeRate.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000080) == 0x00000080)) {
+                    subBuilder = exchangeRate_.toBuilder();
+                  }
+                  exchangeRate_ = input.readMessage(org.floj.wallet.Protos.ExchangeRate.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(exchangeRate_);
+                    exchangeRate_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000080;
+                  break;
+                }
+                case 106: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000100;
+                  memo_ = s;
+                  break;
+                }
+                case 114: {
+                  bitField0_ |= 0x00000200;
+                  floData_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.Transaction.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.Transaction)
+    private static final org.floj.wallet.Protos.Transaction DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Transaction();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.Transaction getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Transaction> PARSER;
+
+    public static com.google.protobuf.Parser<Transaction> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ScryptParametersOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.ScryptParameters)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required bytes salt = 1;</code>
-     *
      * <pre>
      * Salt to use in generation of the wallet password (8 bytes)
      * </pre>
+     *
+     * <code>required bytes salt = 1;</code>
      */
     boolean hasSalt();
     /**
-     * <code>required bytes salt = 1;</code>
-     *
      * <pre>
      * Salt to use in generation of the wallet password (8 bytes)
      * </pre>
+     *
+     * <code>required bytes salt = 1;</code>
      */
     com.google.protobuf.ByteString getSalt();
 
     /**
-     * <code>optional int64 n = 2 [default = 16384];</code>
-     *
      * <pre>
      * CPU/ memory cost parameter
      * </pre>
+     *
+     * <code>optional int64 n = 2 [default = 16384];</code>
      */
     boolean hasN();
     /**
-     * <code>optional int64 n = 2 [default = 16384];</code>
-     *
      * <pre>
      * CPU/ memory cost parameter
      * </pre>
+     *
+     * <code>optional int64 n = 2 [default = 16384];</code>
      */
     long getN();
 
     /**
-     * <code>optional int32 r = 3 [default = 8];</code>
-     *
      * <pre>
      * Block size parameter
      * </pre>
+     *
+     * <code>optional int32 r = 3 [default = 8];</code>
      */
     boolean hasR();
     /**
-     * <code>optional int32 r = 3 [default = 8];</code>
-     *
      * <pre>
      * Block size parameter
      * </pre>
+     *
+     * <code>optional int32 r = 3 [default = 8];</code>
      */
     int getR();
 
     /**
-     * <code>optional int32 p = 4 [default = 1];</code>
-     *
      * <pre>
      * Parallelisation parameter
      * </pre>
+     *
+     * <code>optional int32 p = 4 [default = 1];</code>
      */
     boolean hasP();
     /**
-     * <code>optional int32 p = 4 [default = 1];</code>
-     *
      * <pre>
      * Parallelisation parameter
      * </pre>
+     *
+     * <code>optional int32 p = 4 [default = 1];</code>
      */
     int getP();
   }
   /**
-   * Protobuf type {@code wallet.ScryptParameters}
-   *
    * <pre>
    ** The parameters used in the scrypt key derivation function.
    *  The default values are taken from http://www.tarsnap.com/scrypt/scrypt-slides.pdf.
@@ -11503,231 +10214,206 @@ public final class Protos {
    *  r and p can be used to tweak the algorithm - see:
    *  http://stackoverflow.com/questions/11126315/what-are-optimal-scrypt-work-factors
    * </pre>
+   *
+   * Protobuf type {@code wallet.ScryptParameters}
    */
-  public static final class ScryptParameters extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class ScryptParameters extends
+      com.google.protobuf.GeneratedMessageLite<
+          ScryptParameters, ScryptParameters.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.ScryptParameters)
       ScryptParametersOrBuilder {
-    // Use ScryptParameters.newBuilder() to construct.
-    private ScryptParameters(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
-    }
-    private ScryptParameters(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final ScryptParameters defaultInstance;
-    public static ScryptParameters getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public ScryptParameters getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ScryptParameters(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              salt_ = input.readBytes();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              n_ = input.readInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              r_ = input.readInt32();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              p_ = input.readInt32();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_ScryptParameters_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_ScryptParameters_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.ScryptParameters.class, org.floj.wallet.Protos.ScryptParameters.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<ScryptParameters> PARSER =
-        new com.google.protobuf.AbstractParser<ScryptParameters>() {
-      public ScryptParameters parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ScryptParameters(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ScryptParameters> getParserForType() {
-      return PARSER;
-    }
-
-    private int bitField0_;
-    public static final int SALT_FIELD_NUMBER = 1;
-    private com.google.protobuf.ByteString salt_;
-    /**
-     * <code>required bytes salt = 1;</code>
-     *
-     * <pre>
-     * Salt to use in generation of the wallet password (8 bytes)
-     * </pre>
-     */
-    public boolean hasSalt() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    /**
-     * <code>required bytes salt = 1;</code>
-     *
-     * <pre>
-     * Salt to use in generation of the wallet password (8 bytes)
-     * </pre>
-     */
-    public com.google.protobuf.ByteString getSalt() {
-      return salt_;
-    }
-
-    public static final int N_FIELD_NUMBER = 2;
-    private long n_;
-    /**
-     * <code>optional int64 n = 2 [default = 16384];</code>
-     *
-     * <pre>
-     * CPU/ memory cost parameter
-     * </pre>
-     */
-    public boolean hasN() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
-    }
-    /**
-     * <code>optional int64 n = 2 [default = 16384];</code>
-     *
-     * <pre>
-     * CPU/ memory cost parameter
-     * </pre>
-     */
-    public long getN() {
-      return n_;
-    }
-
-    public static final int R_FIELD_NUMBER = 3;
-    private int r_;
-    /**
-     * <code>optional int32 r = 3 [default = 8];</code>
-     *
-     * <pre>
-     * Block size parameter
-     * </pre>
-     */
-    public boolean hasR() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    /**
-     * <code>optional int32 r = 3 [default = 8];</code>
-     *
-     * <pre>
-     * Block size parameter
-     * </pre>
-     */
-    public int getR() {
-      return r_;
-    }
-
-    public static final int P_FIELD_NUMBER = 4;
-    private int p_;
-    /**
-     * <code>optional int32 p = 4 [default = 1];</code>
-     *
-     * <pre>
-     * Parallelisation parameter
-     * </pre>
-     */
-    public boolean hasP() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
-    }
-    /**
-     * <code>optional int32 p = 4 [default = 1];</code>
-     *
-     * <pre>
-     * Parallelisation parameter
-     * </pre>
-     */
-    public int getP() {
-      return p_;
-    }
-
-    private void initFields() {
+    private ScryptParameters() {
       salt_ = com.google.protobuf.ByteString.EMPTY;
       n_ = 16384L;
       r_ = 8;
       p_ = 1;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+    private int bitField0_;
+    public static final int SALT_FIELD_NUMBER = 1;
+    private com.google.protobuf.ByteString salt_;
+    /**
+     * <pre>
+     * Salt to use in generation of the wallet password (8 bytes)
+     * </pre>
+     *
+     * <code>required bytes salt = 1;</code>
+     */
+    public boolean hasSalt() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <pre>
+     * Salt to use in generation of the wallet password (8 bytes)
+     * </pre>
+     *
+     * <code>required bytes salt = 1;</code>
+     */
+    public com.google.protobuf.ByteString getSalt() {
+      return salt_;
+    }
+    /**
+     * <pre>
+     * Salt to use in generation of the wallet password (8 bytes)
+     * </pre>
+     *
+     * <code>required bytes salt = 1;</code>
+     */
+    private void setSalt(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      salt_ = value;
+    }
+    /**
+     * <pre>
+     * Salt to use in generation of the wallet password (8 bytes)
+     * </pre>
+     *
+     * <code>required bytes salt = 1;</code>
+     */
+    private void clearSalt() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      salt_ = getDefaultInstance().getSalt();
+    }
 
-      if (!hasSalt()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    public static final int N_FIELD_NUMBER = 2;
+    private long n_;
+    /**
+     * <pre>
+     * CPU/ memory cost parameter
+     * </pre>
+     *
+     * <code>optional int64 n = 2 [default = 16384];</code>
+     */
+    public boolean hasN() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * CPU/ memory cost parameter
+     * </pre>
+     *
+     * <code>optional int64 n = 2 [default = 16384];</code>
+     */
+    public long getN() {
+      return n_;
+    }
+    /**
+     * <pre>
+     * CPU/ memory cost parameter
+     * </pre>
+     *
+     * <code>optional int64 n = 2 [default = 16384];</code>
+     */
+    private void setN(long value) {
+      bitField0_ |= 0x00000002;
+      n_ = value;
+    }
+    /**
+     * <pre>
+     * CPU/ memory cost parameter
+     * </pre>
+     *
+     * <code>optional int64 n = 2 [default = 16384];</code>
+     */
+    private void clearN() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      n_ = 16384L;
+    }
+
+    public static final int R_FIELD_NUMBER = 3;
+    private int r_;
+    /**
+     * <pre>
+     * Block size parameter
+     * </pre>
+     *
+     * <code>optional int32 r = 3 [default = 8];</code>
+     */
+    public boolean hasR() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <pre>
+     * Block size parameter
+     * </pre>
+     *
+     * <code>optional int32 r = 3 [default = 8];</code>
+     */
+    public int getR() {
+      return r_;
+    }
+    /**
+     * <pre>
+     * Block size parameter
+     * </pre>
+     *
+     * <code>optional int32 r = 3 [default = 8];</code>
+     */
+    private void setR(int value) {
+      bitField0_ |= 0x00000004;
+      r_ = value;
+    }
+    /**
+     * <pre>
+     * Block size parameter
+     * </pre>
+     *
+     * <code>optional int32 r = 3 [default = 8];</code>
+     */
+    private void clearR() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      r_ = 8;
+    }
+
+    public static final int P_FIELD_NUMBER = 4;
+    private int p_;
+    /**
+     * <pre>
+     * Parallelisation parameter
+     * </pre>
+     *
+     * <code>optional int32 p = 4 [default = 1];</code>
+     */
+    public boolean hasP() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <pre>
+     * Parallelisation parameter
+     * </pre>
+     *
+     * <code>optional int32 p = 4 [default = 1];</code>
+     */
+    public int getP() {
+      return p_;
+    }
+    /**
+     * <pre>
+     * Parallelisation parameter
+     * </pre>
+     *
+     * <code>optional int32 p = 4 [default = 1];</code>
+     */
+    private void setP(int value) {
+      bitField0_ |= 0x00000008;
+      p_ = value;
+    }
+    /**
+     * <pre>
+     * Parallelisation parameter
+     * </pre>
+     *
+     * <code>optional int32 p = 4 [default = 1];</code>
+     */
+    private void clearP() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      p_ = 1;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, salt_);
       }
@@ -11740,10 +10426,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeInt32(4, p_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -11765,87 +10450,80 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(4, p_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.ScryptParameters parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.ScryptParameters prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.ScryptParameters}
-     *
      * <pre>
      ** The parameters used in the scrypt key derivation function.
      *  The default values are taken from http://www.tarsnap.com/scrypt/scrypt-slides.pdf.
@@ -11853,386 +10531,364 @@ public final class Protos {
      *  r and p can be used to tweak the algorithm - see:
      *  http://stackoverflow.com/questions/11126315/what-are-optimal-scrypt-work-factors
      * </pre>
+     *
+     * Protobuf type {@code wallet.ScryptParameters}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.ScryptParameters, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.ScryptParameters)
         org.floj.wallet.Protos.ScryptParametersOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_ScryptParameters_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_ScryptParameters_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.ScryptParameters.class, org.floj.wallet.Protos.ScryptParameters.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.ScryptParameters.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        salt_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        n_ = 16384L;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        r_ = 8;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        p_ = 1;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_ScryptParameters_descriptor;
-      }
-
-      public org.floj.wallet.Protos.ScryptParameters getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.ScryptParameters.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.ScryptParameters build() {
-        org.floj.wallet.Protos.ScryptParameters result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.ScryptParameters buildPartial() {
-        org.floj.wallet.Protos.ScryptParameters result = new org.floj.wallet.Protos.ScryptParameters(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.salt_ = salt_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.n_ = n_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.r_ = r_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.p_ = p_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.ScryptParameters) {
-          return mergeFrom((org.floj.wallet.Protos.ScryptParameters)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.ScryptParameters other) {
-        if (other == org.floj.wallet.Protos.ScryptParameters.getDefaultInstance()) return this;
-        if (other.hasSalt()) {
-          setSalt(other.getSalt());
-        }
-        if (other.hasN()) {
-          setN(other.getN());
-        }
-        if (other.hasR()) {
-          setR(other.getR());
-        }
-        if (other.hasP()) {
-          setP(other.getP());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasSalt()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.ScryptParameters parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.ScryptParameters) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.google.protobuf.ByteString salt_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>required bytes salt = 1;</code>
-       *
        * <pre>
        * Salt to use in generation of the wallet password (8 bytes)
        * </pre>
+       *
+       * <code>required bytes salt = 1;</code>
        */
       public boolean hasSalt() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasSalt();
       }
       /**
-       * <code>required bytes salt = 1;</code>
-       *
        * <pre>
        * Salt to use in generation of the wallet password (8 bytes)
        * </pre>
+       *
+       * <code>required bytes salt = 1;</code>
        */
       public com.google.protobuf.ByteString getSalt() {
-        return salt_;
+        return instance.getSalt();
       }
       /**
-       * <code>required bytes salt = 1;</code>
-       *
        * <pre>
        * Salt to use in generation of the wallet password (8 bytes)
        * </pre>
+       *
+       * <code>required bytes salt = 1;</code>
        */
       public Builder setSalt(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        salt_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setSalt(value);
         return this;
       }
       /**
-       * <code>required bytes salt = 1;</code>
-       *
        * <pre>
        * Salt to use in generation of the wallet password (8 bytes)
        * </pre>
+       *
+       * <code>required bytes salt = 1;</code>
        */
       public Builder clearSalt() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        salt_ = getDefaultInstance().getSalt();
-        onChanged();
+        copyOnWrite();
+        instance.clearSalt();
         return this;
       }
 
-      private long n_ = 16384L;
       /**
-       * <code>optional int64 n = 2 [default = 16384];</code>
-       *
        * <pre>
        * CPU/ memory cost parameter
        * </pre>
+       *
+       * <code>optional int64 n = 2 [default = 16384];</code>
        */
       public boolean hasN() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasN();
       }
       /**
-       * <code>optional int64 n = 2 [default = 16384];</code>
-       *
        * <pre>
        * CPU/ memory cost parameter
        * </pre>
+       *
+       * <code>optional int64 n = 2 [default = 16384];</code>
        */
       public long getN() {
-        return n_;
+        return instance.getN();
       }
       /**
-       * <code>optional int64 n = 2 [default = 16384];</code>
-       *
        * <pre>
        * CPU/ memory cost parameter
        * </pre>
+       *
+       * <code>optional int64 n = 2 [default = 16384];</code>
        */
       public Builder setN(long value) {
-        bitField0_ |= 0x00000002;
-        n_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setN(value);
         return this;
       }
       /**
-       * <code>optional int64 n = 2 [default = 16384];</code>
-       *
        * <pre>
        * CPU/ memory cost parameter
        * </pre>
+       *
+       * <code>optional int64 n = 2 [default = 16384];</code>
        */
       public Builder clearN() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        n_ = 16384L;
-        onChanged();
+        copyOnWrite();
+        instance.clearN();
         return this;
       }
 
-      private int r_ = 8;
       /**
-       * <code>optional int32 r = 3 [default = 8];</code>
-       *
        * <pre>
        * Block size parameter
        * </pre>
+       *
+       * <code>optional int32 r = 3 [default = 8];</code>
        */
       public boolean hasR() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasR();
       }
       /**
-       * <code>optional int32 r = 3 [default = 8];</code>
-       *
        * <pre>
        * Block size parameter
        * </pre>
+       *
+       * <code>optional int32 r = 3 [default = 8];</code>
        */
       public int getR() {
-        return r_;
+        return instance.getR();
       }
       /**
-       * <code>optional int32 r = 3 [default = 8];</code>
-       *
        * <pre>
        * Block size parameter
        * </pre>
+       *
+       * <code>optional int32 r = 3 [default = 8];</code>
        */
       public Builder setR(int value) {
-        bitField0_ |= 0x00000004;
-        r_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setR(value);
         return this;
       }
       /**
-       * <code>optional int32 r = 3 [default = 8];</code>
-       *
        * <pre>
        * Block size parameter
        * </pre>
+       *
+       * <code>optional int32 r = 3 [default = 8];</code>
        */
       public Builder clearR() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        r_ = 8;
-        onChanged();
+        copyOnWrite();
+        instance.clearR();
         return this;
       }
 
-      private int p_ = 1;
       /**
-       * <code>optional int32 p = 4 [default = 1];</code>
-       *
        * <pre>
        * Parallelisation parameter
        * </pre>
+       *
+       * <code>optional int32 p = 4 [default = 1];</code>
        */
       public boolean hasP() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasP();
       }
       /**
-       * <code>optional int32 p = 4 [default = 1];</code>
-       *
        * <pre>
        * Parallelisation parameter
        * </pre>
+       *
+       * <code>optional int32 p = 4 [default = 1];</code>
        */
       public int getP() {
-        return p_;
+        return instance.getP();
       }
       /**
-       * <code>optional int32 p = 4 [default = 1];</code>
-       *
        * <pre>
        * Parallelisation parameter
        * </pre>
+       *
+       * <code>optional int32 p = 4 [default = 1];</code>
        */
       public Builder setP(int value) {
-        bitField0_ |= 0x00000008;
-        p_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setP(value);
         return this;
       }
       /**
-       * <code>optional int32 p = 4 [default = 1];</code>
-       *
        * <pre>
        * Parallelisation parameter
        * </pre>
+       *
+       * <code>optional int32 p = 4 [default = 1];</code>
        */
       public Builder clearP() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        p_ = 1;
-        onChanged();
+        copyOnWrite();
+        instance.clearP();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.ScryptParameters)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.ScryptParameters();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new ScryptParameters(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasSalt()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.ScryptParameters other = (org.floj.wallet.Protos.ScryptParameters) arg1;
+          salt_ = visitor.visitByteString(
+              hasSalt(), salt_,
+              other.hasSalt(), other.salt_);
+          n_ = visitor.visitLong(
+              hasN(), n_,
+              other.hasN(), other.n_);
+          r_ = visitor.visitInt(
+              hasR(), r_,
+              other.hasR(), other.r_);
+          p_ = visitor.visitInt(
+              hasP(), p_,
+              other.hasP(), other.p_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  bitField0_ |= 0x00000001;
+                  salt_ = input.readBytes();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  n_ = input.readInt64();
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000004;
+                  r_ = input.readInt32();
+                  break;
+                }
+                case 32: {
+                  bitField0_ |= 0x00000008;
+                  p_ = input.readInt32();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.ScryptParameters.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.ScryptParameters)
+    private static final org.floj.wallet.Protos.ScryptParameters DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ScryptParameters();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.ScryptParameters getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<ScryptParameters> PARSER;
+
+    public static com.google.protobuf.Parser<ScryptParameters> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ExtensionOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.Extension)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required string id = 1;</code>
-     *
      * <pre>
      * like org.whatever.foo.bar
      * </pre>
+     *
+     * <code>required string id = 1;</code>
      */
     boolean hasId();
     /**
-     * <code>required string id = 1;</code>
-     *
      * <pre>
      * like org.whatever.foo.bar
      * </pre>
+     *
+     * <code>required string id = 1;</code>
      */
     java.lang.String getId();
     /**
-     * <code>required string id = 1;</code>
-     *
      * <pre>
      * like org.whatever.foo.bar
      * </pre>
+     *
+     * <code>required string id = 1;</code>
      */
     com.google.protobuf.ByteString
         getIdBytes();
@@ -12247,190 +10903,116 @@ public final class Protos {
     com.google.protobuf.ByteString getData();
 
     /**
-     * <code>required bool mandatory = 3;</code>
-     *
      * <pre>
      * If we do not understand a mandatory extension, abort to prevent data loss.
      * For example, this could be applied to a new type of holding, such as a contract, where
      * dropping of an extension in a read/write cycle could cause loss of value.
      * </pre>
+     *
+     * <code>required bool mandatory = 3;</code>
      */
     boolean hasMandatory();
     /**
-     * <code>required bool mandatory = 3;</code>
-     *
      * <pre>
      * If we do not understand a mandatory extension, abort to prevent data loss.
      * For example, this could be applied to a new type of holding, such as a contract, where
      * dropping of an extension in a read/write cycle could cause loss of value.
      * </pre>
+     *
+     * <code>required bool mandatory = 3;</code>
      */
     boolean getMandatory();
   }
   /**
-   * Protobuf type {@code wallet.Extension}
-   *
    * <pre>
    ** An extension to the wallet 
    * </pre>
+   *
+   * Protobuf type {@code wallet.Extension}
    */
-  public static final class Extension extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Extension extends
+      com.google.protobuf.GeneratedMessageLite<
+          Extension, Extension.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.Extension)
       ExtensionOrBuilder {
-    // Use Extension.newBuilder() to construct.
-    private Extension(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Extension() {
+      id_ = "";
+      data_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Extension(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Extension defaultInstance;
-    public static Extension getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Extension getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Extension(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              id_ = bs;
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              data_ = input.readBytes();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              mandatory_ = input.readBool();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_Extension_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_Extension_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.Extension.class, org.floj.wallet.Protos.Extension.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Extension> PARSER =
-        new com.google.protobuf.AbstractParser<Extension>() {
-      public Extension parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Extension(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Extension> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ID_FIELD_NUMBER = 1;
-    private java.lang.Object id_;
+    private java.lang.String id_;
     /**
-     * <code>required string id = 1;</code>
-     *
      * <pre>
      * like org.whatever.foo.bar
      * </pre>
+     *
+     * <code>required string id = 1;</code>
      */
     public boolean hasId() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required string id = 1;</code>
-     *
      * <pre>
      * like org.whatever.foo.bar
      * </pre>
+     *
+     * <code>required string id = 1;</code>
      */
     public java.lang.String getId() {
-      java.lang.Object ref = id_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          id_ = s;
-        }
-        return s;
-      }
+      return id_;
     }
     /**
-     * <code>required string id = 1;</code>
-     *
      * <pre>
      * like org.whatever.foo.bar
      * </pre>
+     *
+     * <code>required string id = 1;</code>
      */
     public com.google.protobuf.ByteString
         getIdBytes() {
-      java.lang.Object ref = id_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        id_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(id_);
+    }
+    /**
+     * <pre>
+     * like org.whatever.foo.bar
+     * </pre>
+     *
+     * <code>required string id = 1;</code>
+     */
+    private void setId(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      id_ = value;
+    }
+    /**
+     * <pre>
+     * like org.whatever.foo.bar
+     * </pre>
+     *
+     * <code>required string id = 1;</code>
+     */
+    private void clearId() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      id_ = getDefaultInstance().getId();
+    }
+    /**
+     * <pre>
+     * like org.whatever.foo.bar
+     * </pre>
+     *
+     * <code>required string id = 1;</code>
+     */
+    private void setIdBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      id_ = value.toStringUtf8();
     }
 
     public static final int DATA_FIELD_NUMBER = 2;
@@ -12447,66 +11029,81 @@ public final class Protos {
     public com.google.protobuf.ByteString getData() {
       return data_;
     }
+    /**
+     * <code>required bytes data = 2;</code>
+     */
+    private void setData(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      data_ = value;
+    }
+    /**
+     * <code>required bytes data = 2;</code>
+     */
+    private void clearData() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      data_ = getDefaultInstance().getData();
+    }
 
     public static final int MANDATORY_FIELD_NUMBER = 3;
     private boolean mandatory_;
     /**
-     * <code>required bool mandatory = 3;</code>
-     *
      * <pre>
      * If we do not understand a mandatory extension, abort to prevent data loss.
      * For example, this could be applied to a new type of holding, such as a contract, where
      * dropping of an extension in a read/write cycle could cause loss of value.
      * </pre>
+     *
+     * <code>required bool mandatory = 3;</code>
      */
     public boolean hasMandatory() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>required bool mandatory = 3;</code>
-     *
      * <pre>
      * If we do not understand a mandatory extension, abort to prevent data loss.
      * For example, this could be applied to a new type of holding, such as a contract, where
      * dropping of an extension in a read/write cycle could cause loss of value.
      * </pre>
+     *
+     * <code>required bool mandatory = 3;</code>
      */
     public boolean getMandatory() {
       return mandatory_;
     }
-
-    private void initFields() {
-      id_ = "";
-      data_ = com.google.protobuf.ByteString.EMPTY;
-      mandatory_ = false;
+    /**
+     * <pre>
+     * If we do not understand a mandatory extension, abort to prevent data loss.
+     * For example, this could be applied to a new type of holding, such as a contract, where
+     * dropping of an extension in a read/write cycle could cause loss of value.
+     * </pre>
+     *
+     * <code>required bool mandatory = 3;</code>
+     */
+    private void setMandatory(boolean value) {
+      bitField0_ |= 0x00000004;
+      mandatory_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasData()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasMandatory()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * If we do not understand a mandatory extension, abort to prevent data loss.
+     * For example, this could be applied to a new type of holding, such as a contract, where
+     * dropping of an extension in a read/write cycle could cause loss of value.
+     * </pre>
+     *
+     * <code>required bool mandatory = 3;</code>
+     */
+    private void clearMandatory() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      mandatory_ = false;
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getIdBytes());
+        output.writeString(1, getId());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, data_);
@@ -12514,10 +11111,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBool(3, mandatory_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -12525,7 +11121,7 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getIdBytes());
+          .computeStringSize(1, getId());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -12535,444 +11131,395 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(3, mandatory_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.Extension parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Extension parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Extension parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Extension parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Extension parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Extension parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Extension parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Extension parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Extension parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Extension parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.Extension prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.Extension}
-     *
      * <pre>
      ** An extension to the wallet 
      * </pre>
+     *
+     * Protobuf type {@code wallet.Extension}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.Extension, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.Extension)
         org.floj.wallet.Protos.ExtensionOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_Extension_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_Extension_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.Extension.class, org.floj.wallet.Protos.Extension.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.Extension.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        id_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
-        data_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        mandatory_ = false;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_Extension_descriptor;
-      }
-
-      public org.floj.wallet.Protos.Extension getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.Extension.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.Extension build() {
-        org.floj.wallet.Protos.Extension result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.Extension buildPartial() {
-        org.floj.wallet.Protos.Extension result = new org.floj.wallet.Protos.Extension(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.id_ = id_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.data_ = data_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.mandatory_ = mandatory_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.Extension) {
-          return mergeFrom((org.floj.wallet.Protos.Extension)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.Extension other) {
-        if (other == org.floj.wallet.Protos.Extension.getDefaultInstance()) return this;
-        if (other.hasId()) {
-          bitField0_ |= 0x00000001;
-          id_ = other.id_;
-          onChanged();
-        }
-        if (other.hasData()) {
-          setData(other.getData());
-        }
-        if (other.hasMandatory()) {
-          setMandatory(other.getMandatory());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasId()) {
-          
-          return false;
-        }
-        if (!hasData()) {
-          
-          return false;
-        }
-        if (!hasMandatory()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.Extension parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.Extension) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.lang.Object id_ = "";
       /**
-       * <code>required string id = 1;</code>
-       *
        * <pre>
        * like org.whatever.foo.bar
        * </pre>
+       *
+       * <code>required string id = 1;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasId();
       }
       /**
-       * <code>required string id = 1;</code>
-       *
        * <pre>
        * like org.whatever.foo.bar
        * </pre>
+       *
+       * <code>required string id = 1;</code>
        */
       public java.lang.String getId() {
-        java.lang.Object ref = id_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getId();
       }
       /**
-       * <code>required string id = 1;</code>
-       *
        * <pre>
        * like org.whatever.foo.bar
        * </pre>
+       *
+       * <code>required string id = 1;</code>
        */
       public com.google.protobuf.ByteString
           getIdBytes() {
-        java.lang.Object ref = id_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          id_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getIdBytes();
       }
       /**
-       * <code>required string id = 1;</code>
-       *
        * <pre>
        * like org.whatever.foo.bar
        * </pre>
+       *
+       * <code>required string id = 1;</code>
        */
       public Builder setId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        id_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setId(value);
         return this;
       }
       /**
-       * <code>required string id = 1;</code>
-       *
        * <pre>
        * like org.whatever.foo.bar
        * </pre>
+       *
+       * <code>required string id = 1;</code>
        */
       public Builder clearId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        id_ = getDefaultInstance().getId();
-        onChanged();
+        copyOnWrite();
+        instance.clearId();
         return this;
       }
       /**
-       * <code>required string id = 1;</code>
-       *
        * <pre>
        * like org.whatever.foo.bar
        * </pre>
+       *
+       * <code>required string id = 1;</code>
        */
       public Builder setIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        id_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setIdBytes(value);
         return this;
       }
 
-      private com.google.protobuf.ByteString data_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes data = 2;</code>
        */
       public boolean hasData() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasData();
       }
       /**
        * <code>required bytes data = 2;</code>
        */
       public com.google.protobuf.ByteString getData() {
-        return data_;
+        return instance.getData();
       }
       /**
        * <code>required bytes data = 2;</code>
        */
       public Builder setData(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        data_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setData(value);
         return this;
       }
       /**
        * <code>required bytes data = 2;</code>
        */
       public Builder clearData() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        data_ = getDefaultInstance().getData();
-        onChanged();
+        copyOnWrite();
+        instance.clearData();
         return this;
       }
 
-      private boolean mandatory_ ;
       /**
-       * <code>required bool mandatory = 3;</code>
-       *
        * <pre>
        * If we do not understand a mandatory extension, abort to prevent data loss.
        * For example, this could be applied to a new type of holding, such as a contract, where
        * dropping of an extension in a read/write cycle could cause loss of value.
        * </pre>
+       *
+       * <code>required bool mandatory = 3;</code>
        */
       public boolean hasMandatory() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasMandatory();
       }
       /**
-       * <code>required bool mandatory = 3;</code>
-       *
        * <pre>
        * If we do not understand a mandatory extension, abort to prevent data loss.
        * For example, this could be applied to a new type of holding, such as a contract, where
        * dropping of an extension in a read/write cycle could cause loss of value.
        * </pre>
+       *
+       * <code>required bool mandatory = 3;</code>
        */
       public boolean getMandatory() {
-        return mandatory_;
+        return instance.getMandatory();
       }
       /**
-       * <code>required bool mandatory = 3;</code>
-       *
        * <pre>
        * If we do not understand a mandatory extension, abort to prevent data loss.
        * For example, this could be applied to a new type of holding, such as a contract, where
        * dropping of an extension in a read/write cycle could cause loss of value.
        * </pre>
+       *
+       * <code>required bool mandatory = 3;</code>
        */
       public Builder setMandatory(boolean value) {
-        bitField0_ |= 0x00000004;
-        mandatory_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setMandatory(value);
         return this;
       }
       /**
-       * <code>required bool mandatory = 3;</code>
-       *
        * <pre>
        * If we do not understand a mandatory extension, abort to prevent data loss.
        * For example, this could be applied to a new type of holding, such as a contract, where
        * dropping of an extension in a read/write cycle could cause loss of value.
        * </pre>
+       *
+       * <code>required bool mandatory = 3;</code>
        */
       public Builder clearMandatory() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        mandatory_ = false;
-        onChanged();
+        copyOnWrite();
+        instance.clearMandatory();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.Extension)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.Extension();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Extension(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasId()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasData()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasMandatory()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.Extension other = (org.floj.wallet.Protos.Extension) arg1;
+          id_ = visitor.visitString(
+              hasId(), id_,
+              other.hasId(), other.id_);
+          data_ = visitor.visitByteString(
+              hasData(), data_,
+              other.hasData(), other.data_);
+          mandatory_ = visitor.visitBoolean(
+              hasMandatory(), mandatory_,
+              other.hasMandatory(), other.mandatory_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000001;
+                  id_ = s;
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  data_ = input.readBytes();
+                  break;
+                }
+                case 24: {
+                  bitField0_ |= 0x00000004;
+                  mandatory_ = input.readBool();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.Extension.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.Extension)
+    private static final org.floj.wallet.Protos.Extension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Extension();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.Extension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Extension> PARSER;
+
+    public static com.google.protobuf.Parser<Extension> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface TagOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.Tag)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
      * <code>required string tag = 1;</code>
@@ -12998,117 +11545,27 @@ public final class Protos {
     com.google.protobuf.ByteString getData();
   }
   /**
-   * Protobuf type {@code wallet.Tag}
-   *
    * <pre>
    **
    * A simple key-&gt;value mapping that has no interpreted content at all. A bit like the extensions mechanism except
    * an extension is keyed by the ID of a piece of code that's loaded with the given data, and has the concept of
    * being mandatory if that code isn't found. Whereas this is just a blind key/value store.
    * </pre>
+   *
+   * Protobuf type {@code wallet.Tag}
    */
-  public static final class Tag extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Tag extends
+      com.google.protobuf.GeneratedMessageLite<
+          Tag, Tag.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.Tag)
       TagOrBuilder {
-    // Use Tag.newBuilder() to construct.
-    private Tag(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Tag() {
+      tag_ = "";
+      data_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private Tag(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Tag defaultInstance;
-    public static Tag getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Tag getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Tag(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              tag_ = bs;
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              data_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_Tag_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_Tag_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.Tag.class, org.floj.wallet.Protos.Tag.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Tag> PARSER =
-        new com.google.protobuf.AbstractParser<Tag>() {
-      public Tag parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Tag(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Tag> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int TAG_FIELD_NUMBER = 1;
-    private java.lang.Object tag_;
+    private java.lang.String tag_;
     /**
      * <code>required string tag = 1;</code>
      */
@@ -13119,34 +11576,43 @@ public final class Protos {
      * <code>required string tag = 1;</code>
      */
     public java.lang.String getTag() {
-      java.lang.Object ref = tag_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          tag_ = s;
-        }
-        return s;
-      }
+      return tag_;
     }
     /**
      * <code>required string tag = 1;</code>
      */
     public com.google.protobuf.ByteString
         getTagBytes() {
-      java.lang.Object ref = tag_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        tag_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(tag_);
+    }
+    /**
+     * <code>required string tag = 1;</code>
+     */
+    private void setTag(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      tag_ = value;
+    }
+    /**
+     * <code>required string tag = 1;</code>
+     */
+    private void clearTag() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      tag_ = getDefaultInstance().getTag();
+    }
+    /**
+     * <code>required string tag = 1;</code>
+     */
+    private void setTagBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      tag_ = value.toStringUtf8();
     }
 
     public static final int DATA_FIELD_NUMBER = 2;
@@ -13163,42 +11629,35 @@ public final class Protos {
     public com.google.protobuf.ByteString getData() {
       return data_;
     }
-
-    private void initFields() {
-      tag_ = "";
-      data_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <code>required bytes data = 2;</code>
+     */
+    private void setData(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      data_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasTag()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasData()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <code>required bytes data = 2;</code>
+     */
+    private void clearData() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      data_ = getDefaultInstance().getData();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getTagBytes());
+        output.writeString(1, getTag());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, data_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -13206,295 +11665,140 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getTagBytes());
+          .computeStringSize(1, getTag());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, data_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.Tag parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Tag parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Tag parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Tag parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Tag parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Tag parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Tag parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Tag parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Tag parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Tag parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.Tag prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.Tag}
-     *
      * <pre>
      **
      * A simple key-&gt;value mapping that has no interpreted content at all. A bit like the extensions mechanism except
      * an extension is keyed by the ID of a piece of code that's loaded with the given data, and has the concept of
      * being mandatory if that code isn't found. Whereas this is just a blind key/value store.
      * </pre>
+     *
+     * Protobuf type {@code wallet.Tag}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.Tag, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.Tag)
         org.floj.wallet.Protos.TagOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_Tag_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_Tag_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.Tag.class, org.floj.wallet.Protos.Tag.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.Tag.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        tag_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
-        data_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_Tag_descriptor;
-      }
-
-      public org.floj.wallet.Protos.Tag getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.Tag.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.Tag build() {
-        org.floj.wallet.Protos.Tag result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.Tag buildPartial() {
-        org.floj.wallet.Protos.Tag result = new org.floj.wallet.Protos.Tag(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.tag_ = tag_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.data_ = data_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.Tag) {
-          return mergeFrom((org.floj.wallet.Protos.Tag)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.Tag other) {
-        if (other == org.floj.wallet.Protos.Tag.getDefaultInstance()) return this;
-        if (other.hasTag()) {
-          bitField0_ |= 0x00000001;
-          tag_ = other.tag_;
-          onChanged();
-        }
-        if (other.hasData()) {
-          setData(other.getData());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasTag()) {
-          
-          return false;
-        }
-        if (!hasData()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.Tag parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.Tag) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.lang.Object tag_ = "";
       /**
        * <code>required string tag = 1;</code>
        */
       public boolean hasTag() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasTag();
       }
       /**
        * <code>required string tag = 1;</code>
        */
       public java.lang.String getTag() {
-        java.lang.Object ref = tag_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            tag_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getTag();
       }
       /**
        * <code>required string tag = 1;</code>
        */
       public com.google.protobuf.ByteString
           getTagBytes() {
-        java.lang.Object ref = tag_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          tag_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getTagBytes();
       }
       /**
        * <code>required string tag = 1;</code>
        */
       public Builder setTag(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        tag_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTag(value);
         return this;
       }
       /**
        * <code>required string tag = 1;</code>
        */
       public Builder clearTag() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        tag_ = getDefaultInstance().getTag();
-        onChanged();
+        copyOnWrite();
+        instance.clearTag();
         return this;
       }
       /**
@@ -13502,324 +11806,368 @@ public final class Protos {
        */
       public Builder setTagBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        tag_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setTagBytes(value);
         return this;
       }
 
-      private com.google.protobuf.ByteString data_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes data = 2;</code>
        */
       public boolean hasData() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasData();
       }
       /**
        * <code>required bytes data = 2;</code>
        */
       public com.google.protobuf.ByteString getData() {
-        return data_;
+        return instance.getData();
       }
       /**
        * <code>required bytes data = 2;</code>
        */
       public Builder setData(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        data_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setData(value);
         return this;
       }
       /**
        * <code>required bytes data = 2;</code>
        */
       public Builder clearData() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        data_ = getDefaultInstance().getData();
-        onChanged();
+        copyOnWrite();
+        instance.clearData();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.Tag)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.Tag();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Tag(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasTag()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasData()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.Tag other = (org.floj.wallet.Protos.Tag) arg1;
+          tag_ = visitor.visitString(
+              hasTag(), tag_,
+              other.hasTag(), other.tag_);
+          data_ = visitor.visitByteString(
+              hasData(), data_,
+              other.hasData(), other.data_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000001;
+                  tag_ = s;
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  data_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.Tag.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.Tag)
+    private static final org.floj.wallet.Protos.Tag DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Tag();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.Tag getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Tag> PARSER;
+
+    public static com.google.protobuf.Parser<Tag> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface TransactionSignerOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.TransactionSigner)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required string class_name = 1;</code>
-     *
      * <pre>
      * fully qualified class name of TransactionSigner implementation
      * </pre>
+     *
+     * <code>required string class_name = 1;</code>
      */
     boolean hasClassName();
     /**
-     * <code>required string class_name = 1;</code>
-     *
      * <pre>
      * fully qualified class name of TransactionSigner implementation
      * </pre>
+     *
+     * <code>required string class_name = 1;</code>
      */
     java.lang.String getClassName();
     /**
-     * <code>required string class_name = 1;</code>
-     *
      * <pre>
      * fully qualified class name of TransactionSigner implementation
      * </pre>
+     *
+     * <code>required string class_name = 1;</code>
      */
     com.google.protobuf.ByteString
         getClassNameBytes();
 
     /**
-     * <code>optional bytes data = 2;</code>
-     *
      * <pre>
      * arbitrary data required for signer to function
      * </pre>
+     *
+     * <code>optional bytes data = 2;</code>
      */
     boolean hasData();
     /**
-     * <code>optional bytes data = 2;</code>
-     *
      * <pre>
      * arbitrary data required for signer to function
      * </pre>
+     *
+     * <code>optional bytes data = 2;</code>
      */
     com.google.protobuf.ByteString getData();
   }
   /**
-   * Protobuf type {@code wallet.TransactionSigner}
-   *
    * <pre>
    **
    * Data required to reconstruct TransactionSigner.
    * </pre>
+   *
+   * Protobuf type {@code wallet.TransactionSigner}
    */
-  public static final class TransactionSigner extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class TransactionSigner extends
+      com.google.protobuf.GeneratedMessageLite<
+          TransactionSigner, TransactionSigner.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.TransactionSigner)
       TransactionSignerOrBuilder {
-    // Use TransactionSigner.newBuilder() to construct.
-    private TransactionSigner(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private TransactionSigner() {
+      className_ = "";
+      data_ = com.google.protobuf.ByteString.EMPTY;
     }
-    private TransactionSigner(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final TransactionSigner defaultInstance;
-    public static TransactionSigner getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public TransactionSigner getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private TransactionSigner(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              className_ = bs;
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              data_ = input.readBytes();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionSigner_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_TransactionSigner_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.TransactionSigner.class, org.floj.wallet.Protos.TransactionSigner.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<TransactionSigner> PARSER =
-        new com.google.protobuf.AbstractParser<TransactionSigner>() {
-      public TransactionSigner parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TransactionSigner(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<TransactionSigner> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int CLASS_NAME_FIELD_NUMBER = 1;
-    private java.lang.Object className_;
+    private java.lang.String className_;
     /**
-     * <code>required string class_name = 1;</code>
-     *
      * <pre>
      * fully qualified class name of TransactionSigner implementation
      * </pre>
+     *
+     * <code>required string class_name = 1;</code>
      */
     public boolean hasClassName() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required string class_name = 1;</code>
-     *
      * <pre>
      * fully qualified class name of TransactionSigner implementation
      * </pre>
+     *
+     * <code>required string class_name = 1;</code>
      */
     public java.lang.String getClassName() {
-      java.lang.Object ref = className_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          className_ = s;
-        }
-        return s;
-      }
+      return className_;
     }
     /**
-     * <code>required string class_name = 1;</code>
-     *
      * <pre>
      * fully qualified class name of TransactionSigner implementation
      * </pre>
+     *
+     * <code>required string class_name = 1;</code>
      */
     public com.google.protobuf.ByteString
         getClassNameBytes() {
-      java.lang.Object ref = className_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        className_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(className_);
+    }
+    /**
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     *
+     * <code>required string class_name = 1;</code>
+     */
+    private void setClassName(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      className_ = value;
+    }
+    /**
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     *
+     * <code>required string class_name = 1;</code>
+     */
+    private void clearClassName() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      className_ = getDefaultInstance().getClassName();
+    }
+    /**
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     *
+     * <code>required string class_name = 1;</code>
+     */
+    private void setClassNameBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      className_ = value.toStringUtf8();
     }
 
     public static final int DATA_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString data_;
     /**
-     * <code>optional bytes data = 2;</code>
-     *
      * <pre>
      * arbitrary data required for signer to function
      * </pre>
+     *
+     * <code>optional bytes data = 2;</code>
      */
     public boolean hasData() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional bytes data = 2;</code>
-     *
      * <pre>
      * arbitrary data required for signer to function
      * </pre>
+     *
+     * <code>optional bytes data = 2;</code>
      */
     public com.google.protobuf.ByteString getData() {
       return data_;
     }
-
-    private void initFields() {
-      className_ = "";
-      data_ = com.google.protobuf.ByteString.EMPTY;
+    /**
+     * <pre>
+     * arbitrary data required for signer to function
+     * </pre>
+     *
+     * <code>optional bytes data = 2;</code>
+     */
+    private void setData(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      data_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasClassName()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * arbitrary data required for signer to function
+     * </pre>
+     *
+     * <code>optional bytes data = 2;</code>
+     */
+    private void clearData() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      data_ = getDefaultInstance().getData();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getClassNameBytes());
+        output.writeString(1, getClassName());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, data_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -13827,452 +12175,403 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getClassNameBytes());
+          .computeStringSize(1, getClassName());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, data_);
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.TransactionSigner parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.TransactionSigner prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.TransactionSigner}
-     *
      * <pre>
      **
      * Data required to reconstruct TransactionSigner.
      * </pre>
+     *
+     * Protobuf type {@code wallet.TransactionSigner}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.TransactionSigner, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.TransactionSigner)
         org.floj.wallet.Protos.TransactionSignerOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionSigner_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionSigner_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.TransactionSigner.class, org.floj.wallet.Protos.TransactionSigner.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.TransactionSigner.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        className_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
-        data_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_TransactionSigner_descriptor;
-      }
-
-      public org.floj.wallet.Protos.TransactionSigner getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.TransactionSigner.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.TransactionSigner build() {
-        org.floj.wallet.Protos.TransactionSigner result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.TransactionSigner buildPartial() {
-        org.floj.wallet.Protos.TransactionSigner result = new org.floj.wallet.Protos.TransactionSigner(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.className_ = className_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.data_ = data_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.TransactionSigner) {
-          return mergeFrom((org.floj.wallet.Protos.TransactionSigner)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.TransactionSigner other) {
-        if (other == org.floj.wallet.Protos.TransactionSigner.getDefaultInstance()) return this;
-        if (other.hasClassName()) {
-          bitField0_ |= 0x00000001;
-          className_ = other.className_;
-          onChanged();
-        }
-        if (other.hasData()) {
-          setData(other.getData());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasClassName()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.TransactionSigner parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.TransactionSigner) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.lang.Object className_ = "";
       /**
-       * <code>required string class_name = 1;</code>
-       *
        * <pre>
        * fully qualified class name of TransactionSigner implementation
        * </pre>
+       *
+       * <code>required string class_name = 1;</code>
        */
       public boolean hasClassName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasClassName();
       }
       /**
-       * <code>required string class_name = 1;</code>
-       *
        * <pre>
        * fully qualified class name of TransactionSigner implementation
        * </pre>
+       *
+       * <code>required string class_name = 1;</code>
        */
       public java.lang.String getClassName() {
-        java.lang.Object ref = className_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            className_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getClassName();
       }
       /**
-       * <code>required string class_name = 1;</code>
-       *
        * <pre>
        * fully qualified class name of TransactionSigner implementation
        * </pre>
+       *
+       * <code>required string class_name = 1;</code>
        */
       public com.google.protobuf.ByteString
           getClassNameBytes() {
-        java.lang.Object ref = className_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          className_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getClassNameBytes();
       }
       /**
-       * <code>required string class_name = 1;</code>
-       *
        * <pre>
        * fully qualified class name of TransactionSigner implementation
        * </pre>
+       *
+       * <code>required string class_name = 1;</code>
        */
       public Builder setClassName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        className_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setClassName(value);
         return this;
       }
       /**
-       * <code>required string class_name = 1;</code>
-       *
        * <pre>
        * fully qualified class name of TransactionSigner implementation
        * </pre>
+       *
+       * <code>required string class_name = 1;</code>
        */
       public Builder clearClassName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        className_ = getDefaultInstance().getClassName();
-        onChanged();
+        copyOnWrite();
+        instance.clearClassName();
         return this;
       }
       /**
-       * <code>required string class_name = 1;</code>
-       *
        * <pre>
        * fully qualified class name of TransactionSigner implementation
        * </pre>
+       *
+       * <code>required string class_name = 1;</code>
        */
       public Builder setClassNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        className_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setClassNameBytes(value);
         return this;
       }
 
-      private com.google.protobuf.ByteString data_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes data = 2;</code>
-       *
        * <pre>
        * arbitrary data required for signer to function
        * </pre>
+       *
+       * <code>optional bytes data = 2;</code>
        */
       public boolean hasData() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasData();
       }
       /**
-       * <code>optional bytes data = 2;</code>
-       *
        * <pre>
        * arbitrary data required for signer to function
        * </pre>
+       *
+       * <code>optional bytes data = 2;</code>
        */
       public com.google.protobuf.ByteString getData() {
-        return data_;
+        return instance.getData();
       }
       /**
-       * <code>optional bytes data = 2;</code>
-       *
        * <pre>
        * arbitrary data required for signer to function
        * </pre>
+       *
+       * <code>optional bytes data = 2;</code>
        */
       public Builder setData(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        data_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setData(value);
         return this;
       }
       /**
-       * <code>optional bytes data = 2;</code>
-       *
        * <pre>
        * arbitrary data required for signer to function
        * </pre>
+       *
+       * <code>optional bytes data = 2;</code>
        */
       public Builder clearData() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        data_ = getDefaultInstance().getData();
-        onChanged();
+        copyOnWrite();
+        instance.clearData();
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.TransactionSigner)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.TransactionSigner();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new TransactionSigner(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasClassName()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.TransactionSigner other = (org.floj.wallet.Protos.TransactionSigner) arg1;
+          className_ = visitor.visitString(
+              hasClassName(), className_,
+              other.hasClassName(), other.className_);
+          data_ = visitor.visitByteString(
+              hasData(), data_,
+              other.hasData(), other.data_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000001;
+                  className_ = s;
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  data_ = input.readBytes();
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.TransactionSigner.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.TransactionSigner)
+    private static final org.floj.wallet.Protos.TransactionSigner DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new TransactionSigner();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.TransactionSigner getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<TransactionSigner> PARSER;
+
+    public static com.google.protobuf.Parser<TransactionSigner> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface WalletOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.Wallet)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required string network_identifier = 1;</code>
-     *
      * <pre>
      * the network used by this wallet
      * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
      */
     boolean hasNetworkIdentifier();
     /**
-     * <code>required string network_identifier = 1;</code>
-     *
      * <pre>
      * the network used by this wallet
      * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
      */
     java.lang.String getNetworkIdentifier();
     /**
-     * <code>required string network_identifier = 1;</code>
-     *
      * <pre>
      * the network used by this wallet
      * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
      */
     com.google.protobuf.ByteString
         getNetworkIdentifierBytes();
 
     /**
-     * <code>optional bytes last_seen_block_hash = 2;</code>
-     *
      * <pre>
      * The SHA256 hash of the head of the best chain seen by this wallet.
      * </pre>
+     *
+     * <code>optional bytes last_seen_block_hash = 2;</code>
      */
     boolean hasLastSeenBlockHash();
     /**
-     * <code>optional bytes last_seen_block_hash = 2;</code>
-     *
      * <pre>
      * The SHA256 hash of the head of the best chain seen by this wallet.
      * </pre>
+     *
+     * <code>optional bytes last_seen_block_hash = 2;</code>
      */
     com.google.protobuf.ByteString getLastSeenBlockHash();
 
     /**
-     * <code>optional uint32 last_seen_block_height = 12;</code>
-     *
      * <pre>
      * The height in the chain of the last seen block.
      * </pre>
+     *
+     * <code>optional uint32 last_seen_block_height = 12;</code>
      */
     boolean hasLastSeenBlockHeight();
     /**
-     * <code>optional uint32 last_seen_block_height = 12;</code>
-     *
      * <pre>
      * The height in the chain of the last seen block.
      * </pre>
+     *
+     * <code>optional uint32 last_seen_block_height = 12;</code>
      */
     int getLastSeenBlockHeight();
 
@@ -14298,16 +12597,6 @@ public final class Protos {
      * <code>repeated .wallet.Key key = 3;</code>
      */
     int getKeyCount();
-    /**
-     * <code>repeated .wallet.Key key = 3;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.KeyOrBuilder> 
-        getKeyOrBuilderList();
-    /**
-     * <code>repeated .wallet.Key key = 3;</code>
-     */
-    org.floj.wallet.Protos.KeyOrBuilder getKeyOrBuilder(
-        int index);
 
     /**
      * <code>repeated .wallet.Transaction transaction = 4;</code>
@@ -14322,16 +12611,6 @@ public final class Protos {
      * <code>repeated .wallet.Transaction transaction = 4;</code>
      */
     int getTransactionCount();
-    /**
-     * <code>repeated .wallet.Transaction transaction = 4;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.TransactionOrBuilder> 
-        getTransactionOrBuilderList();
-    /**
-     * <code>repeated .wallet.Transaction transaction = 4;</code>
-     */
-    org.floj.wallet.Protos.TransactionOrBuilder getTransactionOrBuilder(
-        int index);
 
     /**
      * <code>repeated .wallet.Script watched_script = 15;</code>
@@ -14346,16 +12625,6 @@ public final class Protos {
      * <code>repeated .wallet.Script watched_script = 15;</code>
      */
     int getWatchedScriptCount();
-    /**
-     * <code>repeated .wallet.Script watched_script = 15;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.ScriptOrBuilder> 
-        getWatchedScriptOrBuilderList();
-    /**
-     * <code>repeated .wallet.Script watched_script = 15;</code>
-     */
-    org.floj.wallet.Protos.ScriptOrBuilder getWatchedScriptOrBuilder(
-        int index);
 
     /**
      * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
@@ -14374,29 +12643,25 @@ public final class Protos {
      * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
      */
     org.floj.wallet.Protos.ScryptParameters getEncryptionParameters();
-    /**
-     * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
-     */
-    org.floj.wallet.Protos.ScryptParametersOrBuilder getEncryptionParametersOrBuilder();
 
     /**
-     * <code>optional int32 version = 7 [default = 1];</code>
-     *
      * <pre>
      * The version number of the wallet - used to detect wallets that were produced in the future
      * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
      * A version that's higher than the default is considered from the future.
      * </pre>
+     *
+     * <code>optional int32 version = 7 [default = 1];</code>
      */
     boolean hasVersion();
     /**
-     * <code>optional int32 version = 7 [default = 1];</code>
-     *
      * <pre>
      * The version number of the wallet - used to detect wallets that were produced in the future
      * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
      * A version that's higher than the default is considered from the future.
      * </pre>
+     *
+     * <code>optional int32 version = 7 [default = 1];</code>
      */
     int getVersion();
 
@@ -14413,61 +12678,51 @@ public final class Protos {
      * <code>repeated .wallet.Extension extension = 10;</code>
      */
     int getExtensionCount();
-    /**
-     * <code>repeated .wallet.Extension extension = 10;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.ExtensionOrBuilder> 
-        getExtensionOrBuilderList();
-    /**
-     * <code>repeated .wallet.Extension extension = 10;</code>
-     */
-    org.floj.wallet.Protos.ExtensionOrBuilder getExtensionOrBuilder(
-        int index);
 
     /**
-     * <code>optional string description = 11;</code>
-     *
      * <pre>
      * A UTF8 encoded text description of the wallet that is intended for end user provided text.
      * </pre>
+     *
+     * <code>optional string description = 11;</code>
      */
     boolean hasDescription();
     /**
-     * <code>optional string description = 11;</code>
-     *
      * <pre>
      * A UTF8 encoded text description of the wallet that is intended for end user provided text.
      * </pre>
+     *
+     * <code>optional string description = 11;</code>
      */
     java.lang.String getDescription();
     /**
-     * <code>optional string description = 11;</code>
-     *
      * <pre>
      * A UTF8 encoded text description of the wallet that is intended for end user provided text.
      * </pre>
+     *
+     * <code>optional string description = 11;</code>
      */
     com.google.protobuf.ByteString
         getDescriptionBytes();
 
     /**
-     * <code>optional uint64 key_rotation_time = 13;</code>
-     *
      * <pre>
      * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
      * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
      * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
      * </pre>
+     *
+     * <code>optional uint64 key_rotation_time = 13;</code>
      */
     boolean hasKeyRotationTime();
     /**
-     * <code>optional uint64 key_rotation_time = 13;</code>
-     *
      * <pre>
      * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
      * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
      * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
      * </pre>
+     *
+     * <code>optional uint64 key_rotation_time = 13;</code>
      */
     long getKeyRotationTime();
 
@@ -14484,286 +12739,59 @@ public final class Protos {
      * <code>repeated .wallet.Tag tags = 16;</code>
      */
     int getTagsCount();
-    /**
-     * <code>repeated .wallet.Tag tags = 16;</code>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.TagOrBuilder> 
-        getTagsOrBuilderList();
-    /**
-     * <code>repeated .wallet.Tag tags = 16;</code>
-     */
-    org.floj.wallet.Protos.TagOrBuilder getTagsOrBuilder(
-        int index);
 
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     java.util.List<org.floj.wallet.Protos.TransactionSigner> 
         getTransactionSignersList();
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     org.floj.wallet.Protos.TransactionSigner getTransactionSigners(int index);
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     int getTransactionSignersCount();
-    /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
-     * <pre>
-     * transaction signers added to the wallet
-     * </pre>
-     */
-    java.util.List<? extends org.floj.wallet.Protos.TransactionSignerOrBuilder> 
-        getTransactionSignersOrBuilderList();
-    /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
-     * <pre>
-     * transaction signers added to the wallet
-     * </pre>
-     */
-    org.floj.wallet.Protos.TransactionSignerOrBuilder getTransactionSignersOrBuilder(
-        int index);
   }
   /**
-   * Protobuf type {@code wallet.Wallet}
-   *
    * <pre>
    ** A flo wallet 
    * </pre>
+   *
+   * Protobuf type {@code wallet.Wallet}
    */
-  public static final class Wallet extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class Wallet extends
+      com.google.protobuf.GeneratedMessageLite<
+          Wallet, Wallet.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.Wallet)
       WalletOrBuilder {
-    // Use Wallet.newBuilder() to construct.
-    private Wallet(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private Wallet() {
+      networkIdentifier_ = "";
+      lastSeenBlockHash_ = com.google.protobuf.ByteString.EMPTY;
+      key_ = emptyProtobufList();
+      transaction_ = emptyProtobufList();
+      watchedScript_ = emptyProtobufList();
+      encryptionType_ = 1;
+      version_ = 1;
+      extension_ = emptyProtobufList();
+      description_ = "";
+      tags_ = emptyProtobufList();
+      transactionSigners_ = emptyProtobufList();
     }
-    private Wallet(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final Wallet defaultInstance;
-    public static Wallet getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Wallet getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Wallet(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              networkIdentifier_ = bs;
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              lastSeenBlockHash_ = input.readBytes();
-              break;
-            }
-            case 26: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                key_ = new java.util.ArrayList<org.floj.wallet.Protos.Key>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              key_.add(input.readMessage(org.floj.wallet.Protos.Key.PARSER, extensionRegistry));
-              break;
-            }
-            case 34: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                transaction_ = new java.util.ArrayList<org.floj.wallet.Protos.Transaction>();
-                mutable_bitField0_ |= 0x00000020;
-              }
-              transaction_.add(input.readMessage(org.floj.wallet.Protos.Transaction.PARSER, extensionRegistry));
-              break;
-            }
-            case 40: {
-              int rawValue = input.readEnum();
-              org.floj.wallet.Protos.Wallet.EncryptionType value = org.floj.wallet.Protos.Wallet.EncryptionType.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(5, rawValue);
-              } else {
-                bitField0_ |= 0x00000010;
-                encryptionType_ = value;
-              }
-              break;
-            }
-            case 50: {
-              org.floj.wallet.Protos.ScryptParameters.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                subBuilder = encryptionParameters_.toBuilder();
-              }
-              encryptionParameters_ = input.readMessage(org.floj.wallet.Protos.ScryptParameters.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(encryptionParameters_);
-                encryptionParameters_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000020;
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              version_ = input.readInt32();
-              break;
-            }
-            case 82: {
-              if (!((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
-                extension_ = new java.util.ArrayList<org.floj.wallet.Protos.Extension>();
-                mutable_bitField0_ |= 0x00000400;
-              }
-              extension_.add(input.readMessage(org.floj.wallet.Protos.Extension.PARSER, extensionRegistry));
-              break;
-            }
-            case 90: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000080;
-              description_ = bs;
-              break;
-            }
-            case 96: {
-              bitField0_ |= 0x00000004;
-              lastSeenBlockHeight_ = input.readUInt32();
-              break;
-            }
-            case 104: {
-              bitField0_ |= 0x00000100;
-              keyRotationTime_ = input.readUInt64();
-              break;
-            }
-            case 112: {
-              bitField0_ |= 0x00000008;
-              lastSeenBlockTimeSecs_ = input.readInt64();
-              break;
-            }
-            case 122: {
-              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-                watchedScript_ = new java.util.ArrayList<org.floj.wallet.Protos.Script>();
-                mutable_bitField0_ |= 0x00000040;
-              }
-              watchedScript_.add(input.readMessage(org.floj.wallet.Protos.Script.PARSER, extensionRegistry));
-              break;
-            }
-            case 130: {
-              if (!((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
-                tags_ = new java.util.ArrayList<org.floj.wallet.Protos.Tag>();
-                mutable_bitField0_ |= 0x00002000;
-              }
-              tags_.add(input.readMessage(org.floj.wallet.Protos.Tag.PARSER, extensionRegistry));
-              break;
-            }
-            case 138: {
-              if (!((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
-                transactionSigners_ = new java.util.ArrayList<org.floj.wallet.Protos.TransactionSigner>();
-                mutable_bitField0_ |= 0x00004000;
-              }
-              transactionSigners_.add(input.readMessage(org.floj.wallet.Protos.TransactionSigner.PARSER, extensionRegistry));
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          key_ = java.util.Collections.unmodifiableList(key_);
-        }
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-          transaction_ = java.util.Collections.unmodifiableList(transaction_);
-        }
-        if (((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
-          extension_ = java.util.Collections.unmodifiableList(extension_);
-        }
-        if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-          watchedScript_ = java.util.Collections.unmodifiableList(watchedScript_);
-        }
-        if (((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
-          tags_ = java.util.Collections.unmodifiableList(tags_);
-        }
-        if (((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
-          transactionSigners_ = java.util.Collections.unmodifiableList(transactionSigners_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_Wallet_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_Wallet_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.Wallet.class, org.floj.wallet.Protos.Wallet.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<Wallet> PARSER =
-        new com.google.protobuf.AbstractParser<Wallet>() {
-      public Wallet parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Wallet(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<Wallet> getParserForType() {
-      return PARSER;
-    }
-
     /**
-     * Protobuf enum {@code wallet.Wallet.EncryptionType}
-     *
      * <pre>
      **
      * The encryption type of the wallet.
@@ -14771,48 +12799,60 @@ public final class Protos {
      * encryption support are grandfathered in as this wallet type.
      * When a wallet is ENCRYPTED_SCRYPT_AES the keys are either encrypted with the wallet password or are unencrypted.
      * </pre>
+     *
+     * Protobuf enum {@code wallet.Wallet.EncryptionType}
      */
     public enum EncryptionType
-        implements com.google.protobuf.ProtocolMessageEnum {
+        implements com.google.protobuf.Internal.EnumLite {
       /**
-       * <code>UNENCRYPTED = 1;</code>
-       *
        * <pre>
        * All keys in the wallet are unencrypted
        * </pre>
-       */
-      UNENCRYPTED(0, 1),
-      /**
-       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
        *
+       * <code>UNENCRYPTED = 1;</code>
+       */
+      UNENCRYPTED(1),
+      /**
        * <pre>
        * All keys are encrypted with a passphrase based KDF of scrypt and AES encryption
        * </pre>
+       *
+       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
        */
-      ENCRYPTED_SCRYPT_AES(1, 2),
+      ENCRYPTED_SCRYPT_AES(2),
       ;
 
       /**
-       * <code>UNENCRYPTED = 1;</code>
-       *
        * <pre>
        * All keys in the wallet are unencrypted
        * </pre>
+       *
+       * <code>UNENCRYPTED = 1;</code>
        */
       public static final int UNENCRYPTED_VALUE = 1;
       /**
-       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
-       *
        * <pre>
        * All keys are encrypted with a passphrase based KDF of scrypt and AES encryption
        * </pre>
+       *
+       * <code>ENCRYPTED_SCRYPT_AES = 2;</code>
        */
       public static final int ENCRYPTED_SCRYPT_AES_VALUE = 2;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static EncryptionType valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static EncryptionType forNumber(int value) {
         switch (value) {
           case 1: return UNENCRYPTED;
           case 2: return ENCRYPTED_SCRYPT_AES;
@@ -14824,43 +12864,17 @@ public final class Protos {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<EncryptionType>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          EncryptionType> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<EncryptionType>() {
               public EncryptionType findValueByNumber(int number) {
-                return EncryptionType.valueOf(number);
+                return EncryptionType.forNumber(number);
               }
             };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.Wallet.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final EncryptionType[] VALUES = values();
-
-      public static EncryptionType valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
       private final int value;
 
-      private EncryptionType(int index, int value) {
-        this.index = index;
+      private EncryptionType(int value) {
         this.value = value;
       }
 
@@ -14869,103 +12883,171 @@ public final class Protos {
 
     private int bitField0_;
     public static final int NETWORK_IDENTIFIER_FIELD_NUMBER = 1;
-    private java.lang.Object networkIdentifier_;
+    private java.lang.String networkIdentifier_;
     /**
-     * <code>required string network_identifier = 1;</code>
-     *
      * <pre>
      * the network used by this wallet
      * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
      */
     public boolean hasNetworkIdentifier() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required string network_identifier = 1;</code>
-     *
      * <pre>
      * the network used by this wallet
      * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
      */
     public java.lang.String getNetworkIdentifier() {
-      java.lang.Object ref = networkIdentifier_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          networkIdentifier_ = s;
-        }
-        return s;
-      }
+      return networkIdentifier_;
     }
     /**
-     * <code>required string network_identifier = 1;</code>
-     *
      * <pre>
      * the network used by this wallet
      * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
      */
     public com.google.protobuf.ByteString
         getNetworkIdentifierBytes() {
-      java.lang.Object ref = networkIdentifier_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        networkIdentifier_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(networkIdentifier_);
+    }
+    /**
+     * <pre>
+     * the network used by this wallet
+     * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
+     */
+    private void setNetworkIdentifier(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      networkIdentifier_ = value;
+    }
+    /**
+     * <pre>
+     * the network used by this wallet
+     * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
+     */
+    private void clearNetworkIdentifier() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      networkIdentifier_ = getDefaultInstance().getNetworkIdentifier();
+    }
+    /**
+     * <pre>
+     * the network used by this wallet
+     * </pre>
+     *
+     * <code>required string network_identifier = 1;</code>
+     */
+    private void setNetworkIdentifierBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+      networkIdentifier_ = value.toStringUtf8();
     }
 
     public static final int LAST_SEEN_BLOCK_HASH_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString lastSeenBlockHash_;
     /**
-     * <code>optional bytes last_seen_block_hash = 2;</code>
-     *
      * <pre>
      * The SHA256 hash of the head of the best chain seen by this wallet.
      * </pre>
+     *
+     * <code>optional bytes last_seen_block_hash = 2;</code>
      */
     public boolean hasLastSeenBlockHash() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional bytes last_seen_block_hash = 2;</code>
-     *
      * <pre>
      * The SHA256 hash of the head of the best chain seen by this wallet.
      * </pre>
+     *
+     * <code>optional bytes last_seen_block_hash = 2;</code>
      */
     public com.google.protobuf.ByteString getLastSeenBlockHash() {
       return lastSeenBlockHash_;
+    }
+    /**
+     * <pre>
+     * The SHA256 hash of the head of the best chain seen by this wallet.
+     * </pre>
+     *
+     * <code>optional bytes last_seen_block_hash = 2;</code>
+     */
+    private void setLastSeenBlockHash(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+      lastSeenBlockHash_ = value;
+    }
+    /**
+     * <pre>
+     * The SHA256 hash of the head of the best chain seen by this wallet.
+     * </pre>
+     *
+     * <code>optional bytes last_seen_block_hash = 2;</code>
+     */
+    private void clearLastSeenBlockHash() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      lastSeenBlockHash_ = getDefaultInstance().getLastSeenBlockHash();
     }
 
     public static final int LAST_SEEN_BLOCK_HEIGHT_FIELD_NUMBER = 12;
     private int lastSeenBlockHeight_;
     /**
-     * <code>optional uint32 last_seen_block_height = 12;</code>
-     *
      * <pre>
      * The height in the chain of the last seen block.
      * </pre>
+     *
+     * <code>optional uint32 last_seen_block_height = 12;</code>
      */
     public boolean hasLastSeenBlockHeight() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional uint32 last_seen_block_height = 12;</code>
-     *
      * <pre>
      * The height in the chain of the last seen block.
      * </pre>
+     *
+     * <code>optional uint32 last_seen_block_height = 12;</code>
      */
     public int getLastSeenBlockHeight() {
       return lastSeenBlockHeight_;
+    }
+    /**
+     * <pre>
+     * The height in the chain of the last seen block.
+     * </pre>
+     *
+     * <code>optional uint32 last_seen_block_height = 12;</code>
+     */
+    private void setLastSeenBlockHeight(int value) {
+      bitField0_ |= 0x00000004;
+      lastSeenBlockHeight_ = value;
+    }
+    /**
+     * <pre>
+     * The height in the chain of the last seen block.
+     * </pre>
+     *
+     * <code>optional uint32 last_seen_block_height = 12;</code>
+     */
+    private void clearLastSeenBlockHeight() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      lastSeenBlockHeight_ = 0;
     }
 
     public static final int LAST_SEEN_BLOCK_TIME_SECS_FIELD_NUMBER = 14;
@@ -14982,9 +13064,23 @@ public final class Protos {
     public long getLastSeenBlockTimeSecs() {
       return lastSeenBlockTimeSecs_;
     }
+    /**
+     * <code>optional int64 last_seen_block_time_secs = 14;</code>
+     */
+    private void setLastSeenBlockTimeSecs(long value) {
+      bitField0_ |= 0x00000008;
+      lastSeenBlockTimeSecs_ = value;
+    }
+    /**
+     * <code>optional int64 last_seen_block_time_secs = 14;</code>
+     */
+    private void clearLastSeenBlockTimeSecs() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      lastSeenBlockTimeSecs_ = 0L;
+    }
 
     public static final int KEY_FIELD_NUMBER = 3;
-    private java.util.List<org.floj.wallet.Protos.Key> key_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.Key> key_;
     /**
      * <code>repeated .wallet.Key key = 3;</code>
      */
@@ -15017,9 +13113,94 @@ public final class Protos {
         int index) {
       return key_.get(index);
     }
+    private void ensureKeyIsMutable() {
+      if (!key_.isModifiable()) {
+        key_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(key_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void setKey(
+        int index, org.floj.wallet.Protos.Key value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureKeyIsMutable();
+      key_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void setKey(
+        int index, org.floj.wallet.Protos.Key.Builder builderForValue) {
+      ensureKeyIsMutable();
+      key_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void addKey(org.floj.wallet.Protos.Key value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureKeyIsMutable();
+      key_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void addKey(
+        int index, org.floj.wallet.Protos.Key value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureKeyIsMutable();
+      key_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void addKey(
+        org.floj.wallet.Protos.Key.Builder builderForValue) {
+      ensureKeyIsMutable();
+      key_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void addKey(
+        int index, org.floj.wallet.Protos.Key.Builder builderForValue) {
+      ensureKeyIsMutable();
+      key_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void addAllKey(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.Key> values) {
+      ensureKeyIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, key_);
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void clearKey() {
+      key_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.Key key = 3;</code>
+     */
+    private void removeKey(int index) {
+      ensureKeyIsMutable();
+      key_.remove(index);
+    }
 
     public static final int TRANSACTION_FIELD_NUMBER = 4;
-    private java.util.List<org.floj.wallet.Protos.Transaction> transaction_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.Transaction> transaction_;
     /**
      * <code>repeated .wallet.Transaction transaction = 4;</code>
      */
@@ -15052,9 +13233,94 @@ public final class Protos {
         int index) {
       return transaction_.get(index);
     }
+    private void ensureTransactionIsMutable() {
+      if (!transaction_.isModifiable()) {
+        transaction_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(transaction_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void setTransaction(
+        int index, org.floj.wallet.Protos.Transaction value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionIsMutable();
+      transaction_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void setTransaction(
+        int index, org.floj.wallet.Protos.Transaction.Builder builderForValue) {
+      ensureTransactionIsMutable();
+      transaction_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void addTransaction(org.floj.wallet.Protos.Transaction value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionIsMutable();
+      transaction_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void addTransaction(
+        int index, org.floj.wallet.Protos.Transaction value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTransactionIsMutable();
+      transaction_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void addTransaction(
+        org.floj.wallet.Protos.Transaction.Builder builderForValue) {
+      ensureTransactionIsMutable();
+      transaction_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void addTransaction(
+        int index, org.floj.wallet.Protos.Transaction.Builder builderForValue) {
+      ensureTransactionIsMutable();
+      transaction_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void addAllTransaction(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.Transaction> values) {
+      ensureTransactionIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, transaction_);
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void clearTransaction() {
+      transaction_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.Transaction transaction = 4;</code>
+     */
+    private void removeTransaction(int index) {
+      ensureTransactionIsMutable();
+      transaction_.remove(index);
+    }
 
     public static final int WATCHED_SCRIPT_FIELD_NUMBER = 15;
-    private java.util.List<org.floj.wallet.Protos.Script> watchedScript_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.Script> watchedScript_;
     /**
      * <code>repeated .wallet.Script watched_script = 15;</code>
      */
@@ -15087,9 +13353,94 @@ public final class Protos {
         int index) {
       return watchedScript_.get(index);
     }
+    private void ensureWatchedScriptIsMutable() {
+      if (!watchedScript_.isModifiable()) {
+        watchedScript_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(watchedScript_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void setWatchedScript(
+        int index, org.floj.wallet.Protos.Script value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureWatchedScriptIsMutable();
+      watchedScript_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void setWatchedScript(
+        int index, org.floj.wallet.Protos.Script.Builder builderForValue) {
+      ensureWatchedScriptIsMutable();
+      watchedScript_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void addWatchedScript(org.floj.wallet.Protos.Script value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureWatchedScriptIsMutable();
+      watchedScript_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void addWatchedScript(
+        int index, org.floj.wallet.Protos.Script value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureWatchedScriptIsMutable();
+      watchedScript_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void addWatchedScript(
+        org.floj.wallet.Protos.Script.Builder builderForValue) {
+      ensureWatchedScriptIsMutable();
+      watchedScript_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void addWatchedScript(
+        int index, org.floj.wallet.Protos.Script.Builder builderForValue) {
+      ensureWatchedScriptIsMutable();
+      watchedScript_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void addAllWatchedScript(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.Script> values) {
+      ensureWatchedScriptIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, watchedScript_);
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void clearWatchedScript() {
+      watchedScript_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.Script watched_script = 15;</code>
+     */
+    private void removeWatchedScript(int index) {
+      ensureWatchedScriptIsMutable();
+      watchedScript_.remove(index);
+    }
 
     public static final int ENCRYPTION_TYPE_FIELD_NUMBER = 5;
-    private org.floj.wallet.Protos.Wallet.EncryptionType encryptionType_;
+    private int encryptionType_;
     /**
      * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
      */
@@ -15100,7 +13451,25 @@ public final class Protos {
      * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
      */
     public org.floj.wallet.Protos.Wallet.EncryptionType getEncryptionType() {
-      return encryptionType_;
+      org.floj.wallet.Protos.Wallet.EncryptionType result = org.floj.wallet.Protos.Wallet.EncryptionType.forNumber(encryptionType_);
+      return result == null ? org.floj.wallet.Protos.Wallet.EncryptionType.UNENCRYPTED : result;
+    }
+    /**
+     * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
+     */
+    private void setEncryptionType(org.floj.wallet.Protos.Wallet.EncryptionType value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      bitField0_ |= 0x00000010;
+      encryptionType_ = value.getNumber();
+    }
+    /**
+     * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
+     */
+    private void clearEncryptionType() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      encryptionType_ = 1;
     }
 
     public static final int ENCRYPTION_PARAMETERS_FIELD_NUMBER = 6;
@@ -15115,44 +13484,101 @@ public final class Protos {
      * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
      */
     public org.floj.wallet.Protos.ScryptParameters getEncryptionParameters() {
-      return encryptionParameters_;
+      return encryptionParameters_ == null ? org.floj.wallet.Protos.ScryptParameters.getDefaultInstance() : encryptionParameters_;
     }
     /**
      * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
      */
-    public org.floj.wallet.Protos.ScryptParametersOrBuilder getEncryptionParametersOrBuilder() {
-      return encryptionParameters_;
+    private void setEncryptionParameters(org.floj.wallet.Protos.ScryptParameters value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      encryptionParameters_ = value;
+      bitField0_ |= 0x00000020;
+      }
+    /**
+     * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
+     */
+    private void setEncryptionParameters(
+        org.floj.wallet.Protos.ScryptParameters.Builder builderForValue) {
+      encryptionParameters_ = builderForValue.build();
+      bitField0_ |= 0x00000020;
+    }
+    /**
+     * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
+     */
+    private void mergeEncryptionParameters(org.floj.wallet.Protos.ScryptParameters value) {
+      if (encryptionParameters_ != null &&
+          encryptionParameters_ != org.floj.wallet.Protos.ScryptParameters.getDefaultInstance()) {
+        encryptionParameters_ =
+          org.floj.wallet.Protos.ScryptParameters.newBuilder(encryptionParameters_).mergeFrom(value).buildPartial();
+      } else {
+        encryptionParameters_ = value;
+      }
+      bitField0_ |= 0x00000020;
+    }
+    /**
+     * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
+     */
+    private void clearEncryptionParameters() {  encryptionParameters_ = null;
+      bitField0_ = (bitField0_ & ~0x00000020);
     }
 
     public static final int VERSION_FIELD_NUMBER = 7;
     private int version_;
     /**
-     * <code>optional int32 version = 7 [default = 1];</code>
-     *
      * <pre>
      * The version number of the wallet - used to detect wallets that were produced in the future
      * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
      * A version that's higher than the default is considered from the future.
      * </pre>
+     *
+     * <code>optional int32 version = 7 [default = 1];</code>
      */
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
-     * <code>optional int32 version = 7 [default = 1];</code>
-     *
      * <pre>
      * The version number of the wallet - used to detect wallets that were produced in the future
      * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
      * A version that's higher than the default is considered from the future.
      * </pre>
+     *
+     * <code>optional int32 version = 7 [default = 1];</code>
      */
     public int getVersion() {
       return version_;
     }
+    /**
+     * <pre>
+     * The version number of the wallet - used to detect wallets that were produced in the future
+     * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
+     * A version that's higher than the default is considered from the future.
+     * </pre>
+     *
+     * <code>optional int32 version = 7 [default = 1];</code>
+     */
+    private void setVersion(int value) {
+      bitField0_ |= 0x00000040;
+      version_ = value;
+    }
+    /**
+     * <pre>
+     * The version number of the wallet - used to detect wallets that were produced in the future
+     * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
+     * A version that's higher than the default is considered from the future.
+     * </pre>
+     *
+     * <code>optional int32 version = 7 [default = 1];</code>
+     */
+    private void clearVersion() {
+      bitField0_ = (bitField0_ & ~0x00000040);
+      version_ = 1;
+    }
 
     public static final int EXTENSION_FIELD_NUMBER = 10;
-    private java.util.List<org.floj.wallet.Protos.Extension> extension_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.Extension> extension_;
     /**
      * <code>repeated .wallet.Extension extension = 10;</code>
      */
@@ -15185,90 +13611,222 @@ public final class Protos {
         int index) {
       return extension_.get(index);
     }
+    private void ensureExtensionIsMutable() {
+      if (!extension_.isModifiable()) {
+        extension_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(extension_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void setExtension(
+        int index, org.floj.wallet.Protos.Extension value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureExtensionIsMutable();
+      extension_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void setExtension(
+        int index, org.floj.wallet.Protos.Extension.Builder builderForValue) {
+      ensureExtensionIsMutable();
+      extension_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void addExtension(org.floj.wallet.Protos.Extension value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureExtensionIsMutable();
+      extension_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void addExtension(
+        int index, org.floj.wallet.Protos.Extension value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureExtensionIsMutable();
+      extension_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void addExtension(
+        org.floj.wallet.Protos.Extension.Builder builderForValue) {
+      ensureExtensionIsMutable();
+      extension_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void addExtension(
+        int index, org.floj.wallet.Protos.Extension.Builder builderForValue) {
+      ensureExtensionIsMutable();
+      extension_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void addAllExtension(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.Extension> values) {
+      ensureExtensionIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, extension_);
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void clearExtension() {
+      extension_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.Extension extension = 10;</code>
+     */
+    private void removeExtension(int index) {
+      ensureExtensionIsMutable();
+      extension_.remove(index);
+    }
 
     public static final int DESCRIPTION_FIELD_NUMBER = 11;
-    private java.lang.Object description_;
+    private java.lang.String description_;
     /**
-     * <code>optional string description = 11;</code>
-     *
      * <pre>
      * A UTF8 encoded text description of the wallet that is intended for end user provided text.
      * </pre>
+     *
+     * <code>optional string description = 11;</code>
      */
     public boolean hasDescription() {
       return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
-     * <code>optional string description = 11;</code>
-     *
      * <pre>
      * A UTF8 encoded text description of the wallet that is intended for end user provided text.
      * </pre>
+     *
+     * <code>optional string description = 11;</code>
      */
     public java.lang.String getDescription() {
-      java.lang.Object ref = description_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          description_ = s;
-        }
-        return s;
-      }
+      return description_;
     }
     /**
-     * <code>optional string description = 11;</code>
-     *
      * <pre>
      * A UTF8 encoded text description of the wallet that is intended for end user provided text.
      * </pre>
+     *
+     * <code>optional string description = 11;</code>
      */
     public com.google.protobuf.ByteString
         getDescriptionBytes() {
-      java.lang.Object ref = description_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        description_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(description_);
+    }
+    /**
+     * <pre>
+     * A UTF8 encoded text description of the wallet that is intended for end user provided text.
+     * </pre>
+     *
+     * <code>optional string description = 11;</code>
+     */
+    private void setDescription(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+      description_ = value;
+    }
+    /**
+     * <pre>
+     * A UTF8 encoded text description of the wallet that is intended for end user provided text.
+     * </pre>
+     *
+     * <code>optional string description = 11;</code>
+     */
+    private void clearDescription() {
+      bitField0_ = (bitField0_ & ~0x00000080);
+      description_ = getDefaultInstance().getDescription();
+    }
+    /**
+     * <pre>
+     * A UTF8 encoded text description of the wallet that is intended for end user provided text.
+     * </pre>
+     *
+     * <code>optional string description = 11;</code>
+     */
+    private void setDescriptionBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+      description_ = value.toStringUtf8();
     }
 
     public static final int KEY_ROTATION_TIME_FIELD_NUMBER = 13;
     private long keyRotationTime_;
     /**
-     * <code>optional uint64 key_rotation_time = 13;</code>
-     *
      * <pre>
      * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
      * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
      * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
      * </pre>
+     *
+     * <code>optional uint64 key_rotation_time = 13;</code>
      */
     public boolean hasKeyRotationTime() {
       return ((bitField0_ & 0x00000100) == 0x00000100);
     }
     /**
-     * <code>optional uint64 key_rotation_time = 13;</code>
-     *
      * <pre>
      * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
      * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
      * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
      * </pre>
+     *
+     * <code>optional uint64 key_rotation_time = 13;</code>
      */
     public long getKeyRotationTime() {
       return keyRotationTime_;
     }
+    /**
+     * <pre>
+     * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
+     * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
+     * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
+     * </pre>
+     *
+     * <code>optional uint64 key_rotation_time = 13;</code>
+     */
+    private void setKeyRotationTime(long value) {
+      bitField0_ |= 0x00000100;
+      keyRotationTime_ = value;
+    }
+    /**
+     * <pre>
+     * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
+     * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
+     * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
+     * </pre>
+     *
+     * <code>optional uint64 key_rotation_time = 13;</code>
+     */
+    private void clearKeyRotationTime() {
+      bitField0_ = (bitField0_ & ~0x00000100);
+      keyRotationTime_ = 0L;
+    }
 
     public static final int TAGS_FIELD_NUMBER = 16;
-    private java.util.List<org.floj.wallet.Protos.Tag> tags_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.Tag> tags_;
     /**
      * <code>repeated .wallet.Tag tags = 16;</code>
      */
@@ -15301,140 +13859,272 @@ public final class Protos {
         int index) {
       return tags_.get(index);
     }
+    private void ensureTagsIsMutable() {
+      if (!tags_.isModifiable()) {
+        tags_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(tags_);
+       }
+    }
+
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void setTags(
+        int index, org.floj.wallet.Protos.Tag value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTagsIsMutable();
+      tags_.set(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void setTags(
+        int index, org.floj.wallet.Protos.Tag.Builder builderForValue) {
+      ensureTagsIsMutable();
+      tags_.set(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void addTags(org.floj.wallet.Protos.Tag value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTagsIsMutable();
+      tags_.add(value);
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void addTags(
+        int index, org.floj.wallet.Protos.Tag value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      ensureTagsIsMutable();
+      tags_.add(index, value);
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void addTags(
+        org.floj.wallet.Protos.Tag.Builder builderForValue) {
+      ensureTagsIsMutable();
+      tags_.add(builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void addTags(
+        int index, org.floj.wallet.Protos.Tag.Builder builderForValue) {
+      ensureTagsIsMutable();
+      tags_.add(index, builderForValue.build());
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void addAllTags(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.Tag> values) {
+      ensureTagsIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, tags_);
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void clearTags() {
+      tags_ = emptyProtobufList();
+    }
+    /**
+     * <code>repeated .wallet.Tag tags = 16;</code>
+     */
+    private void removeTags(int index) {
+      ensureTagsIsMutable();
+      tags_.remove(index);
+    }
 
     public static final int TRANSACTION_SIGNERS_FIELD_NUMBER = 17;
-    private java.util.List<org.floj.wallet.Protos.TransactionSigner> transactionSigners_;
+    private com.google.protobuf.Internal.ProtobufList<org.floj.wallet.Protos.TransactionSigner> transactionSigners_;
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     public java.util.List<org.floj.wallet.Protos.TransactionSigner> getTransactionSignersList() {
       return transactionSigners_;
     }
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     public java.util.List<? extends org.floj.wallet.Protos.TransactionSignerOrBuilder> 
         getTransactionSignersOrBuilderList() {
       return transactionSigners_;
     }
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     public int getTransactionSignersCount() {
       return transactionSigners_.size();
     }
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     public org.floj.wallet.Protos.TransactionSigner getTransactionSigners(int index) {
       return transactionSigners_.get(index);
     }
     /**
-     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-     *
      * <pre>
      * transaction signers added to the wallet
      * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
      */
     public org.floj.wallet.Protos.TransactionSignerOrBuilder getTransactionSignersOrBuilder(
         int index) {
       return transactionSigners_.get(index);
     }
-
-    private void initFields() {
-      networkIdentifier_ = "";
-      lastSeenBlockHash_ = com.google.protobuf.ByteString.EMPTY;
-      lastSeenBlockHeight_ = 0;
-      lastSeenBlockTimeSecs_ = 0L;
-      key_ = java.util.Collections.emptyList();
-      transaction_ = java.util.Collections.emptyList();
-      watchedScript_ = java.util.Collections.emptyList();
-      encryptionType_ = org.floj.wallet.Protos.Wallet.EncryptionType.UNENCRYPTED;
-      encryptionParameters_ = org.floj.wallet.Protos.ScryptParameters.getDefaultInstance();
-      version_ = 1;
-      extension_ = java.util.Collections.emptyList();
-      description_ = "";
-      keyRotationTime_ = 0L;
-      tags_ = java.util.Collections.emptyList();
-      transactionSigners_ = java.util.Collections.emptyList();
+    private void ensureTransactionSignersIsMutable() {
+      if (!transactionSigners_.isModifiable()) {
+        transactionSigners_ =
+            com.google.protobuf.GeneratedMessageLite.mutableCopy(transactionSigners_);
+       }
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
 
-      if (!hasNetworkIdentifier()) {
-        memoizedIsInitialized = 0;
-        return false;
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void setTransactionSigners(
+        int index, org.floj.wallet.Protos.TransactionSigner value) {
+      if (value == null) {
+        throw new NullPointerException();
       }
-      for (int i = 0; i < getKeyCount(); i++) {
-        if (!getKey(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
+      ensureTransactionSignersIsMutable();
+      transactionSigners_.set(index, value);
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void setTransactionSigners(
+        int index, org.floj.wallet.Protos.TransactionSigner.Builder builderForValue) {
+      ensureTransactionSignersIsMutable();
+      transactionSigners_.set(index, builderForValue.build());
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void addTransactionSigners(org.floj.wallet.Protos.TransactionSigner value) {
+      if (value == null) {
+        throw new NullPointerException();
       }
-      for (int i = 0; i < getTransactionCount(); i++) {
-        if (!getTransaction(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
+      ensureTransactionSignersIsMutable();
+      transactionSigners_.add(value);
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void addTransactionSigners(
+        int index, org.floj.wallet.Protos.TransactionSigner value) {
+      if (value == null) {
+        throw new NullPointerException();
       }
-      for (int i = 0; i < getWatchedScriptCount(); i++) {
-        if (!getWatchedScript(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      if (hasEncryptionParameters()) {
-        if (!getEncryptionParameters().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      for (int i = 0; i < getExtensionCount(); i++) {
-        if (!getExtension(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      for (int i = 0; i < getTagsCount(); i++) {
-        if (!getTags(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      for (int i = 0; i < getTransactionSignersCount(); i++) {
-        if (!getTransactionSigners(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
+      ensureTransactionSignersIsMutable();
+      transactionSigners_.add(index, value);
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void addTransactionSigners(
+        org.floj.wallet.Protos.TransactionSigner.Builder builderForValue) {
+      ensureTransactionSignersIsMutable();
+      transactionSigners_.add(builderForValue.build());
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void addTransactionSigners(
+        int index, org.floj.wallet.Protos.TransactionSigner.Builder builderForValue) {
+      ensureTransactionSignersIsMutable();
+      transactionSigners_.add(index, builderForValue.build());
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void addAllTransactionSigners(
+        java.lang.Iterable<? extends org.floj.wallet.Protos.TransactionSigner> values) {
+      ensureTransactionSignersIsMutable();
+      com.google.protobuf.AbstractMessageLite.addAll(
+          values, transactionSigners_);
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void clearTransactionSigners() {
+      transactionSigners_ = emptyProtobufList();
+    }
+    /**
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     *
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     */
+    private void removeTransactionSigners(int index) {
+      ensureTransactionSignersIsMutable();
+      transactionSigners_.remove(index);
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getNetworkIdentifierBytes());
+        output.writeString(1, getNetworkIdentifier());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, lastSeenBlockHash_);
@@ -15446,10 +14136,10 @@ public final class Protos {
         output.writeMessage(4, transaction_.get(i));
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeEnum(5, encryptionType_.getNumber());
+        output.writeEnum(5, encryptionType_);
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        output.writeMessage(6, encryptionParameters_);
+        output.writeMessage(6, getEncryptionParameters());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         output.writeInt32(7, version_);
@@ -15458,7 +14148,7 @@ public final class Protos {
         output.writeMessage(10, extension_.get(i));
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
-        output.writeBytes(11, getDescriptionBytes());
+        output.writeString(11, getDescription());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeUInt32(12, lastSeenBlockHeight_);
@@ -15478,10 +14168,9 @@ public final class Protos {
       for (int i = 0; i < transactionSigners_.size(); i++) {
         output.writeMessage(17, transactionSigners_.get(i));
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -15489,7 +14178,7 @@ public final class Protos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getNetworkIdentifierBytes());
+          .computeStringSize(1, getNetworkIdentifier());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -15505,11 +14194,11 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(5, encryptionType_.getNumber());
+          .computeEnumSize(5, encryptionType_);
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(6, encryptionParameters_);
+          .computeMessageSize(6, getEncryptionParameters());
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
@@ -15521,7 +14210,7 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(11, getDescriptionBytes());
+          .computeStringSize(11, getDescription());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
@@ -15547,878 +14236,311 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(17, transactionSigners_.get(i));
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.Wallet parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Wallet parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Wallet parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.Wallet parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Wallet parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Wallet parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Wallet parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Wallet parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.Wallet parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.Wallet parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.Wallet prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.Wallet}
-     *
      * <pre>
      ** A flo wallet 
      * </pre>
+     *
+     * Protobuf type {@code wallet.Wallet}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.Wallet, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.Wallet)
         org.floj.wallet.Protos.WalletOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_Wallet_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_Wallet_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.Wallet.class, org.floj.wallet.Protos.Wallet.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.Wallet.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getKeyFieldBuilder();
-          getTransactionFieldBuilder();
-          getWatchedScriptFieldBuilder();
-          getEncryptionParametersFieldBuilder();
-          getExtensionFieldBuilder();
-          getTagsFieldBuilder();
-          getTransactionSignersFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        networkIdentifier_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
-        lastSeenBlockHash_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        lastSeenBlockHeight_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        lastSeenBlockTimeSecs_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        if (keyBuilder_ == null) {
-          key_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        } else {
-          keyBuilder_.clear();
-        }
-        if (transactionBuilder_ == null) {
-          transaction_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
-        } else {
-          transactionBuilder_.clear();
-        }
-        if (watchedScriptBuilder_ == null) {
-          watchedScript_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000040);
-        } else {
-          watchedScriptBuilder_.clear();
-        }
-        encryptionType_ = org.floj.wallet.Protos.Wallet.EncryptionType.UNENCRYPTED;
-        bitField0_ = (bitField0_ & ~0x00000080);
-        if (encryptionParametersBuilder_ == null) {
-          encryptionParameters_ = org.floj.wallet.Protos.ScryptParameters.getDefaultInstance();
-        } else {
-          encryptionParametersBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000100);
-        version_ = 1;
-        bitField0_ = (bitField0_ & ~0x00000200);
-        if (extensionBuilder_ == null) {
-          extension_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000400);
-        } else {
-          extensionBuilder_.clear();
-        }
-        description_ = "";
-        bitField0_ = (bitField0_ & ~0x00000800);
-        keyRotationTime_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00001000);
-        if (tagsBuilder_ == null) {
-          tags_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00002000);
-        } else {
-          tagsBuilder_.clear();
-        }
-        if (transactionSignersBuilder_ == null) {
-          transactionSigners_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00004000);
-        } else {
-          transactionSignersBuilder_.clear();
-        }
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_Wallet_descriptor;
-      }
-
-      public org.floj.wallet.Protos.Wallet getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.Wallet.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.Wallet build() {
-        org.floj.wallet.Protos.Wallet result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.Wallet buildPartial() {
-        org.floj.wallet.Protos.Wallet result = new org.floj.wallet.Protos.Wallet(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.networkIdentifier_ = networkIdentifier_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.lastSeenBlockHash_ = lastSeenBlockHash_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.lastSeenBlockHeight_ = lastSeenBlockHeight_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.lastSeenBlockTimeSecs_ = lastSeenBlockTimeSecs_;
-        if (keyBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010)) {
-            key_ = java.util.Collections.unmodifiableList(key_);
-            bitField0_ = (bitField0_ & ~0x00000010);
-          }
-          result.key_ = key_;
-        } else {
-          result.key_ = keyBuilder_.build();
-        }
-        if (transactionBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
-            transaction_ = java.util.Collections.unmodifiableList(transaction_);
-            bitField0_ = (bitField0_ & ~0x00000020);
-          }
-          result.transaction_ = transaction_;
-        } else {
-          result.transaction_ = transactionBuilder_.build();
-        }
-        if (watchedScriptBuilder_ == null) {
-          if (((bitField0_ & 0x00000040) == 0x00000040)) {
-            watchedScript_ = java.util.Collections.unmodifiableList(watchedScript_);
-            bitField0_ = (bitField0_ & ~0x00000040);
-          }
-          result.watchedScript_ = watchedScript_;
-        } else {
-          result.watchedScript_ = watchedScriptBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.encryptionType_ = encryptionType_;
-        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        if (encryptionParametersBuilder_ == null) {
-          result.encryptionParameters_ = encryptionParameters_;
-        } else {
-          result.encryptionParameters_ = encryptionParametersBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
-          to_bitField0_ |= 0x00000040;
-        }
-        result.version_ = version_;
-        if (extensionBuilder_ == null) {
-          if (((bitField0_ & 0x00000400) == 0x00000400)) {
-            extension_ = java.util.Collections.unmodifiableList(extension_);
-            bitField0_ = (bitField0_ & ~0x00000400);
-          }
-          result.extension_ = extension_;
-        } else {
-          result.extension_ = extensionBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
-          to_bitField0_ |= 0x00000080;
-        }
-        result.description_ = description_;
-        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
-          to_bitField0_ |= 0x00000100;
-        }
-        result.keyRotationTime_ = keyRotationTime_;
-        if (tagsBuilder_ == null) {
-          if (((bitField0_ & 0x00002000) == 0x00002000)) {
-            tags_ = java.util.Collections.unmodifiableList(tags_);
-            bitField0_ = (bitField0_ & ~0x00002000);
-          }
-          result.tags_ = tags_;
-        } else {
-          result.tags_ = tagsBuilder_.build();
-        }
-        if (transactionSignersBuilder_ == null) {
-          if (((bitField0_ & 0x00004000) == 0x00004000)) {
-            transactionSigners_ = java.util.Collections.unmodifiableList(transactionSigners_);
-            bitField0_ = (bitField0_ & ~0x00004000);
-          }
-          result.transactionSigners_ = transactionSigners_;
-        } else {
-          result.transactionSigners_ = transactionSignersBuilder_.build();
-        }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.Wallet) {
-          return mergeFrom((org.floj.wallet.Protos.Wallet)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.Wallet other) {
-        if (other == org.floj.wallet.Protos.Wallet.getDefaultInstance()) return this;
-        if (other.hasNetworkIdentifier()) {
-          bitField0_ |= 0x00000001;
-          networkIdentifier_ = other.networkIdentifier_;
-          onChanged();
-        }
-        if (other.hasLastSeenBlockHash()) {
-          setLastSeenBlockHash(other.getLastSeenBlockHash());
-        }
-        if (other.hasLastSeenBlockHeight()) {
-          setLastSeenBlockHeight(other.getLastSeenBlockHeight());
-        }
-        if (other.hasLastSeenBlockTimeSecs()) {
-          setLastSeenBlockTimeSecs(other.getLastSeenBlockTimeSecs());
-        }
-        if (keyBuilder_ == null) {
-          if (!other.key_.isEmpty()) {
-            if (key_.isEmpty()) {
-              key_ = other.key_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-            } else {
-              ensureKeyIsMutable();
-              key_.addAll(other.key_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.key_.isEmpty()) {
-            if (keyBuilder_.isEmpty()) {
-              keyBuilder_.dispose();
-              keyBuilder_ = null;
-              key_ = other.key_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-              keyBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getKeyFieldBuilder() : null;
-            } else {
-              keyBuilder_.addAllMessages(other.key_);
-            }
-          }
-        }
-        if (transactionBuilder_ == null) {
-          if (!other.transaction_.isEmpty()) {
-            if (transaction_.isEmpty()) {
-              transaction_ = other.transaction_;
-              bitField0_ = (bitField0_ & ~0x00000020);
-            } else {
-              ensureTransactionIsMutable();
-              transaction_.addAll(other.transaction_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.transaction_.isEmpty()) {
-            if (transactionBuilder_.isEmpty()) {
-              transactionBuilder_.dispose();
-              transactionBuilder_ = null;
-              transaction_ = other.transaction_;
-              bitField0_ = (bitField0_ & ~0x00000020);
-              transactionBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getTransactionFieldBuilder() : null;
-            } else {
-              transactionBuilder_.addAllMessages(other.transaction_);
-            }
-          }
-        }
-        if (watchedScriptBuilder_ == null) {
-          if (!other.watchedScript_.isEmpty()) {
-            if (watchedScript_.isEmpty()) {
-              watchedScript_ = other.watchedScript_;
-              bitField0_ = (bitField0_ & ~0x00000040);
-            } else {
-              ensureWatchedScriptIsMutable();
-              watchedScript_.addAll(other.watchedScript_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.watchedScript_.isEmpty()) {
-            if (watchedScriptBuilder_.isEmpty()) {
-              watchedScriptBuilder_.dispose();
-              watchedScriptBuilder_ = null;
-              watchedScript_ = other.watchedScript_;
-              bitField0_ = (bitField0_ & ~0x00000040);
-              watchedScriptBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getWatchedScriptFieldBuilder() : null;
-            } else {
-              watchedScriptBuilder_.addAllMessages(other.watchedScript_);
-            }
-          }
-        }
-        if (other.hasEncryptionType()) {
-          setEncryptionType(other.getEncryptionType());
-        }
-        if (other.hasEncryptionParameters()) {
-          mergeEncryptionParameters(other.getEncryptionParameters());
-        }
-        if (other.hasVersion()) {
-          setVersion(other.getVersion());
-        }
-        if (extensionBuilder_ == null) {
-          if (!other.extension_.isEmpty()) {
-            if (extension_.isEmpty()) {
-              extension_ = other.extension_;
-              bitField0_ = (bitField0_ & ~0x00000400);
-            } else {
-              ensureExtensionIsMutable();
-              extension_.addAll(other.extension_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.extension_.isEmpty()) {
-            if (extensionBuilder_.isEmpty()) {
-              extensionBuilder_.dispose();
-              extensionBuilder_ = null;
-              extension_ = other.extension_;
-              bitField0_ = (bitField0_ & ~0x00000400);
-              extensionBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getExtensionFieldBuilder() : null;
-            } else {
-              extensionBuilder_.addAllMessages(other.extension_);
-            }
-          }
-        }
-        if (other.hasDescription()) {
-          bitField0_ |= 0x00000800;
-          description_ = other.description_;
-          onChanged();
-        }
-        if (other.hasKeyRotationTime()) {
-          setKeyRotationTime(other.getKeyRotationTime());
-        }
-        if (tagsBuilder_ == null) {
-          if (!other.tags_.isEmpty()) {
-            if (tags_.isEmpty()) {
-              tags_ = other.tags_;
-              bitField0_ = (bitField0_ & ~0x00002000);
-            } else {
-              ensureTagsIsMutable();
-              tags_.addAll(other.tags_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.tags_.isEmpty()) {
-            if (tagsBuilder_.isEmpty()) {
-              tagsBuilder_.dispose();
-              tagsBuilder_ = null;
-              tags_ = other.tags_;
-              bitField0_ = (bitField0_ & ~0x00002000);
-              tagsBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getTagsFieldBuilder() : null;
-            } else {
-              tagsBuilder_.addAllMessages(other.tags_);
-            }
-          }
-        }
-        if (transactionSignersBuilder_ == null) {
-          if (!other.transactionSigners_.isEmpty()) {
-            if (transactionSigners_.isEmpty()) {
-              transactionSigners_ = other.transactionSigners_;
-              bitField0_ = (bitField0_ & ~0x00004000);
-            } else {
-              ensureTransactionSignersIsMutable();
-              transactionSigners_.addAll(other.transactionSigners_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.transactionSigners_.isEmpty()) {
-            if (transactionSignersBuilder_.isEmpty()) {
-              transactionSignersBuilder_.dispose();
-              transactionSignersBuilder_ = null;
-              transactionSigners_ = other.transactionSigners_;
-              bitField0_ = (bitField0_ & ~0x00004000);
-              transactionSignersBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getTransactionSignersFieldBuilder() : null;
-            } else {
-              transactionSignersBuilder_.addAllMessages(other.transactionSigners_);
-            }
-          }
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasNetworkIdentifier()) {
-          
-          return false;
-        }
-        for (int i = 0; i < getKeyCount(); i++) {
-          if (!getKey(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        for (int i = 0; i < getTransactionCount(); i++) {
-          if (!getTransaction(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        for (int i = 0; i < getWatchedScriptCount(); i++) {
-          if (!getWatchedScript(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        if (hasEncryptionParameters()) {
-          if (!getEncryptionParameters().isInitialized()) {
-            
-            return false;
-          }
-        }
-        for (int i = 0; i < getExtensionCount(); i++) {
-          if (!getExtension(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        for (int i = 0; i < getTagsCount(); i++) {
-          if (!getTags(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        for (int i = 0; i < getTransactionSignersCount(); i++) {
-          if (!getTransactionSigners(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.Wallet parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.Wallet) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.lang.Object networkIdentifier_ = "";
       /**
-       * <code>required string network_identifier = 1;</code>
-       *
        * <pre>
        * the network used by this wallet
        * </pre>
+       *
+       * <code>required string network_identifier = 1;</code>
        */
       public boolean hasNetworkIdentifier() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasNetworkIdentifier();
       }
       /**
-       * <code>required string network_identifier = 1;</code>
-       *
        * <pre>
        * the network used by this wallet
        * </pre>
+       *
+       * <code>required string network_identifier = 1;</code>
        */
       public java.lang.String getNetworkIdentifier() {
-        java.lang.Object ref = networkIdentifier_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            networkIdentifier_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getNetworkIdentifier();
       }
       /**
-       * <code>required string network_identifier = 1;</code>
-       *
        * <pre>
        * the network used by this wallet
        * </pre>
+       *
+       * <code>required string network_identifier = 1;</code>
        */
       public com.google.protobuf.ByteString
           getNetworkIdentifierBytes() {
-        java.lang.Object ref = networkIdentifier_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          networkIdentifier_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getNetworkIdentifierBytes();
       }
       /**
-       * <code>required string network_identifier = 1;</code>
-       *
        * <pre>
        * the network used by this wallet
        * </pre>
+       *
+       * <code>required string network_identifier = 1;</code>
        */
       public Builder setNetworkIdentifier(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        networkIdentifier_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setNetworkIdentifier(value);
         return this;
       }
       /**
-       * <code>required string network_identifier = 1;</code>
-       *
        * <pre>
        * the network used by this wallet
        * </pre>
+       *
+       * <code>required string network_identifier = 1;</code>
        */
       public Builder clearNetworkIdentifier() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        networkIdentifier_ = getDefaultInstance().getNetworkIdentifier();
-        onChanged();
+        copyOnWrite();
+        instance.clearNetworkIdentifier();
         return this;
       }
       /**
-       * <code>required string network_identifier = 1;</code>
-       *
        * <pre>
        * the network used by this wallet
        * </pre>
+       *
+       * <code>required string network_identifier = 1;</code>
        */
       public Builder setNetworkIdentifierBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        networkIdentifier_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setNetworkIdentifierBytes(value);
         return this;
       }
 
-      private com.google.protobuf.ByteString lastSeenBlockHash_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>optional bytes last_seen_block_hash = 2;</code>
-       *
        * <pre>
        * The SHA256 hash of the head of the best chain seen by this wallet.
        * </pre>
+       *
+       * <code>optional bytes last_seen_block_hash = 2;</code>
        */
       public boolean hasLastSeenBlockHash() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasLastSeenBlockHash();
       }
       /**
-       * <code>optional bytes last_seen_block_hash = 2;</code>
-       *
        * <pre>
        * The SHA256 hash of the head of the best chain seen by this wallet.
        * </pre>
+       *
+       * <code>optional bytes last_seen_block_hash = 2;</code>
        */
       public com.google.protobuf.ByteString getLastSeenBlockHash() {
-        return lastSeenBlockHash_;
+        return instance.getLastSeenBlockHash();
       }
       /**
-       * <code>optional bytes last_seen_block_hash = 2;</code>
-       *
        * <pre>
        * The SHA256 hash of the head of the best chain seen by this wallet.
        * </pre>
+       *
+       * <code>optional bytes last_seen_block_hash = 2;</code>
        */
       public Builder setLastSeenBlockHash(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        lastSeenBlockHash_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLastSeenBlockHash(value);
         return this;
       }
       /**
-       * <code>optional bytes last_seen_block_hash = 2;</code>
-       *
        * <pre>
        * The SHA256 hash of the head of the best chain seen by this wallet.
        * </pre>
+       *
+       * <code>optional bytes last_seen_block_hash = 2;</code>
        */
       public Builder clearLastSeenBlockHash() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        lastSeenBlockHash_ = getDefaultInstance().getLastSeenBlockHash();
-        onChanged();
+        copyOnWrite();
+        instance.clearLastSeenBlockHash();
         return this;
       }
 
-      private int lastSeenBlockHeight_ ;
       /**
-       * <code>optional uint32 last_seen_block_height = 12;</code>
-       *
        * <pre>
        * The height in the chain of the last seen block.
        * </pre>
+       *
+       * <code>optional uint32 last_seen_block_height = 12;</code>
        */
       public boolean hasLastSeenBlockHeight() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasLastSeenBlockHeight();
       }
       /**
-       * <code>optional uint32 last_seen_block_height = 12;</code>
-       *
        * <pre>
        * The height in the chain of the last seen block.
        * </pre>
+       *
+       * <code>optional uint32 last_seen_block_height = 12;</code>
        */
       public int getLastSeenBlockHeight() {
-        return lastSeenBlockHeight_;
+        return instance.getLastSeenBlockHeight();
       }
       /**
-       * <code>optional uint32 last_seen_block_height = 12;</code>
-       *
        * <pre>
        * The height in the chain of the last seen block.
        * </pre>
+       *
+       * <code>optional uint32 last_seen_block_height = 12;</code>
        */
       public Builder setLastSeenBlockHeight(int value) {
-        bitField0_ |= 0x00000004;
-        lastSeenBlockHeight_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLastSeenBlockHeight(value);
         return this;
       }
       /**
-       * <code>optional uint32 last_seen_block_height = 12;</code>
-       *
        * <pre>
        * The height in the chain of the last seen block.
        * </pre>
+       *
+       * <code>optional uint32 last_seen_block_height = 12;</code>
        */
       public Builder clearLastSeenBlockHeight() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        lastSeenBlockHeight_ = 0;
-        onChanged();
+        copyOnWrite();
+        instance.clearLastSeenBlockHeight();
         return this;
       }
 
-      private long lastSeenBlockTimeSecs_ ;
       /**
        * <code>optional int64 last_seen_block_time_secs = 14;</code>
        */
       public boolean hasLastSeenBlockTimeSecs() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return instance.hasLastSeenBlockTimeSecs();
       }
       /**
        * <code>optional int64 last_seen_block_time_secs = 14;</code>
        */
       public long getLastSeenBlockTimeSecs() {
-        return lastSeenBlockTimeSecs_;
+        return instance.getLastSeenBlockTimeSecs();
       }
       /**
        * <code>optional int64 last_seen_block_time_secs = 14;</code>
        */
       public Builder setLastSeenBlockTimeSecs(long value) {
-        bitField0_ |= 0x00000008;
-        lastSeenBlockTimeSecs_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setLastSeenBlockTimeSecs(value);
         return this;
       }
       /**
        * <code>optional int64 last_seen_block_time_secs = 14;</code>
        */
       public Builder clearLastSeenBlockTimeSecs() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        lastSeenBlockTimeSecs_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearLastSeenBlockTimeSecs();
         return this;
       }
-
-      private java.util.List<org.floj.wallet.Protos.Key> key_ =
-        java.util.Collections.emptyList();
-      private void ensureKeyIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          key_ = new java.util.ArrayList<org.floj.wallet.Protos.Key>(key_);
-          bitField0_ |= 0x00000010;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Key, org.floj.wallet.Protos.Key.Builder, org.floj.wallet.Protos.KeyOrBuilder> keyBuilder_;
 
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
       public java.util.List<org.floj.wallet.Protos.Key> getKeyList() {
-        if (keyBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(key_);
-        } else {
-          return keyBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getKeyList());
       }
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
       public int getKeyCount() {
-        if (keyBuilder_ == null) {
-          return key_.size();
-        } else {
-          return keyBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getKeyCount();
+      }/**
        * <code>repeated .wallet.Key key = 3;</code>
        */
       public org.floj.wallet.Protos.Key getKey(int index) {
-        if (keyBuilder_ == null) {
-          return key_.get(index);
-        } else {
-          return keyBuilder_.getMessage(index);
-        }
+        return instance.getKey(index);
       }
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
       public Builder setKey(
           int index, org.floj.wallet.Protos.Key value) {
-        if (keyBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureKeyIsMutable();
-          key_.set(index, value);
-          onChanged();
-        } else {
-          keyBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setKey(index, value);
         return this;
       }
       /**
@@ -16426,29 +14548,16 @@ public final class Protos {
        */
       public Builder setKey(
           int index, org.floj.wallet.Protos.Key.Builder builderForValue) {
-        if (keyBuilder_ == null) {
-          ensureKeyIsMutable();
-          key_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          keyBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setKey(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
       public Builder addKey(org.floj.wallet.Protos.Key value) {
-        if (keyBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureKeyIsMutable();
-          key_.add(value);
-          onChanged();
-        } else {
-          keyBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addKey(value);
         return this;
       }
       /**
@@ -16456,16 +14565,8 @@ public final class Protos {
        */
       public Builder addKey(
           int index, org.floj.wallet.Protos.Key value) {
-        if (keyBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureKeyIsMutable();
-          key_.add(index, value);
-          onChanged();
-        } else {
-          keyBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addKey(index, value);
         return this;
       }
       /**
@@ -16473,13 +14574,8 @@ public final class Protos {
        */
       public Builder addKey(
           org.floj.wallet.Protos.Key.Builder builderForValue) {
-        if (keyBuilder_ == null) {
-          ensureKeyIsMutable();
-          key_.add(builderForValue.build());
-          onChanged();
-        } else {
-          keyBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addKey(builderForValue);
         return this;
       }
       /**
@@ -16487,13 +14583,8 @@ public final class Protos {
        */
       public Builder addKey(
           int index, org.floj.wallet.Protos.Key.Builder builderForValue) {
-        if (keyBuilder_ == null) {
-          ensureKeyIsMutable();
-          key_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          keyBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addKey(index, builderForValue);
         return this;
       }
       /**
@@ -16501,164 +14592,52 @@ public final class Protos {
        */
       public Builder addAllKey(
           java.lang.Iterable<? extends org.floj.wallet.Protos.Key> values) {
-        if (keyBuilder_ == null) {
-          ensureKeyIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, key_);
-          onChanged();
-        } else {
-          keyBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllKey(values);
         return this;
       }
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
       public Builder clearKey() {
-        if (keyBuilder_ == null) {
-          key_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-          onChanged();
-        } else {
-          keyBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearKey();
         return this;
       }
       /**
        * <code>repeated .wallet.Key key = 3;</code>
        */
       public Builder removeKey(int index) {
-        if (keyBuilder_ == null) {
-          ensureKeyIsMutable();
-          key_.remove(index);
-          onChanged();
-        } else {
-          keyBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeKey(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.Key key = 3;</code>
-       */
-      public org.floj.wallet.Protos.Key.Builder getKeyBuilder(
-          int index) {
-        return getKeyFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.Key key = 3;</code>
-       */
-      public org.floj.wallet.Protos.KeyOrBuilder getKeyOrBuilder(
-          int index) {
-        if (keyBuilder_ == null) {
-          return key_.get(index);  } else {
-          return keyBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Key key = 3;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.KeyOrBuilder> 
-           getKeyOrBuilderList() {
-        if (keyBuilder_ != null) {
-          return keyBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(key_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Key key = 3;</code>
-       */
-      public org.floj.wallet.Protos.Key.Builder addKeyBuilder() {
-        return getKeyFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.Key.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Key key = 3;</code>
-       */
-      public org.floj.wallet.Protos.Key.Builder addKeyBuilder(
-          int index) {
-        return getKeyFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.Key.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Key key = 3;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.Key.Builder> 
-           getKeyBuilderList() {
-        return getKeyFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Key, org.floj.wallet.Protos.Key.Builder, org.floj.wallet.Protos.KeyOrBuilder> 
-          getKeyFieldBuilder() {
-        if (keyBuilder_ == null) {
-          keyBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.Key, org.floj.wallet.Protos.Key.Builder, org.floj.wallet.Protos.KeyOrBuilder>(
-                  key_,
-                  ((bitField0_ & 0x00000010) == 0x00000010),
-                  getParentForChildren(),
-                  isClean());
-          key_ = null;
-        }
-        return keyBuilder_;
-      }
-
-      private java.util.List<org.floj.wallet.Protos.Transaction> transaction_ =
-        java.util.Collections.emptyList();
-      private void ensureTransactionIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-          transaction_ = new java.util.ArrayList<org.floj.wallet.Protos.Transaction>(transaction_);
-          bitField0_ |= 0x00000020;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Transaction, org.floj.wallet.Protos.Transaction.Builder, org.floj.wallet.Protos.TransactionOrBuilder> transactionBuilder_;
 
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
       public java.util.List<org.floj.wallet.Protos.Transaction> getTransactionList() {
-        if (transactionBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(transaction_);
-        } else {
-          return transactionBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getTransactionList());
       }
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
       public int getTransactionCount() {
-        if (transactionBuilder_ == null) {
-          return transaction_.size();
-        } else {
-          return transactionBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getTransactionCount();
+      }/**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
       public org.floj.wallet.Protos.Transaction getTransaction(int index) {
-        if (transactionBuilder_ == null) {
-          return transaction_.get(index);
-        } else {
-          return transactionBuilder_.getMessage(index);
-        }
+        return instance.getTransaction(index);
       }
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
       public Builder setTransaction(
           int index, org.floj.wallet.Protos.Transaction value) {
-        if (transactionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionIsMutable();
-          transaction_.set(index, value);
-          onChanged();
-        } else {
-          transactionBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setTransaction(index, value);
         return this;
       }
       /**
@@ -16666,29 +14645,16 @@ public final class Protos {
        */
       public Builder setTransaction(
           int index, org.floj.wallet.Protos.Transaction.Builder builderForValue) {
-        if (transactionBuilder_ == null) {
-          ensureTransactionIsMutable();
-          transaction_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setTransaction(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
       public Builder addTransaction(org.floj.wallet.Protos.Transaction value) {
-        if (transactionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionIsMutable();
-          transaction_.add(value);
-          onChanged();
-        } else {
-          transactionBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addTransaction(value);
         return this;
       }
       /**
@@ -16696,16 +14662,8 @@ public final class Protos {
        */
       public Builder addTransaction(
           int index, org.floj.wallet.Protos.Transaction value) {
-        if (transactionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionIsMutable();
-          transaction_.add(index, value);
-          onChanged();
-        } else {
-          transactionBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addTransaction(index, value);
         return this;
       }
       /**
@@ -16713,13 +14671,8 @@ public final class Protos {
        */
       public Builder addTransaction(
           org.floj.wallet.Protos.Transaction.Builder builderForValue) {
-        if (transactionBuilder_ == null) {
-          ensureTransactionIsMutable();
-          transaction_.add(builderForValue.build());
-          onChanged();
-        } else {
-          transactionBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransaction(builderForValue);
         return this;
       }
       /**
@@ -16727,13 +14680,8 @@ public final class Protos {
        */
       public Builder addTransaction(
           int index, org.floj.wallet.Protos.Transaction.Builder builderForValue) {
-        if (transactionBuilder_ == null) {
-          ensureTransactionIsMutable();
-          transaction_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransaction(index, builderForValue);
         return this;
       }
       /**
@@ -16741,164 +14689,52 @@ public final class Protos {
        */
       public Builder addAllTransaction(
           java.lang.Iterable<? extends org.floj.wallet.Protos.Transaction> values) {
-        if (transactionBuilder_ == null) {
-          ensureTransactionIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, transaction_);
-          onChanged();
-        } else {
-          transactionBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllTransaction(values);
         return this;
       }
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
       public Builder clearTransaction() {
-        if (transactionBuilder_ == null) {
-          transaction_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
-          onChanged();
-        } else {
-          transactionBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearTransaction();
         return this;
       }
       /**
        * <code>repeated .wallet.Transaction transaction = 4;</code>
        */
       public Builder removeTransaction(int index) {
-        if (transactionBuilder_ == null) {
-          ensureTransactionIsMutable();
-          transaction_.remove(index);
-          onChanged();
-        } else {
-          transactionBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeTransaction(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.Transaction transaction = 4;</code>
-       */
-      public org.floj.wallet.Protos.Transaction.Builder getTransactionBuilder(
-          int index) {
-        return getTransactionFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.Transaction transaction = 4;</code>
-       */
-      public org.floj.wallet.Protos.TransactionOrBuilder getTransactionOrBuilder(
-          int index) {
-        if (transactionBuilder_ == null) {
-          return transaction_.get(index);  } else {
-          return transactionBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Transaction transaction = 4;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.TransactionOrBuilder> 
-           getTransactionOrBuilderList() {
-        if (transactionBuilder_ != null) {
-          return transactionBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(transaction_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Transaction transaction = 4;</code>
-       */
-      public org.floj.wallet.Protos.Transaction.Builder addTransactionBuilder() {
-        return getTransactionFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.Transaction.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Transaction transaction = 4;</code>
-       */
-      public org.floj.wallet.Protos.Transaction.Builder addTransactionBuilder(
-          int index) {
-        return getTransactionFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.Transaction.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Transaction transaction = 4;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.Transaction.Builder> 
-           getTransactionBuilderList() {
-        return getTransactionFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Transaction, org.floj.wallet.Protos.Transaction.Builder, org.floj.wallet.Protos.TransactionOrBuilder> 
-          getTransactionFieldBuilder() {
-        if (transactionBuilder_ == null) {
-          transactionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.Transaction, org.floj.wallet.Protos.Transaction.Builder, org.floj.wallet.Protos.TransactionOrBuilder>(
-                  transaction_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
-                  getParentForChildren(),
-                  isClean());
-          transaction_ = null;
-        }
-        return transactionBuilder_;
-      }
-
-      private java.util.List<org.floj.wallet.Protos.Script> watchedScript_ =
-        java.util.Collections.emptyList();
-      private void ensureWatchedScriptIsMutable() {
-        if (!((bitField0_ & 0x00000040) == 0x00000040)) {
-          watchedScript_ = new java.util.ArrayList<org.floj.wallet.Protos.Script>(watchedScript_);
-          bitField0_ |= 0x00000040;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Script, org.floj.wallet.Protos.Script.Builder, org.floj.wallet.Protos.ScriptOrBuilder> watchedScriptBuilder_;
 
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
       public java.util.List<org.floj.wallet.Protos.Script> getWatchedScriptList() {
-        if (watchedScriptBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(watchedScript_);
-        } else {
-          return watchedScriptBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getWatchedScriptList());
       }
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
       public int getWatchedScriptCount() {
-        if (watchedScriptBuilder_ == null) {
-          return watchedScript_.size();
-        } else {
-          return watchedScriptBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getWatchedScriptCount();
+      }/**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
       public org.floj.wallet.Protos.Script getWatchedScript(int index) {
-        if (watchedScriptBuilder_ == null) {
-          return watchedScript_.get(index);
-        } else {
-          return watchedScriptBuilder_.getMessage(index);
-        }
+        return instance.getWatchedScript(index);
       }
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
       public Builder setWatchedScript(
           int index, org.floj.wallet.Protos.Script value) {
-        if (watchedScriptBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureWatchedScriptIsMutable();
-          watchedScript_.set(index, value);
-          onChanged();
-        } else {
-          watchedScriptBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setWatchedScript(index, value);
         return this;
       }
       /**
@@ -16906,29 +14742,16 @@ public final class Protos {
        */
       public Builder setWatchedScript(
           int index, org.floj.wallet.Protos.Script.Builder builderForValue) {
-        if (watchedScriptBuilder_ == null) {
-          ensureWatchedScriptIsMutable();
-          watchedScript_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          watchedScriptBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setWatchedScript(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
       public Builder addWatchedScript(org.floj.wallet.Protos.Script value) {
-        if (watchedScriptBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureWatchedScriptIsMutable();
-          watchedScript_.add(value);
-          onChanged();
-        } else {
-          watchedScriptBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addWatchedScript(value);
         return this;
       }
       /**
@@ -16936,16 +14759,8 @@ public final class Protos {
        */
       public Builder addWatchedScript(
           int index, org.floj.wallet.Protos.Script value) {
-        if (watchedScriptBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureWatchedScriptIsMutable();
-          watchedScript_.add(index, value);
-          onChanged();
-        } else {
-          watchedScriptBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addWatchedScript(index, value);
         return this;
       }
       /**
@@ -16953,13 +14768,8 @@ public final class Protos {
        */
       public Builder addWatchedScript(
           org.floj.wallet.Protos.Script.Builder builderForValue) {
-        if (watchedScriptBuilder_ == null) {
-          ensureWatchedScriptIsMutable();
-          watchedScript_.add(builderForValue.build());
-          onChanged();
-        } else {
-          watchedScriptBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addWatchedScript(builderForValue);
         return this;
       }
       /**
@@ -16967,13 +14777,8 @@ public final class Protos {
        */
       public Builder addWatchedScript(
           int index, org.floj.wallet.Protos.Script.Builder builderForValue) {
-        if (watchedScriptBuilder_ == null) {
-          ensureWatchedScriptIsMutable();
-          watchedScript_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          watchedScriptBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addWatchedScript(index, builderForValue);
         return this;
       }
       /**
@@ -16981,371 +14786,179 @@ public final class Protos {
        */
       public Builder addAllWatchedScript(
           java.lang.Iterable<? extends org.floj.wallet.Protos.Script> values) {
-        if (watchedScriptBuilder_ == null) {
-          ensureWatchedScriptIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, watchedScript_);
-          onChanged();
-        } else {
-          watchedScriptBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllWatchedScript(values);
         return this;
       }
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
       public Builder clearWatchedScript() {
-        if (watchedScriptBuilder_ == null) {
-          watchedScript_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000040);
-          onChanged();
-        } else {
-          watchedScriptBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearWatchedScript();
         return this;
       }
       /**
        * <code>repeated .wallet.Script watched_script = 15;</code>
        */
       public Builder removeWatchedScript(int index) {
-        if (watchedScriptBuilder_ == null) {
-          ensureWatchedScriptIsMutable();
-          watchedScript_.remove(index);
-          onChanged();
-        } else {
-          watchedScriptBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeWatchedScript(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.Script watched_script = 15;</code>
-       */
-      public org.floj.wallet.Protos.Script.Builder getWatchedScriptBuilder(
-          int index) {
-        return getWatchedScriptFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.Script watched_script = 15;</code>
-       */
-      public org.floj.wallet.Protos.ScriptOrBuilder getWatchedScriptOrBuilder(
-          int index) {
-        if (watchedScriptBuilder_ == null) {
-          return watchedScript_.get(index);  } else {
-          return watchedScriptBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Script watched_script = 15;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.ScriptOrBuilder> 
-           getWatchedScriptOrBuilderList() {
-        if (watchedScriptBuilder_ != null) {
-          return watchedScriptBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(watchedScript_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Script watched_script = 15;</code>
-       */
-      public org.floj.wallet.Protos.Script.Builder addWatchedScriptBuilder() {
-        return getWatchedScriptFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.Script.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Script watched_script = 15;</code>
-       */
-      public org.floj.wallet.Protos.Script.Builder addWatchedScriptBuilder(
-          int index) {
-        return getWatchedScriptFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.Script.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Script watched_script = 15;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.Script.Builder> 
-           getWatchedScriptBuilderList() {
-        return getWatchedScriptFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Script, org.floj.wallet.Protos.Script.Builder, org.floj.wallet.Protos.ScriptOrBuilder> 
-          getWatchedScriptFieldBuilder() {
-        if (watchedScriptBuilder_ == null) {
-          watchedScriptBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.Script, org.floj.wallet.Protos.Script.Builder, org.floj.wallet.Protos.ScriptOrBuilder>(
-                  watchedScript_,
-                  ((bitField0_ & 0x00000040) == 0x00000040),
-                  getParentForChildren(),
-                  isClean());
-          watchedScript_ = null;
-        }
-        return watchedScriptBuilder_;
-      }
 
-      private org.floj.wallet.Protos.Wallet.EncryptionType encryptionType_ = org.floj.wallet.Protos.Wallet.EncryptionType.UNENCRYPTED;
       /**
        * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
        */
       public boolean hasEncryptionType() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return instance.hasEncryptionType();
       }
       /**
        * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
        */
       public org.floj.wallet.Protos.Wallet.EncryptionType getEncryptionType() {
-        return encryptionType_;
+        return instance.getEncryptionType();
       }
       /**
        * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
        */
       public Builder setEncryptionType(org.floj.wallet.Protos.Wallet.EncryptionType value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000080;
-        encryptionType_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setEncryptionType(value);
         return this;
       }
       /**
        * <code>optional .wallet.Wallet.EncryptionType encryption_type = 5 [default = UNENCRYPTED];</code>
        */
       public Builder clearEncryptionType() {
-        bitField0_ = (bitField0_ & ~0x00000080);
-        encryptionType_ = org.floj.wallet.Protos.Wallet.EncryptionType.UNENCRYPTED;
-        onChanged();
+        copyOnWrite();
+        instance.clearEncryptionType();
         return this;
       }
 
-      private org.floj.wallet.Protos.ScryptParameters encryptionParameters_ = org.floj.wallet.Protos.ScryptParameters.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.ScryptParameters, org.floj.wallet.Protos.ScryptParameters.Builder, org.floj.wallet.Protos.ScryptParametersOrBuilder> encryptionParametersBuilder_;
       /**
        * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
        */
       public boolean hasEncryptionParameters() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
+        return instance.hasEncryptionParameters();
       }
       /**
        * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
        */
       public org.floj.wallet.Protos.ScryptParameters getEncryptionParameters() {
-        if (encryptionParametersBuilder_ == null) {
-          return encryptionParameters_;
-        } else {
-          return encryptionParametersBuilder_.getMessage();
-        }
+        return instance.getEncryptionParameters();
       }
       /**
        * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
        */
       public Builder setEncryptionParameters(org.floj.wallet.Protos.ScryptParameters value) {
-        if (encryptionParametersBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          encryptionParameters_ = value;
-          onChanged();
-        } else {
-          encryptionParametersBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.setEncryptionParameters(value);
         return this;
-      }
+        }
       /**
        * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
        */
       public Builder setEncryptionParameters(
           org.floj.wallet.Protos.ScryptParameters.Builder builderForValue) {
-        if (encryptionParametersBuilder_ == null) {
-          encryptionParameters_ = builderForValue.build();
-          onChanged();
-        } else {
-          encryptionParametersBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.setEncryptionParameters(builderForValue);
         return this;
       }
       /**
        * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
        */
       public Builder mergeEncryptionParameters(org.floj.wallet.Protos.ScryptParameters value) {
-        if (encryptionParametersBuilder_ == null) {
-          if (((bitField0_ & 0x00000100) == 0x00000100) &&
-              encryptionParameters_ != org.floj.wallet.Protos.ScryptParameters.getDefaultInstance()) {
-            encryptionParameters_ =
-              org.floj.wallet.Protos.ScryptParameters.newBuilder(encryptionParameters_).mergeFrom(value).buildPartial();
-          } else {
-            encryptionParameters_ = value;
-          }
-          onChanged();
-        } else {
-          encryptionParametersBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000100;
+        copyOnWrite();
+        instance.mergeEncryptionParameters(value);
         return this;
       }
       /**
        * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
        */
-      public Builder clearEncryptionParameters() {
-        if (encryptionParametersBuilder_ == null) {
-          encryptionParameters_ = org.floj.wallet.Protos.ScryptParameters.getDefaultInstance();
-          onChanged();
-        } else {
-          encryptionParametersBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000100);
+      public Builder clearEncryptionParameters() {  copyOnWrite();
+        instance.clearEncryptionParameters();
         return this;
-      }
-      /**
-       * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
-       */
-      public org.floj.wallet.Protos.ScryptParameters.Builder getEncryptionParametersBuilder() {
-        bitField0_ |= 0x00000100;
-        onChanged();
-        return getEncryptionParametersFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
-       */
-      public org.floj.wallet.Protos.ScryptParametersOrBuilder getEncryptionParametersOrBuilder() {
-        if (encryptionParametersBuilder_ != null) {
-          return encryptionParametersBuilder_.getMessageOrBuilder();
-        } else {
-          return encryptionParameters_;
-        }
-      }
-      /**
-       * <code>optional .wallet.ScryptParameters encryption_parameters = 6;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.floj.wallet.Protos.ScryptParameters, org.floj.wallet.Protos.ScryptParameters.Builder, org.floj.wallet.Protos.ScryptParametersOrBuilder> 
-          getEncryptionParametersFieldBuilder() {
-        if (encryptionParametersBuilder_ == null) {
-          encryptionParametersBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.floj.wallet.Protos.ScryptParameters, org.floj.wallet.Protos.ScryptParameters.Builder, org.floj.wallet.Protos.ScryptParametersOrBuilder>(
-                  getEncryptionParameters(),
-                  getParentForChildren(),
-                  isClean());
-          encryptionParameters_ = null;
-        }
-        return encryptionParametersBuilder_;
       }
 
-      private int version_ = 1;
       /**
-       * <code>optional int32 version = 7 [default = 1];</code>
-       *
        * <pre>
        * The version number of the wallet - used to detect wallets that were produced in the future
        * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
        * A version that's higher than the default is considered from the future.
        * </pre>
+       *
+       * <code>optional int32 version = 7 [default = 1];</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
+        return instance.hasVersion();
       }
       /**
-       * <code>optional int32 version = 7 [default = 1];</code>
-       *
        * <pre>
        * The version number of the wallet - used to detect wallets that were produced in the future
        * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
        * A version that's higher than the default is considered from the future.
        * </pre>
+       *
+       * <code>optional int32 version = 7 [default = 1];</code>
        */
       public int getVersion() {
-        return version_;
+        return instance.getVersion();
       }
       /**
-       * <code>optional int32 version = 7 [default = 1];</code>
-       *
        * <pre>
        * The version number of the wallet - used to detect wallets that were produced in the future
        * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
        * A version that's higher than the default is considered from the future.
        * </pre>
+       *
+       * <code>optional int32 version = 7 [default = 1];</code>
        */
       public Builder setVersion(int value) {
-        bitField0_ |= 0x00000200;
-        version_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setVersion(value);
         return this;
       }
       /**
-       * <code>optional int32 version = 7 [default = 1];</code>
-       *
        * <pre>
        * The version number of the wallet - used to detect wallets that were produced in the future
        * (i.e. the wallet may contain some future format this protobuf or parser code does not know about).
        * A version that's higher than the default is considered from the future.
        * </pre>
+       *
+       * <code>optional int32 version = 7 [default = 1];</code>
        */
       public Builder clearVersion() {
-        bitField0_ = (bitField0_ & ~0x00000200);
-        version_ = 1;
-        onChanged();
+        copyOnWrite();
+        instance.clearVersion();
         return this;
       }
-
-      private java.util.List<org.floj.wallet.Protos.Extension> extension_ =
-        java.util.Collections.emptyList();
-      private void ensureExtensionIsMutable() {
-        if (!((bitField0_ & 0x00000400) == 0x00000400)) {
-          extension_ = new java.util.ArrayList<org.floj.wallet.Protos.Extension>(extension_);
-          bitField0_ |= 0x00000400;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Extension, org.floj.wallet.Protos.Extension.Builder, org.floj.wallet.Protos.ExtensionOrBuilder> extensionBuilder_;
 
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
       public java.util.List<org.floj.wallet.Protos.Extension> getExtensionList() {
-        if (extensionBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(extension_);
-        } else {
-          return extensionBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getExtensionList());
       }
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
       public int getExtensionCount() {
-        if (extensionBuilder_ == null) {
-          return extension_.size();
-        } else {
-          return extensionBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getExtensionCount();
+      }/**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
       public org.floj.wallet.Protos.Extension getExtension(int index) {
-        if (extensionBuilder_ == null) {
-          return extension_.get(index);
-        } else {
-          return extensionBuilder_.getMessage(index);
-        }
+        return instance.getExtension(index);
       }
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
       public Builder setExtension(
           int index, org.floj.wallet.Protos.Extension value) {
-        if (extensionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureExtensionIsMutable();
-          extension_.set(index, value);
-          onChanged();
-        } else {
-          extensionBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setExtension(index, value);
         return this;
       }
       /**
@@ -17353,29 +14966,16 @@ public final class Protos {
        */
       public Builder setExtension(
           int index, org.floj.wallet.Protos.Extension.Builder builderForValue) {
-        if (extensionBuilder_ == null) {
-          ensureExtensionIsMutable();
-          extension_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          extensionBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setExtension(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
       public Builder addExtension(org.floj.wallet.Protos.Extension value) {
-        if (extensionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureExtensionIsMutable();
-          extension_.add(value);
-          onChanged();
-        } else {
-          extensionBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addExtension(value);
         return this;
       }
       /**
@@ -17383,16 +14983,8 @@ public final class Protos {
        */
       public Builder addExtension(
           int index, org.floj.wallet.Protos.Extension value) {
-        if (extensionBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureExtensionIsMutable();
-          extension_.add(index, value);
-          onChanged();
-        } else {
-          extensionBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addExtension(index, value);
         return this;
       }
       /**
@@ -17400,13 +14992,8 @@ public final class Protos {
        */
       public Builder addExtension(
           org.floj.wallet.Protos.Extension.Builder builderForValue) {
-        if (extensionBuilder_ == null) {
-          ensureExtensionIsMutable();
-          extension_.add(builderForValue.build());
-          onChanged();
-        } else {
-          extensionBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addExtension(builderForValue);
         return this;
       }
       /**
@@ -17414,13 +15001,8 @@ public final class Protos {
        */
       public Builder addExtension(
           int index, org.floj.wallet.Protos.Extension.Builder builderForValue) {
-        if (extensionBuilder_ == null) {
-          ensureExtensionIsMutable();
-          extension_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          extensionBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addExtension(index, builderForValue);
         return this;
       }
       /**
@@ -17428,320 +15010,175 @@ public final class Protos {
        */
       public Builder addAllExtension(
           java.lang.Iterable<? extends org.floj.wallet.Protos.Extension> values) {
-        if (extensionBuilder_ == null) {
-          ensureExtensionIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, extension_);
-          onChanged();
-        } else {
-          extensionBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllExtension(values);
         return this;
       }
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
       public Builder clearExtension() {
-        if (extensionBuilder_ == null) {
-          extension_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000400);
-          onChanged();
-        } else {
-          extensionBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearExtension();
         return this;
       }
       /**
        * <code>repeated .wallet.Extension extension = 10;</code>
        */
       public Builder removeExtension(int index) {
-        if (extensionBuilder_ == null) {
-          ensureExtensionIsMutable();
-          extension_.remove(index);
-          onChanged();
-        } else {
-          extensionBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeExtension(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.Extension extension = 10;</code>
-       */
-      public org.floj.wallet.Protos.Extension.Builder getExtensionBuilder(
-          int index) {
-        return getExtensionFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.Extension extension = 10;</code>
-       */
-      public org.floj.wallet.Protos.ExtensionOrBuilder getExtensionOrBuilder(
-          int index) {
-        if (extensionBuilder_ == null) {
-          return extension_.get(index);  } else {
-          return extensionBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Extension extension = 10;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.ExtensionOrBuilder> 
-           getExtensionOrBuilderList() {
-        if (extensionBuilder_ != null) {
-          return extensionBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(extension_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Extension extension = 10;</code>
-       */
-      public org.floj.wallet.Protos.Extension.Builder addExtensionBuilder() {
-        return getExtensionFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.Extension.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Extension extension = 10;</code>
-       */
-      public org.floj.wallet.Protos.Extension.Builder addExtensionBuilder(
-          int index) {
-        return getExtensionFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.Extension.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Extension extension = 10;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.Extension.Builder> 
-           getExtensionBuilderList() {
-        return getExtensionFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Extension, org.floj.wallet.Protos.Extension.Builder, org.floj.wallet.Protos.ExtensionOrBuilder> 
-          getExtensionFieldBuilder() {
-        if (extensionBuilder_ == null) {
-          extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.Extension, org.floj.wallet.Protos.Extension.Builder, org.floj.wallet.Protos.ExtensionOrBuilder>(
-                  extension_,
-                  ((bitField0_ & 0x00000400) == 0x00000400),
-                  getParentForChildren(),
-                  isClean());
-          extension_ = null;
-        }
-        return extensionBuilder_;
-      }
 
-      private java.lang.Object description_ = "";
       /**
-       * <code>optional string description = 11;</code>
-       *
        * <pre>
        * A UTF8 encoded text description of the wallet that is intended for end user provided text.
        * </pre>
+       *
+       * <code>optional string description = 11;</code>
        */
       public boolean hasDescription() {
-        return ((bitField0_ & 0x00000800) == 0x00000800);
+        return instance.hasDescription();
       }
       /**
-       * <code>optional string description = 11;</code>
-       *
        * <pre>
        * A UTF8 encoded text description of the wallet that is intended for end user provided text.
        * </pre>
+       *
+       * <code>optional string description = 11;</code>
        */
       public java.lang.String getDescription() {
-        java.lang.Object ref = description_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            description_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getDescription();
       }
       /**
-       * <code>optional string description = 11;</code>
-       *
        * <pre>
        * A UTF8 encoded text description of the wallet that is intended for end user provided text.
        * </pre>
+       *
+       * <code>optional string description = 11;</code>
        */
       public com.google.protobuf.ByteString
           getDescriptionBytes() {
-        java.lang.Object ref = description_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          description_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getDescriptionBytes();
       }
       /**
-       * <code>optional string description = 11;</code>
-       *
        * <pre>
        * A UTF8 encoded text description of the wallet that is intended for end user provided text.
        * </pre>
+       *
+       * <code>optional string description = 11;</code>
        */
       public Builder setDescription(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000800;
-        description_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setDescription(value);
         return this;
       }
       /**
-       * <code>optional string description = 11;</code>
-       *
        * <pre>
        * A UTF8 encoded text description of the wallet that is intended for end user provided text.
        * </pre>
+       *
+       * <code>optional string description = 11;</code>
        */
       public Builder clearDescription() {
-        bitField0_ = (bitField0_ & ~0x00000800);
-        description_ = getDefaultInstance().getDescription();
-        onChanged();
+        copyOnWrite();
+        instance.clearDescription();
         return this;
       }
       /**
-       * <code>optional string description = 11;</code>
-       *
        * <pre>
        * A UTF8 encoded text description of the wallet that is intended for end user provided text.
        * </pre>
+       *
+       * <code>optional string description = 11;</code>
        */
       public Builder setDescriptionBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000800;
-        description_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setDescriptionBytes(value);
         return this;
       }
 
-      private long keyRotationTime_ ;
       /**
-       * <code>optional uint64 key_rotation_time = 13;</code>
-       *
        * <pre>
        * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
        * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
        * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
        * </pre>
+       *
+       * <code>optional uint64 key_rotation_time = 13;</code>
        */
       public boolean hasKeyRotationTime() {
-        return ((bitField0_ & 0x00001000) == 0x00001000);
+        return instance.hasKeyRotationTime();
       }
       /**
-       * <code>optional uint64 key_rotation_time = 13;</code>
-       *
        * <pre>
        * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
        * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
        * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
        * </pre>
+       *
+       * <code>optional uint64 key_rotation_time = 13;</code>
        */
       public long getKeyRotationTime() {
-        return keyRotationTime_;
+        return instance.getKeyRotationTime();
       }
       /**
-       * <code>optional uint64 key_rotation_time = 13;</code>
-       *
        * <pre>
        * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
        * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
        * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
        * </pre>
+       *
+       * <code>optional uint64 key_rotation_time = 13;</code>
        */
       public Builder setKeyRotationTime(long value) {
-        bitField0_ |= 0x00001000;
-        keyRotationTime_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setKeyRotationTime(value);
         return this;
       }
       /**
-       * <code>optional uint64 key_rotation_time = 13;</code>
-       *
        * <pre>
        * UNIX time in seconds since the epoch. If set, then any keys created before this date are assumed to be no longer
        * wanted. Money sent to them will be re-spent automatically to the first key that was created after this time. It
        * can be used to recover a compromised wallet, or just as part of preventative defence-in-depth measures.
        * </pre>
+       *
+       * <code>optional uint64 key_rotation_time = 13;</code>
        */
       public Builder clearKeyRotationTime() {
-        bitField0_ = (bitField0_ & ~0x00001000);
-        keyRotationTime_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearKeyRotationTime();
         return this;
       }
-
-      private java.util.List<org.floj.wallet.Protos.Tag> tags_ =
-        java.util.Collections.emptyList();
-      private void ensureTagsIsMutable() {
-        if (!((bitField0_ & 0x00002000) == 0x00002000)) {
-          tags_ = new java.util.ArrayList<org.floj.wallet.Protos.Tag>(tags_);
-          bitField0_ |= 0x00002000;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Tag, org.floj.wallet.Protos.Tag.Builder, org.floj.wallet.Protos.TagOrBuilder> tagsBuilder_;
 
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
       public java.util.List<org.floj.wallet.Protos.Tag> getTagsList() {
-        if (tagsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(tags_);
-        } else {
-          return tagsBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getTagsList());
       }
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
       public int getTagsCount() {
-        if (tagsBuilder_ == null) {
-          return tags_.size();
-        } else {
-          return tagsBuilder_.getCount();
-        }
-      }
-      /**
+        return instance.getTagsCount();
+      }/**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
       public org.floj.wallet.Protos.Tag getTags(int index) {
-        if (tagsBuilder_ == null) {
-          return tags_.get(index);
-        } else {
-          return tagsBuilder_.getMessage(index);
-        }
+        return instance.getTags(index);
       }
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
       public Builder setTags(
           int index, org.floj.wallet.Protos.Tag value) {
-        if (tagsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTagsIsMutable();
-          tags_.set(index, value);
-          onChanged();
-        } else {
-          tagsBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setTags(index, value);
         return this;
       }
       /**
@@ -17749,29 +15186,16 @@ public final class Protos {
        */
       public Builder setTags(
           int index, org.floj.wallet.Protos.Tag.Builder builderForValue) {
-        if (tagsBuilder_ == null) {
-          ensureTagsIsMutable();
-          tags_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          tagsBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setTags(index, builderForValue);
         return this;
       }
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
       public Builder addTags(org.floj.wallet.Protos.Tag value) {
-        if (tagsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTagsIsMutable();
-          tags_.add(value);
-          onChanged();
-        } else {
-          tagsBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addTags(value);
         return this;
       }
       /**
@@ -17779,16 +15203,8 @@ public final class Protos {
        */
       public Builder addTags(
           int index, org.floj.wallet.Protos.Tag value) {
-        if (tagsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTagsIsMutable();
-          tags_.add(index, value);
-          onChanged();
-        } else {
-          tagsBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addTags(index, value);
         return this;
       }
       /**
@@ -17796,13 +15212,8 @@ public final class Protos {
        */
       public Builder addTags(
           org.floj.wallet.Protos.Tag.Builder builderForValue) {
-        if (tagsBuilder_ == null) {
-          ensureTagsIsMutable();
-          tags_.add(builderForValue.build());
-          onChanged();
-        } else {
-          tagsBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTags(builderForValue);
         return this;
       }
       /**
@@ -17810,13 +15221,8 @@ public final class Protos {
        */
       public Builder addTags(
           int index, org.floj.wallet.Protos.Tag.Builder builderForValue) {
-        if (tagsBuilder_ == null) {
-          ensureTagsIsMutable();
-          tags_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          tagsBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTags(index, builderForValue);
         return this;
       }
       /**
@@ -17824,736 +15230,732 @@ public final class Protos {
        */
       public Builder addAllTags(
           java.lang.Iterable<? extends org.floj.wallet.Protos.Tag> values) {
-        if (tagsBuilder_ == null) {
-          ensureTagsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, tags_);
-          onChanged();
-        } else {
-          tagsBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllTags(values);
         return this;
       }
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
       public Builder clearTags() {
-        if (tagsBuilder_ == null) {
-          tags_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00002000);
-          onChanged();
-        } else {
-          tagsBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearTags();
         return this;
       }
       /**
        * <code>repeated .wallet.Tag tags = 16;</code>
        */
       public Builder removeTags(int index) {
-        if (tagsBuilder_ == null) {
-          ensureTagsIsMutable();
-          tags_.remove(index);
-          onChanged();
-        } else {
-          tagsBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeTags(index);
         return this;
       }
-      /**
-       * <code>repeated .wallet.Tag tags = 16;</code>
-       */
-      public org.floj.wallet.Protos.Tag.Builder getTagsBuilder(
-          int index) {
-        return getTagsFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.Tag tags = 16;</code>
-       */
-      public org.floj.wallet.Protos.TagOrBuilder getTagsOrBuilder(
-          int index) {
-        if (tagsBuilder_ == null) {
-          return tags_.get(index);  } else {
-          return tagsBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Tag tags = 16;</code>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.TagOrBuilder> 
-           getTagsOrBuilderList() {
-        if (tagsBuilder_ != null) {
-          return tagsBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(tags_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.Tag tags = 16;</code>
-       */
-      public org.floj.wallet.Protos.Tag.Builder addTagsBuilder() {
-        return getTagsFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.Tag.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Tag tags = 16;</code>
-       */
-      public org.floj.wallet.Protos.Tag.Builder addTagsBuilder(
-          int index) {
-        return getTagsFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.Tag.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.Tag tags = 16;</code>
-       */
-      public java.util.List<org.floj.wallet.Protos.Tag.Builder> 
-           getTagsBuilderList() {
-        return getTagsFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.Tag, org.floj.wallet.Protos.Tag.Builder, org.floj.wallet.Protos.TagOrBuilder> 
-          getTagsFieldBuilder() {
-        if (tagsBuilder_ == null) {
-          tagsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.Tag, org.floj.wallet.Protos.Tag.Builder, org.floj.wallet.Protos.TagOrBuilder>(
-                  tags_,
-                  ((bitField0_ & 0x00002000) == 0x00002000),
-                  getParentForChildren(),
-                  isClean());
-          tags_ = null;
-        }
-        return tagsBuilder_;
-      }
-
-      private java.util.List<org.floj.wallet.Protos.TransactionSigner> transactionSigners_ =
-        java.util.Collections.emptyList();
-      private void ensureTransactionSignersIsMutable() {
-        if (!((bitField0_ & 0x00004000) == 0x00004000)) {
-          transactionSigners_ = new java.util.ArrayList<org.floj.wallet.Protos.TransactionSigner>(transactionSigners_);
-          bitField0_ |= 0x00004000;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.TransactionSigner, org.floj.wallet.Protos.TransactionSigner.Builder, org.floj.wallet.Protos.TransactionSignerOrBuilder> transactionSignersBuilder_;
 
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public java.util.List<org.floj.wallet.Protos.TransactionSigner> getTransactionSignersList() {
-        if (transactionSignersBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(transactionSigners_);
-        } else {
-          return transactionSignersBuilder_.getMessageList();
-        }
+        return java.util.Collections.unmodifiableList(
+            instance.getTransactionSignersList());
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public int getTransactionSignersCount() {
-        if (transactionSignersBuilder_ == null) {
-          return transactionSigners_.size();
-        } else {
-          return transactionSignersBuilder_.getCount();
-        }
-      }
-      /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
+        return instance.getTransactionSignersCount();
+      }/**
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public org.floj.wallet.Protos.TransactionSigner getTransactionSigners(int index) {
-        if (transactionSignersBuilder_ == null) {
-          return transactionSigners_.get(index);
-        } else {
-          return transactionSignersBuilder_.getMessage(index);
-        }
+        return instance.getTransactionSigners(index);
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder setTransactionSigners(
           int index, org.floj.wallet.Protos.TransactionSigner value) {
-        if (transactionSignersBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionSignersIsMutable();
-          transactionSigners_.set(index, value);
-          onChanged();
-        } else {
-          transactionSignersBuilder_.setMessage(index, value);
-        }
+        copyOnWrite();
+        instance.setTransactionSigners(index, value);
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder setTransactionSigners(
           int index, org.floj.wallet.Protos.TransactionSigner.Builder builderForValue) {
-        if (transactionSignersBuilder_ == null) {
-          ensureTransactionSignersIsMutable();
-          transactionSigners_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionSignersBuilder_.setMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.setTransactionSigners(index, builderForValue);
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder addTransactionSigners(org.floj.wallet.Protos.TransactionSigner value) {
-        if (transactionSignersBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionSignersIsMutable();
-          transactionSigners_.add(value);
-          onChanged();
-        } else {
-          transactionSignersBuilder_.addMessage(value);
-        }
+        copyOnWrite();
+        instance.addTransactionSigners(value);
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder addTransactionSigners(
           int index, org.floj.wallet.Protos.TransactionSigner value) {
-        if (transactionSignersBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransactionSignersIsMutable();
-          transactionSigners_.add(index, value);
-          onChanged();
-        } else {
-          transactionSignersBuilder_.addMessage(index, value);
-        }
+        copyOnWrite();
+        instance.addTransactionSigners(index, value);
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder addTransactionSigners(
           org.floj.wallet.Protos.TransactionSigner.Builder builderForValue) {
-        if (transactionSignersBuilder_ == null) {
-          ensureTransactionSignersIsMutable();
-          transactionSigners_.add(builderForValue.build());
-          onChanged();
-        } else {
-          transactionSignersBuilder_.addMessage(builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransactionSigners(builderForValue);
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder addTransactionSigners(
           int index, org.floj.wallet.Protos.TransactionSigner.Builder builderForValue) {
-        if (transactionSignersBuilder_ == null) {
-          ensureTransactionSignersIsMutable();
-          transactionSigners_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          transactionSignersBuilder_.addMessage(index, builderForValue.build());
-        }
+        copyOnWrite();
+        instance.addTransactionSigners(index, builderForValue);
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder addAllTransactionSigners(
           java.lang.Iterable<? extends org.floj.wallet.Protos.TransactionSigner> values) {
-        if (transactionSignersBuilder_ == null) {
-          ensureTransactionSignersIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, transactionSigners_);
-          onChanged();
-        } else {
-          transactionSignersBuilder_.addAllMessages(values);
-        }
+        copyOnWrite();
+        instance.addAllTransactionSigners(values);
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder clearTransactionSigners() {
-        if (transactionSignersBuilder_ == null) {
-          transactionSigners_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00004000);
-          onChanged();
-        } else {
-          transactionSignersBuilder_.clear();
-        }
+        copyOnWrite();
+        instance.clearTransactionSigners();
         return this;
       }
       /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
        * <pre>
        * transaction signers added to the wallet
        * </pre>
+       *
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
        */
       public Builder removeTransactionSigners(int index) {
-        if (transactionSignersBuilder_ == null) {
-          ensureTransactionSignersIsMutable();
-          transactionSigners_.remove(index);
-          onChanged();
-        } else {
-          transactionSignersBuilder_.remove(index);
-        }
+        copyOnWrite();
+        instance.removeTransactionSigners(index);
         return this;
-      }
-      /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
-       * <pre>
-       * transaction signers added to the wallet
-       * </pre>
-       */
-      public org.floj.wallet.Protos.TransactionSigner.Builder getTransactionSignersBuilder(
-          int index) {
-        return getTransactionSignersFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
-       * <pre>
-       * transaction signers added to the wallet
-       * </pre>
-       */
-      public org.floj.wallet.Protos.TransactionSignerOrBuilder getTransactionSignersOrBuilder(
-          int index) {
-        if (transactionSignersBuilder_ == null) {
-          return transactionSigners_.get(index);  } else {
-          return transactionSignersBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
-       * <pre>
-       * transaction signers added to the wallet
-       * </pre>
-       */
-      public java.util.List<? extends org.floj.wallet.Protos.TransactionSignerOrBuilder> 
-           getTransactionSignersOrBuilderList() {
-        if (transactionSignersBuilder_ != null) {
-          return transactionSignersBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(transactionSigners_);
-        }
-      }
-      /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
-       * <pre>
-       * transaction signers added to the wallet
-       * </pre>
-       */
-      public org.floj.wallet.Protos.TransactionSigner.Builder addTransactionSignersBuilder() {
-        return getTransactionSignersFieldBuilder().addBuilder(
-            org.floj.wallet.Protos.TransactionSigner.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
-       * <pre>
-       * transaction signers added to the wallet
-       * </pre>
-       */
-      public org.floj.wallet.Protos.TransactionSigner.Builder addTransactionSignersBuilder(
-          int index) {
-        return getTransactionSignersFieldBuilder().addBuilder(
-            index, org.floj.wallet.Protos.TransactionSigner.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
-       *
-       * <pre>
-       * transaction signers added to the wallet
-       * </pre>
-       */
-      public java.util.List<org.floj.wallet.Protos.TransactionSigner.Builder> 
-           getTransactionSignersBuilderList() {
-        return getTransactionSignersFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilder<
-          org.floj.wallet.Protos.TransactionSigner, org.floj.wallet.Protos.TransactionSigner.Builder, org.floj.wallet.Protos.TransactionSignerOrBuilder> 
-          getTransactionSignersFieldBuilder() {
-        if (transactionSignersBuilder_ == null) {
-          transactionSignersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              org.floj.wallet.Protos.TransactionSigner, org.floj.wallet.Protos.TransactionSigner.Builder, org.floj.wallet.Protos.TransactionSignerOrBuilder>(
-                  transactionSigners_,
-                  ((bitField0_ & 0x00004000) == 0x00004000),
-                  getParentForChildren(),
-                  isClean());
-          transactionSigners_ = null;
-        }
-        return transactionSignersBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.Wallet)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.Wallet();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new Wallet(true);
-      defaultInstance.initFields();
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasNetworkIdentifier()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          for (int i = 0; i < getKeyCount(); i++) {
+            if (!getKey(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          for (int i = 0; i < getTransactionCount(); i++) {
+            if (!getTransaction(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          for (int i = 0; i < getWatchedScriptCount(); i++) {
+            if (!getWatchedScript(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (hasEncryptionParameters()) {
+            if (!getEncryptionParameters().isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          for (int i = 0; i < getExtensionCount(); i++) {
+            if (!getExtension(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          for (int i = 0; i < getTagsCount(); i++) {
+            if (!getTags(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          for (int i = 0; i < getTransactionSignersCount(); i++) {
+            if (!getTransactionSigners(i).isInitialized()) {
+              if (shouldMemoize) {
+                memoizedIsInitialized = 0;
+              }
+              return null;
+            }
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          key_.makeImmutable();
+          transaction_.makeImmutable();
+          watchedScript_.makeImmutable();
+          extension_.makeImmutable();
+          tags_.makeImmutable();
+          transactionSigners_.makeImmutable();
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.Wallet other = (org.floj.wallet.Protos.Wallet) arg1;
+          networkIdentifier_ = visitor.visitString(
+              hasNetworkIdentifier(), networkIdentifier_,
+              other.hasNetworkIdentifier(), other.networkIdentifier_);
+          lastSeenBlockHash_ = visitor.visitByteString(
+              hasLastSeenBlockHash(), lastSeenBlockHash_,
+              other.hasLastSeenBlockHash(), other.lastSeenBlockHash_);
+          lastSeenBlockHeight_ = visitor.visitInt(
+              hasLastSeenBlockHeight(), lastSeenBlockHeight_,
+              other.hasLastSeenBlockHeight(), other.lastSeenBlockHeight_);
+          lastSeenBlockTimeSecs_ = visitor.visitLong(
+              hasLastSeenBlockTimeSecs(), lastSeenBlockTimeSecs_,
+              other.hasLastSeenBlockTimeSecs(), other.lastSeenBlockTimeSecs_);
+          key_= visitor.visitList(key_, other.key_);
+          transaction_= visitor.visitList(transaction_, other.transaction_);
+          watchedScript_= visitor.visitList(watchedScript_, other.watchedScript_);
+          encryptionType_ = visitor.visitInt(hasEncryptionType(), encryptionType_,
+              other.hasEncryptionType(), other.encryptionType_);
+          encryptionParameters_ = visitor.visitMessage(encryptionParameters_, other.encryptionParameters_);
+          version_ = visitor.visitInt(
+              hasVersion(), version_,
+              other.hasVersion(), other.version_);
+          extension_= visitor.visitList(extension_, other.extension_);
+          description_ = visitor.visitString(
+              hasDescription(), description_,
+              other.hasDescription(), other.description_);
+          keyRotationTime_ = visitor.visitLong(
+              hasKeyRotationTime(), keyRotationTime_,
+              other.hasKeyRotationTime(), other.keyRotationTime_);
+          tags_= visitor.visitList(tags_, other.tags_);
+          transactionSigners_= visitor.visitList(transactionSigners_, other.transactionSigners_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 10: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000001;
+                  networkIdentifier_ = s;
+                  break;
+                }
+                case 18: {
+                  bitField0_ |= 0x00000002;
+                  lastSeenBlockHash_ = input.readBytes();
+                  break;
+                }
+                case 26: {
+                  if (!key_.isModifiable()) {
+                    key_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(key_);
+                  }
+                  key_.add(
+                      input.readMessage(org.floj.wallet.Protos.Key.parser(), extensionRegistry));
+                  break;
+                }
+                case 34: {
+                  if (!transaction_.isModifiable()) {
+                    transaction_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(transaction_);
+                  }
+                  transaction_.add(
+                      input.readMessage(org.floj.wallet.Protos.Transaction.parser(), extensionRegistry));
+                  break;
+                }
+                case 40: {
+                  int rawValue = input.readEnum();
+                  org.floj.wallet.Protos.Wallet.EncryptionType value = org.floj.wallet.Protos.Wallet.EncryptionType.forNumber(rawValue);
+                  if (value == null) {
+                    super.mergeVarintField(5, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000010;
+                    encryptionType_ = rawValue;
+                  }
+                  break;
+                }
+                case 50: {
+                  org.floj.wallet.Protos.ScryptParameters.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                    subBuilder = encryptionParameters_.toBuilder();
+                  }
+                  encryptionParameters_ = input.readMessage(org.floj.wallet.Protos.ScryptParameters.parser(), extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(encryptionParameters_);
+                    encryptionParameters_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000020;
+                  break;
+                }
+                case 56: {
+                  bitField0_ |= 0x00000040;
+                  version_ = input.readInt32();
+                  break;
+                }
+                case 82: {
+                  if (!extension_.isModifiable()) {
+                    extension_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(extension_);
+                  }
+                  extension_.add(
+                      input.readMessage(org.floj.wallet.Protos.Extension.parser(), extensionRegistry));
+                  break;
+                }
+                case 90: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000080;
+                  description_ = s;
+                  break;
+                }
+                case 96: {
+                  bitField0_ |= 0x00000004;
+                  lastSeenBlockHeight_ = input.readUInt32();
+                  break;
+                }
+                case 104: {
+                  bitField0_ |= 0x00000100;
+                  keyRotationTime_ = input.readUInt64();
+                  break;
+                }
+                case 112: {
+                  bitField0_ |= 0x00000008;
+                  lastSeenBlockTimeSecs_ = input.readInt64();
+                  break;
+                }
+                case 122: {
+                  if (!watchedScript_.isModifiable()) {
+                    watchedScript_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(watchedScript_);
+                  }
+                  watchedScript_.add(
+                      input.readMessage(org.floj.wallet.Protos.Script.parser(), extensionRegistry));
+                  break;
+                }
+                case 130: {
+                  if (!tags_.isModifiable()) {
+                    tags_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(tags_);
+                  }
+                  tags_.add(
+                      input.readMessage(org.floj.wallet.Protos.Tag.parser(), extensionRegistry));
+                  break;
+                }
+                case 138: {
+                  if (!transactionSigners_.isModifiable()) {
+                    transactionSigners_ =
+                        com.google.protobuf.GeneratedMessageLite.mutableCopy(transactionSigners_);
+                  }
+                  transactionSigners_.add(
+                      input.readMessage(org.floj.wallet.Protos.TransactionSigner.parser(), extensionRegistry));
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.Wallet.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
     }
 
+
     // @@protoc_insertion_point(class_scope:wallet.Wallet)
+    private static final org.floj.wallet.Protos.Wallet DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new Wallet();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.Wallet getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<Wallet> PARSER;
+
+    public static com.google.protobuf.Parser<Wallet> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
   }
 
   public interface ExchangeRateOrBuilder extends
       // @@protoc_insertion_point(interface_extends:wallet.ExchangeRate)
-      com.google.protobuf.MessageOrBuilder {
+      com.google.protobuf.MessageLiteOrBuilder {
 
     /**
-     * <code>required int64 coin_value = 1;</code>
-     *
      * <pre>
      * This much of satoshis (1E-8 fractions)…
      * </pre>
+     *
+     * <code>required int64 coin_value = 1;</code>
      */
     boolean hasCoinValue();
     /**
-     * <code>required int64 coin_value = 1;</code>
-     *
      * <pre>
      * This much of satoshis (1E-8 fractions)…
      * </pre>
+     *
+     * <code>required int64 coin_value = 1;</code>
      */
     long getCoinValue();
 
     /**
-     * <code>required int64 fiat_value = 2;</code>
-     *
      * <pre>
      * …is worth this much of fiat (1E-4 fractions).
      * </pre>
+     *
+     * <code>required int64 fiat_value = 2;</code>
      */
     boolean hasFiatValue();
     /**
-     * <code>required int64 fiat_value = 2;</code>
-     *
      * <pre>
      * …is worth this much of fiat (1E-4 fractions).
      * </pre>
+     *
+     * <code>required int64 fiat_value = 2;</code>
      */
     long getFiatValue();
 
     /**
-     * <code>required string fiat_currency_code = 3;</code>
-     *
      * <pre>
      * ISO 4217 currency code (if available) of the fiat currency.
      * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
      */
     boolean hasFiatCurrencyCode();
     /**
-     * <code>required string fiat_currency_code = 3;</code>
-     *
      * <pre>
      * ISO 4217 currency code (if available) of the fiat currency.
      * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
      */
     java.lang.String getFiatCurrencyCode();
     /**
-     * <code>required string fiat_currency_code = 3;</code>
-     *
      * <pre>
      * ISO 4217 currency code (if available) of the fiat currency.
      * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
      */
     com.google.protobuf.ByteString
         getFiatCurrencyCodeBytes();
   }
   /**
-   * Protobuf type {@code wallet.ExchangeRate}
-   *
    * <pre>
    ** An exchange rate between FLO and some fiat currency. 
    * </pre>
+   *
+   * Protobuf type {@code wallet.ExchangeRate}
    */
-  public static final class ExchangeRate extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class ExchangeRate extends
+      com.google.protobuf.GeneratedMessageLite<
+          ExchangeRate, ExchangeRate.Builder> implements
       // @@protoc_insertion_point(message_implements:wallet.ExchangeRate)
       ExchangeRateOrBuilder {
-    // Use ExchangeRate.newBuilder() to construct.
-    private ExchangeRate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
+    private ExchangeRate() {
+      fiatCurrencyCode_ = "";
     }
-    private ExchangeRate(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final ExchangeRate defaultInstance;
-    public static ExchangeRate getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public ExchangeRate getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ExchangeRate(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              coinValue_ = input.readInt64();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              fiatValue_ = input.readInt64();
-              break;
-            }
-            case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000004;
-              fiatCurrencyCode_ = bs;
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.floj.wallet.Protos.internal_static_wallet_ExchangeRate_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.floj.wallet.Protos.internal_static_wallet_ExchangeRate_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.floj.wallet.Protos.ExchangeRate.class, org.floj.wallet.Protos.ExchangeRate.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<ExchangeRate> PARSER =
-        new com.google.protobuf.AbstractParser<ExchangeRate>() {
-      public ExchangeRate parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ExchangeRate(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ExchangeRate> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int COIN_VALUE_FIELD_NUMBER = 1;
     private long coinValue_;
     /**
-     * <code>required int64 coin_value = 1;</code>
-     *
      * <pre>
      * This much of satoshis (1E-8 fractions)…
      * </pre>
+     *
+     * <code>required int64 coin_value = 1;</code>
      */
     public boolean hasCoinValue() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required int64 coin_value = 1;</code>
-     *
      * <pre>
      * This much of satoshis (1E-8 fractions)…
      * </pre>
+     *
+     * <code>required int64 coin_value = 1;</code>
      */
     public long getCoinValue() {
       return coinValue_;
+    }
+    /**
+     * <pre>
+     * This much of satoshis (1E-8 fractions)…
+     * </pre>
+     *
+     * <code>required int64 coin_value = 1;</code>
+     */
+    private void setCoinValue(long value) {
+      bitField0_ |= 0x00000001;
+      coinValue_ = value;
+    }
+    /**
+     * <pre>
+     * This much of satoshis (1E-8 fractions)…
+     * </pre>
+     *
+     * <code>required int64 coin_value = 1;</code>
+     */
+    private void clearCoinValue() {
+      bitField0_ = (bitField0_ & ~0x00000001);
+      coinValue_ = 0L;
     }
 
     public static final int FIAT_VALUE_FIELD_NUMBER = 2;
     private long fiatValue_;
     /**
-     * <code>required int64 fiat_value = 2;</code>
-     *
      * <pre>
      * …is worth this much of fiat (1E-4 fractions).
      * </pre>
+     *
+     * <code>required int64 fiat_value = 2;</code>
      */
     public boolean hasFiatValue() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required int64 fiat_value = 2;</code>
-     *
      * <pre>
      * …is worth this much of fiat (1E-4 fractions).
      * </pre>
+     *
+     * <code>required int64 fiat_value = 2;</code>
      */
     public long getFiatValue() {
       return fiatValue_;
     }
+    /**
+     * <pre>
+     * …is worth this much of fiat (1E-4 fractions).
+     * </pre>
+     *
+     * <code>required int64 fiat_value = 2;</code>
+     */
+    private void setFiatValue(long value) {
+      bitField0_ |= 0x00000002;
+      fiatValue_ = value;
+    }
+    /**
+     * <pre>
+     * …is worth this much of fiat (1E-4 fractions).
+     * </pre>
+     *
+     * <code>required int64 fiat_value = 2;</code>
+     */
+    private void clearFiatValue() {
+      bitField0_ = (bitField0_ & ~0x00000002);
+      fiatValue_ = 0L;
+    }
 
     public static final int FIAT_CURRENCY_CODE_FIELD_NUMBER = 3;
-    private java.lang.Object fiatCurrencyCode_;
+    private java.lang.String fiatCurrencyCode_;
     /**
-     * <code>required string fiat_currency_code = 3;</code>
-     *
      * <pre>
      * ISO 4217 currency code (if available) of the fiat currency.
      * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
      */
     public boolean hasFiatCurrencyCode() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>required string fiat_currency_code = 3;</code>
-     *
      * <pre>
      * ISO 4217 currency code (if available) of the fiat currency.
      * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
      */
     public java.lang.String getFiatCurrencyCode() {
-      java.lang.Object ref = fiatCurrencyCode_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          fiatCurrencyCode_ = s;
-        }
-        return s;
-      }
+      return fiatCurrencyCode_;
     }
     /**
-     * <code>required string fiat_currency_code = 3;</code>
-     *
      * <pre>
      * ISO 4217 currency code (if available) of the fiat currency.
      * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
      */
     public com.google.protobuf.ByteString
         getFiatCurrencyCodeBytes() {
-      java.lang.Object ref = fiatCurrencyCode_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        fiatCurrencyCode_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+      return com.google.protobuf.ByteString.copyFromUtf8(fiatCurrencyCode_);
     }
-
-    private void initFields() {
-      coinValue_ = 0L;
-      fiatValue_ = 0L;
-      fiatCurrencyCode_ = "";
+    /**
+     * <pre>
+     * ISO 4217 currency code (if available) of the fiat currency.
+     * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
+     */
+    private void setFiatCurrencyCode(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      fiatCurrencyCode_ = value;
     }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      if (!hasCoinValue()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasFiatValue()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasFiatCurrencyCode()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
+    /**
+     * <pre>
+     * ISO 4217 currency code (if available) of the fiat currency.
+     * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
+     */
+    private void clearFiatCurrencyCode() {
+      bitField0_ = (bitField0_ & ~0x00000004);
+      fiatCurrencyCode_ = getDefaultInstance().getFiatCurrencyCode();
+    }
+    /**
+     * <pre>
+     * ISO 4217 currency code (if available) of the fiat currency.
+     * </pre>
+     *
+     * <code>required string fiat_currency_code = 3;</code>
+     */
+    private void setFiatCurrencyCodeBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+      fiatCurrencyCode_ = value.toStringUtf8();
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt64(1, coinValue_);
       }
@@ -18561,12 +15963,11 @@ public final class Protos {
         output.writeInt64(2, fiatValue_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeBytes(3, getFiatCurrencyCodeBytes());
+        output.writeString(3, getFiatCurrencyCode());
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -18582,715 +15983,404 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(3, getFiatCurrencyCodeBytes());
+          .computeStringSize(3, getFiatCurrencyCode());
       }
-      size += getUnknownFields().getSerializedSize();
+      size += unknownFields.getSerializedSize();
       memoizedSerializedSize = size;
       return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
     }
 
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, data, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return parseDelimitedFrom(DEFAULT_INSTANCE, input, extensionRegistry);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input);
     }
     public static org.floj.wallet.Protos.ExchangeRate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageLite.parseFrom(
+          DEFAULT_INSTANCE, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
     public static Builder newBuilder(org.floj.wallet.Protos.ExchangeRate prototype) {
-      return newBuilder().mergeFrom(prototype);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    public Builder toBuilder() { return newBuilder(this); }
 
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
     /**
-     * Protobuf type {@code wallet.ExchangeRate}
-     *
      * <pre>
      ** An exchange rate between FLO and some fiat currency. 
      * </pre>
+     *
+     * Protobuf type {@code wallet.ExchangeRate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.floj.wallet.Protos.ExchangeRate, Builder> implements
         // @@protoc_insertion_point(builder_implements:wallet.ExchangeRate)
         org.floj.wallet.Protos.ExchangeRateOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.floj.wallet.Protos.internal_static_wallet_ExchangeRate_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.floj.wallet.Protos.internal_static_wallet_ExchangeRate_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.floj.wallet.Protos.ExchangeRate.class, org.floj.wallet.Protos.ExchangeRate.Builder.class);
-      }
-
       // Construct using org.floj.wallet.Protos.ExchangeRate.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+        super(DEFAULT_INSTANCE);
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
 
-      public Builder clear() {
-        super.clear();
-        coinValue_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        fiatValue_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        fiatCurrencyCode_ = "";
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.floj.wallet.Protos.internal_static_wallet_ExchangeRate_descriptor;
-      }
-
-      public org.floj.wallet.Protos.ExchangeRate getDefaultInstanceForType() {
-        return org.floj.wallet.Protos.ExchangeRate.getDefaultInstance();
-      }
-
-      public org.floj.wallet.Protos.ExchangeRate build() {
-        org.floj.wallet.Protos.ExchangeRate result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public org.floj.wallet.Protos.ExchangeRate buildPartial() {
-        org.floj.wallet.Protos.ExchangeRate result = new org.floj.wallet.Protos.ExchangeRate(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.coinValue_ = coinValue_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.fiatValue_ = fiatValue_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.fiatCurrencyCode_ = fiatCurrencyCode_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.floj.wallet.Protos.ExchangeRate) {
-          return mergeFrom((org.floj.wallet.Protos.ExchangeRate)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.floj.wallet.Protos.ExchangeRate other) {
-        if (other == org.floj.wallet.Protos.ExchangeRate.getDefaultInstance()) return this;
-        if (other.hasCoinValue()) {
-          setCoinValue(other.getCoinValue());
-        }
-        if (other.hasFiatValue()) {
-          setFiatValue(other.getFiatValue());
-        }
-        if (other.hasFiatCurrencyCode()) {
-          bitField0_ |= 0x00000004;
-          fiatCurrencyCode_ = other.fiatCurrencyCode_;
-          onChanged();
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasCoinValue()) {
-          
-          return false;
-        }
-        if (!hasFiatValue()) {
-          
-          return false;
-        }
-        if (!hasFiatCurrencyCode()) {
-          
-          return false;
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.floj.wallet.Protos.ExchangeRate parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.floj.wallet.Protos.ExchangeRate) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private long coinValue_ ;
       /**
-       * <code>required int64 coin_value = 1;</code>
-       *
        * <pre>
        * This much of satoshis (1E-8 fractions)…
        * </pre>
+       *
+       * <code>required int64 coin_value = 1;</code>
        */
       public boolean hasCoinValue() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return instance.hasCoinValue();
       }
       /**
-       * <code>required int64 coin_value = 1;</code>
-       *
        * <pre>
        * This much of satoshis (1E-8 fractions)…
        * </pre>
+       *
+       * <code>required int64 coin_value = 1;</code>
        */
       public long getCoinValue() {
-        return coinValue_;
+        return instance.getCoinValue();
       }
       /**
-       * <code>required int64 coin_value = 1;</code>
-       *
        * <pre>
        * This much of satoshis (1E-8 fractions)…
        * </pre>
+       *
+       * <code>required int64 coin_value = 1;</code>
        */
       public Builder setCoinValue(long value) {
-        bitField0_ |= 0x00000001;
-        coinValue_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setCoinValue(value);
         return this;
       }
       /**
-       * <code>required int64 coin_value = 1;</code>
-       *
        * <pre>
        * This much of satoshis (1E-8 fractions)…
        * </pre>
+       *
+       * <code>required int64 coin_value = 1;</code>
        */
       public Builder clearCoinValue() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        coinValue_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearCoinValue();
         return this;
       }
 
-      private long fiatValue_ ;
       /**
-       * <code>required int64 fiat_value = 2;</code>
-       *
        * <pre>
        * …is worth this much of fiat (1E-4 fractions).
        * </pre>
+       *
+       * <code>required int64 fiat_value = 2;</code>
        */
       public boolean hasFiatValue() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return instance.hasFiatValue();
       }
       /**
-       * <code>required int64 fiat_value = 2;</code>
-       *
        * <pre>
        * …is worth this much of fiat (1E-4 fractions).
        * </pre>
+       *
+       * <code>required int64 fiat_value = 2;</code>
        */
       public long getFiatValue() {
-        return fiatValue_;
+        return instance.getFiatValue();
       }
       /**
-       * <code>required int64 fiat_value = 2;</code>
-       *
        * <pre>
        * …is worth this much of fiat (1E-4 fractions).
        * </pre>
+       *
+       * <code>required int64 fiat_value = 2;</code>
        */
       public Builder setFiatValue(long value) {
-        bitField0_ |= 0x00000002;
-        fiatValue_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setFiatValue(value);
         return this;
       }
       /**
-       * <code>required int64 fiat_value = 2;</code>
-       *
        * <pre>
        * …is worth this much of fiat (1E-4 fractions).
        * </pre>
+       *
+       * <code>required int64 fiat_value = 2;</code>
        */
       public Builder clearFiatValue() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        fiatValue_ = 0L;
-        onChanged();
+        copyOnWrite();
+        instance.clearFiatValue();
         return this;
       }
 
-      private java.lang.Object fiatCurrencyCode_ = "";
       /**
-       * <code>required string fiat_currency_code = 3;</code>
-       *
        * <pre>
        * ISO 4217 currency code (if available) of the fiat currency.
        * </pre>
+       *
+       * <code>required string fiat_currency_code = 3;</code>
        */
       public boolean hasFiatCurrencyCode() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return instance.hasFiatCurrencyCode();
       }
       /**
-       * <code>required string fiat_currency_code = 3;</code>
-       *
        * <pre>
        * ISO 4217 currency code (if available) of the fiat currency.
        * </pre>
+       *
+       * <code>required string fiat_currency_code = 3;</code>
        */
       public java.lang.String getFiatCurrencyCode() {
-        java.lang.Object ref = fiatCurrencyCode_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            fiatCurrencyCode_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+        return instance.getFiatCurrencyCode();
       }
       /**
-       * <code>required string fiat_currency_code = 3;</code>
-       *
        * <pre>
        * ISO 4217 currency code (if available) of the fiat currency.
        * </pre>
+       *
+       * <code>required string fiat_currency_code = 3;</code>
        */
       public com.google.protobuf.ByteString
           getFiatCurrencyCodeBytes() {
-        java.lang.Object ref = fiatCurrencyCode_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          fiatCurrencyCode_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+        return instance.getFiatCurrencyCodeBytes();
       }
       /**
-       * <code>required string fiat_currency_code = 3;</code>
-       *
        * <pre>
        * ISO 4217 currency code (if available) of the fiat currency.
        * </pre>
+       *
+       * <code>required string fiat_currency_code = 3;</code>
        */
       public Builder setFiatCurrencyCode(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        fiatCurrencyCode_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setFiatCurrencyCode(value);
         return this;
       }
       /**
-       * <code>required string fiat_currency_code = 3;</code>
-       *
        * <pre>
        * ISO 4217 currency code (if available) of the fiat currency.
        * </pre>
+       *
+       * <code>required string fiat_currency_code = 3;</code>
        */
       public Builder clearFiatCurrencyCode() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        fiatCurrencyCode_ = getDefaultInstance().getFiatCurrencyCode();
-        onChanged();
+        copyOnWrite();
+        instance.clearFiatCurrencyCode();
         return this;
       }
       /**
-       * <code>required string fiat_currency_code = 3;</code>
-       *
        * <pre>
        * ISO 4217 currency code (if available) of the fiat currency.
        * </pre>
+       *
+       * <code>required string fiat_currency_code = 3;</code>
        */
       public Builder setFiatCurrencyCodeBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
-        fiatCurrencyCode_ = value;
-        onChanged();
+        copyOnWrite();
+        instance.setFiatCurrencyCodeBytes(value);
         return this;
       }
 
       // @@protoc_insertion_point(builder_scope:wallet.ExchangeRate)
     }
+    private byte memoizedIsInitialized = -1;
+    protected final Object dynamicMethod(
+        com.google.protobuf.GeneratedMessageLite.MethodToInvoke method,
+        Object arg0, Object arg1) {
+      switch (method) {
+        case NEW_MUTABLE_INSTANCE: {
+          return new org.floj.wallet.Protos.ExchangeRate();
+        }
+        case IS_INITIALIZED: {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized == 1) return DEFAULT_INSTANCE;
+          if (isInitialized == 0) return null;
 
-    static {
-      defaultInstance = new ExchangeRate(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:wallet.ExchangeRate)
-  }
-
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_PeerAddress_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_PeerAddress_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_EncryptedData_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_EncryptedData_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_DeterministicKey_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_DeterministicKey_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_Key_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_Key_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_Script_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_Script_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_TransactionInput_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_TransactionInput_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_TransactionOutput_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_TransactionOutput_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_TransactionConfidence_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_TransactionConfidence_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_Transaction_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_Transaction_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_ScryptParameters_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_ScryptParameters_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_Extension_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_Extension_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_Tag_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_Tag_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_TransactionSigner_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_TransactionSigner_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_Wallet_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_Wallet_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_wallet_ExchangeRate_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_wallet_ExchangeRate_fieldAccessorTable;
-
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
-    return descriptor;
-  }
-  private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
-  static {
-    java.lang.String[] descriptorData = {
-      "\n\014wallet.proto\022\006wallet\"A\n\013PeerAddress\022\022\n" +
-      "\nip_address\030\001 \002(\014\022\014\n\004port\030\002 \002(\r\022\020\n\010servi" +
-      "ces\030\003 \002(\004\"M\n\rEncryptedData\022\035\n\025initialisa" +
-      "tion_vector\030\001 \002(\014\022\035\n\025encrypted_private_k" +
-      "ey\030\002 \002(\014\"\231\001\n\020DeterministicKey\022\022\n\nchain_c" +
-      "ode\030\001 \002(\014\022\014\n\004path\030\002 \003(\r\022\026\n\016issued_subkey" +
-      "s\030\003 \001(\r\022\026\n\016lookahead_size\030\004 \001(\r\022\023\n\013isFol" +
-      "lowing\030\005 \001(\010\022\036\n\023sigsRequiredToSpend\030\006 \001(" +
-      "\r:\0011\"\232\003\n\003Key\022\036\n\004type\030\001 \002(\0162\020.wallet.Key." +
-      "Type\022\024\n\014secret_bytes\030\002 \001(\014\022-\n\016encrypted_",
-      "data\030\006 \001(\0132\025.wallet.EncryptedData\022\022\n\npub" +
-      "lic_key\030\003 \001(\014\022\r\n\005label\030\004 \001(\t\022\032\n\022creation" +
-      "_timestamp\030\005 \001(\003\0223\n\021deterministic_key\030\007 " +
-      "\001(\0132\030.wallet.DeterministicKey\022\032\n\022determi" +
-      "nistic_seed\030\010 \001(\014\022;\n\034encrypted_determini" +
-      "stic_seed\030\t \001(\0132\025.wallet.EncryptedData\"a" +
-      "\n\004Type\022\014\n\010ORIGINAL\020\001\022\030\n\024ENCRYPTED_SCRYPT" +
-      "_AES\020\002\022\032\n\026DETERMINISTIC_MNEMONIC\020\003\022\025\n\021DE" +
-      "TERMINISTIC_KEY\020\004\"5\n\006Script\022\017\n\007program\030\001" +
-      " \002(\014\022\032\n\022creation_timestamp\030\002 \002(\003\"\222\001\n\020Tra",
-      "nsactionInput\022\"\n\032transaction_out_point_h" +
-      "ash\030\001 \002(\014\022#\n\033transaction_out_point_index" +
-      "\030\002 \002(\r\022\024\n\014script_bytes\030\003 \002(\014\022\020\n\010sequence" +
-      "\030\004 \001(\r\022\r\n\005value\030\005 \001(\003\"\177\n\021TransactionOutp" +
-      "ut\022\r\n\005value\030\001 \002(\003\022\024\n\014script_bytes\030\002 \002(\014\022" +
-      "!\n\031spent_by_transaction_hash\030\003 \001(\014\022\"\n\032sp" +
-      "ent_by_transaction_index\030\004 \001(\005\"\267\003\n\025Trans" +
-      "actionConfidence\0220\n\004type\030\001 \001(\0162\".wallet." +
-      "TransactionConfidence.Type\022\032\n\022appeared_a" +
-      "t_height\030\002 \001(\005\022\036\n\026overriding_transaction",
-      "\030\003 \001(\014\022\r\n\005depth\030\004 \001(\005\022)\n\014broadcast_by\030\006 " +
-      "\003(\0132\023.wallet.PeerAddress\022\033\n\023last_broadca" +
-      "sted_at\030\010 \001(\003\0224\n\006source\030\007 \001(\0162$.wallet.T" +
-      "ransactionConfidence.Source\"`\n\004Type\022\013\n\007U" +
-      "NKNOWN\020\000\022\014\n\010BUILDING\020\001\022\013\n\007PENDING\020\002\022\025\n\021N" +
-      "OT_IN_BEST_CHAIN\020\003\022\010\n\004DEAD\020\004\022\017\n\013IN_CONFL" +
-      "ICT\020\005\"A\n\006Source\022\022\n\016SOURCE_UNKNOWN\020\000\022\022\n\016S" +
-      "OURCE_NETWORK\020\001\022\017\n\013SOURCE_SELF\020\002\"\325\005\n\013Tra" +
-      "nsaction\022\017\n\007version\030\001 \002(\005\022\014\n\004hash\030\002 \002(\014\022" +
-      "&\n\004pool\030\003 \001(\0162\030.wallet.Transaction.Pool\022",
-      "\021\n\tlock_time\030\004 \001(\r\022\022\n\nupdated_at\030\005 \001(\003\0223" +
-      "\n\021transaction_input\030\006 \003(\0132\030.wallet.Trans" +
-      "actionInput\0225\n\022transaction_output\030\007 \003(\0132" +
-      "\031.wallet.TransactionOutput\022\022\n\nblock_hash" +
-      "\030\010 \003(\014\022 \n\030block_relativity_offsets\030\013 \003(\005" +
-      "\0221\n\nconfidence\030\t \001(\0132\035.wallet.Transactio" +
-      "nConfidence\0225\n\007purpose\030\n \001(\0162\033.wallet.Tr" +
-      "ansaction.Purpose:\007UNKNOWN\022+\n\rexchange_r" +
-      "ate\030\014 \001(\0132\024.wallet.ExchangeRate\022\014\n\004memo\030" +
-      "\r \001(\t\022\020\n\010flo_data\030\016 \001(\014\"Y\n\004Pool\022\013\n\007UNSPE",
-      "NT\020\004\022\t\n\005SPENT\020\005\022\014\n\010INACTIVE\020\002\022\010\n\004DEAD\020\n\022" +
-      "\013\n\007PENDING\020\020\022\024\n\020PENDING_INACTIVE\020\022\"\243\001\n\007P" +
-      "urpose\022\013\n\007UNKNOWN\020\000\022\020\n\014USER_PAYMENT\020\001\022\020\n" +
-      "\014KEY_ROTATION\020\002\022\034\n\030ASSURANCE_CONTRACT_CL" +
-      "AIM\020\003\022\035\n\031ASSURANCE_CONTRACT_PLEDGE\020\004\022\033\n\027" +
-      "ASSURANCE_CONTRACT_STUB\020\005\022\r\n\tRAISE_FEE\020\006" +
-      "\"N\n\020ScryptParameters\022\014\n\004salt\030\001 \002(\014\022\020\n\001n\030" +
-      "\002 \001(\003:\00516384\022\014\n\001r\030\003 \001(\005:\0018\022\014\n\001p\030\004 \001(\005:\0011" +
-      "\"8\n\tExtension\022\n\n\002id\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\022" +
-      "\021\n\tmandatory\030\003 \002(\010\" \n\003Tag\022\013\n\003tag\030\001 \002(\t\022\014",
-      "\n\004data\030\002 \002(\014\"5\n\021TransactionSigner\022\022\n\ncla" +
-      "ss_name\030\001 \002(\t\022\014\n\004data\030\002 \001(\014\"\351\004\n\006Wallet\022\032" +
-      "\n\022network_identifier\030\001 \002(\t\022\034\n\024last_seen_" +
-      "block_hash\030\002 \001(\014\022\036\n\026last_seen_block_heig" +
-      "ht\030\014 \001(\r\022!\n\031last_seen_block_time_secs\030\016 " +
-      "\001(\003\022\030\n\003key\030\003 \003(\0132\013.wallet.Key\022(\n\013transac" +
-      "tion\030\004 \003(\0132\023.wallet.Transaction\022&\n\016watch" +
-      "ed_script\030\017 \003(\0132\016.wallet.Script\022C\n\017encry" +
-      "ption_type\030\005 \001(\0162\035.wallet.Wallet.Encrypt" +
-      "ionType:\013UNENCRYPTED\0227\n\025encryption_param",
-      "eters\030\006 \001(\0132\030.wallet.ScryptParameters\022\022\n" +
-      "\007version\030\007 \001(\005:\0011\022$\n\textension\030\n \003(\0132\021.w" +
-      "allet.Extension\022\023\n\013description\030\013 \001(\t\022\031\n\021" +
-      "key_rotation_time\030\r \001(\004\022\031\n\004tags\030\020 \003(\0132\013." +
-      "wallet.Tag\0226\n\023transaction_signers\030\021 \003(\0132" +
-      "\031.wallet.TransactionSigner\";\n\016Encryption" +
-      "Type\022\017\n\013UNENCRYPTED\020\001\022\030\n\024ENCRYPTED_SCRYP" +
-      "T_AES\020\002\"R\n\014ExchangeRate\022\022\n\ncoin_value\030\001 " +
-      "\002(\003\022\022\n\nfiat_value\030\002 \002(\003\022\032\n\022fiat_currency" +
-      "_code\030\003 \002(\tB\031\n\017org.floj.walletB\006Protos"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
+          boolean shouldMemoize = ((Boolean) arg0).booleanValue();
+          if (!hasCoinValue()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
             return null;
           }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-    internal_static_wallet_PeerAddress_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_wallet_PeerAddress_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_PeerAddress_descriptor,
-        new java.lang.String[] { "IpAddress", "Port", "Services", });
-    internal_static_wallet_EncryptedData_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_wallet_EncryptedData_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_EncryptedData_descriptor,
-        new java.lang.String[] { "InitialisationVector", "EncryptedPrivateKey", });
-    internal_static_wallet_DeterministicKey_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_wallet_DeterministicKey_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_DeterministicKey_descriptor,
-        new java.lang.String[] { "ChainCode", "Path", "IssuedSubkeys", "LookaheadSize", "IsFollowing", "SigsRequiredToSpend", });
-    internal_static_wallet_Key_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_wallet_Key_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_Key_descriptor,
-        new java.lang.String[] { "Type", "SecretBytes", "EncryptedData", "PublicKey", "Label", "CreationTimestamp", "DeterministicKey", "DeterministicSeed", "EncryptedDeterministicSeed", });
-    internal_static_wallet_Script_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_wallet_Script_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_Script_descriptor,
-        new java.lang.String[] { "Program", "CreationTimestamp", });
-    internal_static_wallet_TransactionInput_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_wallet_TransactionInput_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_TransactionInput_descriptor,
-        new java.lang.String[] { "TransactionOutPointHash", "TransactionOutPointIndex", "ScriptBytes", "Sequence", "Value", });
-    internal_static_wallet_TransactionOutput_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_wallet_TransactionOutput_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_TransactionOutput_descriptor,
-        new java.lang.String[] { "Value", "ScriptBytes", "SpentByTransactionHash", "SpentByTransactionIndex", });
-    internal_static_wallet_TransactionConfidence_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_wallet_TransactionConfidence_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_TransactionConfidence_descriptor,
-        new java.lang.String[] { "Type", "AppearedAtHeight", "OverridingTransaction", "Depth", "BroadcastBy", "LastBroadcastedAt", "Source", });
-    internal_static_wallet_Transaction_descriptor =
-      getDescriptor().getMessageTypes().get(8);
-    internal_static_wallet_Transaction_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_Transaction_descriptor,
-        new java.lang.String[] { "Version", "Hash", "Pool", "LockTime", "UpdatedAt", "TransactionInput", "TransactionOutput", "BlockHash", "BlockRelativityOffsets", "Confidence", "Purpose", "ExchangeRate", "Memo", "FloData", });
-    internal_static_wallet_ScryptParameters_descriptor =
-      getDescriptor().getMessageTypes().get(9);
-    internal_static_wallet_ScryptParameters_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_ScryptParameters_descriptor,
-        new java.lang.String[] { "Salt", "N", "R", "P", });
-    internal_static_wallet_Extension_descriptor =
-      getDescriptor().getMessageTypes().get(10);
-    internal_static_wallet_Extension_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_Extension_descriptor,
-        new java.lang.String[] { "Id", "Data", "Mandatory", });
-    internal_static_wallet_Tag_descriptor =
-      getDescriptor().getMessageTypes().get(11);
-    internal_static_wallet_Tag_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_Tag_descriptor,
-        new java.lang.String[] { "Tag", "Data", });
-    internal_static_wallet_TransactionSigner_descriptor =
-      getDescriptor().getMessageTypes().get(12);
-    internal_static_wallet_TransactionSigner_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_TransactionSigner_descriptor,
-        new java.lang.String[] { "ClassName", "Data", });
-    internal_static_wallet_Wallet_descriptor =
-      getDescriptor().getMessageTypes().get(13);
-    internal_static_wallet_Wallet_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_Wallet_descriptor,
-        new java.lang.String[] { "NetworkIdentifier", "LastSeenBlockHash", "LastSeenBlockHeight", "LastSeenBlockTimeSecs", "Key", "Transaction", "WatchedScript", "EncryptionType", "EncryptionParameters", "Version", "Extension", "Description", "KeyRotationTime", "Tags", "TransactionSigners", });
-    internal_static_wallet_ExchangeRate_descriptor =
-      getDescriptor().getMessageTypes().get(14);
-    internal_static_wallet_ExchangeRate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_wallet_ExchangeRate_descriptor,
-        new java.lang.String[] { "CoinValue", "FiatValue", "FiatCurrencyCode", });
+          if (!hasFiatValue()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (!hasFiatCurrencyCode()) {
+            if (shouldMemoize) {
+              memoizedIsInitialized = 0;
+            }
+            return null;
+          }
+          if (shouldMemoize) memoizedIsInitialized = 1;
+          return DEFAULT_INSTANCE;
+
+        }
+        case MAKE_IMMUTABLE: {
+          return null;
+        }
+        case NEW_BUILDER: {
+          return new Builder();
+        }
+        case VISIT: {
+          Visitor visitor = (Visitor) arg0;
+          org.floj.wallet.Protos.ExchangeRate other = (org.floj.wallet.Protos.ExchangeRate) arg1;
+          coinValue_ = visitor.visitLong(
+              hasCoinValue(), coinValue_,
+              other.hasCoinValue(), other.coinValue_);
+          fiatValue_ = visitor.visitLong(
+              hasFiatValue(), fiatValue_,
+              other.hasFiatValue(), other.fiatValue_);
+          fiatCurrencyCode_ = visitor.visitString(
+              hasFiatCurrencyCode(), fiatCurrencyCode_,
+              other.hasFiatCurrencyCode(), other.fiatCurrencyCode_);
+          if (visitor == com.google.protobuf.GeneratedMessageLite.MergeFromVisitor
+              .INSTANCE) {
+            bitField0_ |= other.bitField0_;
+          }
+          return this;
+        }
+        case MERGE_FROM_STREAM: {
+          com.google.protobuf.CodedInputStream input =
+              (com.google.protobuf.CodedInputStream) arg0;
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry =
+              (com.google.protobuf.ExtensionRegistryLite) arg1;
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(tag, input)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  coinValue_ = input.readInt64();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  fiatValue_ = input.readInt64();
+                  break;
+                }
+                case 26: {
+                  String s = input.readString();
+                  bitField0_ |= 0x00000004;
+                  fiatCurrencyCode_ = s;
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw new RuntimeException(e.setUnfinishedMessage(this));
+          } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                new com.google.protobuf.InvalidProtocolBufferException(
+                    e.getMessage()).setUnfinishedMessage(this));
+          } finally {
+          }
+        }
+        case GET_DEFAULT_INSTANCE: {
+          return DEFAULT_INSTANCE;
+        }
+        case GET_PARSER: {
+          if (PARSER == null) {    synchronized (org.floj.wallet.Protos.ExchangeRate.class) {
+              if (PARSER == null) {
+                PARSER = new DefaultInstanceBasedParser(DEFAULT_INSTANCE);
+              }
+            }
+          }
+          return PARSER;
+        }
+      }
+      throw new UnsupportedOperationException();
+    }
+
+
+    // @@protoc_insertion_point(class_scope:wallet.ExchangeRate)
+    private static final org.floj.wallet.Protos.ExchangeRate DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ExchangeRate();
+      DEFAULT_INSTANCE.makeImmutable();
+    }
+
+    public static org.floj.wallet.Protos.ExchangeRate getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static volatile com.google.protobuf.Parser<ExchangeRate> PARSER;
+
+    public static com.google.protobuf.Parser<ExchangeRate> parser() {
+      return DEFAULT_INSTANCE.getParserForType();
+    }
+  }
+
+
+  static {
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/floj-core/src/main/java/org/floj/wallet/WalletProtobufSerializer.java
+++ b/floj-core/src/main/java/org/floj/wallet/WalletProtobufSerializer.java
@@ -31,7 +31,6 @@ import org.floj.wallet.Protos.Wallet.EncryptionType;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
-import com.google.protobuf.TextFormat;
 import com.google.protobuf.WireFormat;
 
 import org.slf4j.Logger;
@@ -122,18 +121,6 @@ public class WalletProtobufSerializer {
     public void writeWallet(Wallet wallet, OutputStream output) throws IOException {
         Protos.Wallet walletProto = walletToProto(wallet);
         walletProto.writeTo(output);
-    }
-
-    /**
-     * Returns the given wallet formatted as text. The text format is that used by protocol buffers and although it
-     * can also be parsed using {@link TextFormat#merge(CharSequence, com.google.protobuf.Message.Builder)},
-     * it is designed more for debugging than storage. It is not well specified and wallets are largely binary data
-     * structures anyway, consisting as they do of keys (large random numbers) and {@link Transaction}s which also
-     * mostly contain keys and hashes.
-     */
-    public String walletToText(Wallet wallet) {
-        Protos.Wallet walletProto = walletToProto(wallet);
-        return TextFormat.printToString(walletProto);
     }
 
     /**
@@ -402,7 +389,7 @@ public class WalletProtobufSerializer {
      * Wallet object with {@code forceReset} set {@code true}. It won't work.</p>
      *
      * <p>If {@code forceReset} is {@code true}, then no transactions are loaded from the wallet, and it is configured
-     * to replay transactions from the blockchain (as if the wallet had been loaded and {@link Wallet.reset}
+     * to replay transactions from the blockchain (as if the wallet had been loaded and {@link Wallet#reset()}
      * had been called immediately thereafter).
      *
      * <p>A wallet can be unreadable for various reasons, such as inability to open the file, corrupt data, internally
@@ -451,7 +438,7 @@ public class WalletProtobufSerializer {
      * Wallet object with {@code forceReset} set {@code true}. It won't work.</p>
      *
      * <p>If {@code forceReset} is {@code true}, then no transactions are loaded from the wallet, and it is configured
-     * to replay transactions from the blockchain (as if the wallet had been loaded and {@link Wallet.reset}
+     * to replay transactions from the blockchain (as if the wallet had been loaded and {@link Wallet#reset()}
      * had been called immediately thereafter).
      *
      * <p>A wallet can be unreadable for various reasons, such as inability to open the file, corrupt data, internally

--- a/floj-core/src/paymentchannel.proto
+++ b/floj-core/src/paymentchannel.proto
@@ -16,7 +16,7 @@
 /*
  * Authors: Mike Hearn, Matt Corallo
  */
- 
+ syntax = 'proto2';
 /* Notes:
  * - Endianness: All byte arrays that represent numbers (such as hashes and private keys) are Big Endian
  * - To regenerate after editing, run mvn clean package -DupdateProtobuf

--- a/floj-core/src/paymentrequest.proto
+++ b/floj-core/src/paymentrequest.proto
@@ -21,7 +21,7 @@
  * - Endianness: All byte arrays that represent numbers (such as hashes and private keys) are Big Endian
  * - To regenerate after editing, run mvn clean package -DupdateProtobuf
  */
-
+syntax = 'proto2';
 //
 // Simple FLO Payment Protocol messages
 //

--- a/floj-core/src/peerseeds.proto
+++ b/floj-core/src/peerseeds.proto
@@ -1,3 +1,5 @@
+syntax = 'proto2';
+
 package org.flo.crawler;
 
 //

--- a/floj-core/src/storedclientpaymentchannel.proto
+++ b/floj-core/src/storedclientpaymentchannel.proto
@@ -21,6 +21,7 @@
  * - Endianness: All byte arrays that represent numbers (such as hashes and private keys) are Big Endian
  * - To regenerate after editing, run mvn clean package -DupdateProtobuf
  */
+syntax = 'proto2';
 
 package paymentchannels;
 

--- a/floj-core/src/storedserverpaymentchannel.proto
+++ b/floj-core/src/storedserverpaymentchannel.proto
@@ -21,6 +21,7 @@
  * - Endianness: All byte arrays that represent numbers (such as hashes and private keys) are Big Endian
  * - To regenerate after editing, run mvn clean package -DupdateProtobuf
  */
+syntax = 'proto2';
 
 package paymentchannels;
 

--- a/floj-core/src/test/java/org/floj/protocols/channels/ChannelConnectionTest.java
+++ b/floj-core/src/test/java/org/floj/protocols/channels/ChannelConnectionTest.java
@@ -729,7 +729,7 @@ public class ChannelConnectionTest extends TestWithWallet {
         Protos.TwoWayChannelMessage.Builder initiateMsg = Protos.TwoWayChannelMessage.newBuilder(pair.serverRecorder.checkNextMsg(MessageType.INITIATE));
         ByteString brokenKey = initiateMsg.getInitiate().getMultisigKey();
         brokenKey = ByteString.copyFrom(Arrays.copyOf(brokenKey.toByteArray(), brokenKey.size() + 1));
-        initiateMsg.getInitiateBuilder().setMultisigKey(brokenKey);
+        initiateMsg.setInitiate(Protos.Initiate.newBuilder().setMultisigKey(brokenKey));
         client.receiveMessage(initiateMsg.build());
         pair.clientRecorder.checkNextMsg(MessageType.ERROR);
         assertEquals(CloseReason.REMOTE_SENT_INVALID_MESSAGE, pair.clientRecorder.q.take());


### PR DESCRIPTION
Set protobuf syntax to "2" in all protobuf files to remove warnings

In order to build with protobuf-lite, protoc-gen-javalite must be in the users PATH.  Follow the instructions at https://github.com/google/protobuf/blob/master/java/lite.md to download.

The biggest change requiring code changes is the removal of get*Builder() methods from the generated Protos

The other change requiring a code change is com.google.protobuf.TextFormat is not available in protobuf-lite.  This class was used in one method that is currently unused, so I removed the method.  The method was most likely used for debugging as it just converted a Wallet to formatted text.